### PR TITLE
Add Input component

### DIFF
--- a/__mocks__/@react-native-clipboard/clipboard.ts
+++ b/__mocks__/@react-native-clipboard/clipboard.ts
@@ -1,0 +1,7 @@
+export default {
+  setString: jest.fn(),
+  getString: jest.fn(),
+  hasString: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+};

--- a/__tests__/components/sds/Input.test.tsx
+++ b/__tests__/components/sds/Input.test.tsx
@@ -1,0 +1,206 @@
+import Clipboard from "@react-native-clipboard/clipboard";
+import { fireEvent, render } from "@testing-library/react-native";
+import { Input } from "components/sds/Input";
+import { Text } from "components/sds/Typography";
+import { THEME } from "config/theme";
+import { fsValue, pxValue } from "helpers/dimensions";
+import React from "react";
+
+describe("Input", () => {
+  const onChangeTextMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Size handling", () => {
+    it("applies correct styles for each field size", () => {
+      const sizes = {
+        sm: { fontSize: 12, lineHeight: 18, paddingVertical: 4 },
+        md: { fontSize: 14, lineHeight: 20, paddingVertical: 6 },
+        lg: { fontSize: 16, lineHeight: 24, paddingVertical: 8 },
+      };
+
+      Object.entries(sizes).forEach(([size, metrics]) => {
+        const { getByTestId } = render(
+          <Input
+            fieldSize={size as "sm" | "md" | "lg"}
+            testID="test-input"
+            value=""
+          />,
+        );
+        const input = getByTestId("test-input");
+
+        expect(input.props.style).toMatchObject({
+          fontSize: fsValue(metrics.fontSize),
+          height: pxValue(metrics.lineHeight + 2 * metrics.paddingVertical),
+        });
+      });
+    });
+
+    it("defaults to medium size", () => {
+      const { getByTestId } = render(<Input testID="test-input" value="" />);
+      const input = getByTestId("test-input");
+
+      expect(input.props.style).toMatchObject({
+        fontSize: fsValue(14), // md size
+        height: pxValue(32), // lineHeight(20) + 2 * paddingVertical(6)
+      });
+    });
+  });
+
+  describe("Label handling", () => {
+    it("renders label when provided", () => {
+      const { getByText } = render(<Input label="Test Label" value="" />);
+      expect(getByText("Test Label")).toBeTruthy();
+    });
+
+    it("renders label suffix when provided", () => {
+      const { getByText } = render(
+        <Input label="Test Label" labelSuffix="(optional)" value="" />,
+      );
+      expect(getByText("(optional)")).toBeTruthy();
+    });
+
+    it("renders uppercase label when isLabelUppercase is true", () => {
+      const { getByText } = render(
+        <Input label="test label" isLabelUppercase value="" />,
+      );
+      expect(getByText("TEST LABEL")).toBeTruthy();
+    });
+  });
+
+  describe("Error state", () => {
+    it("applies error styles when isError is true", () => {
+      const { getByTestId } = render(
+        <Input isError testID="test-input" value="" />,
+      );
+
+      const inputContainer = getByTestId("test-input-container");
+      expect(inputContainer.props.style).toMatchObject({
+        borderColor: THEME.colors.status.error,
+      });
+    });
+
+    it("applies error styles when error message is provided", () => {
+      const { getByTestId, getByText } = render(
+        <Input error="Error message" testID="test-input" value="" />,
+      );
+
+      const inputContainer = getByTestId("test-input-container");
+      expect(inputContainer.props.style).toMatchObject({
+        borderColor: THEME.colors.status.error,
+      });
+      expect(getByText("Error message")).toBeTruthy();
+    });
+  });
+
+  describe("Side elements", () => {
+    it("renders left element when provided", () => {
+      const { getByTestId } = render(
+        <Input
+          leftElement={<Text testID="left-element">Left</Text>}
+          testID="test-input"
+          value=""
+        />,
+      );
+      expect(getByTestId("left-element")).toBeTruthy();
+    });
+
+    it("renders right element when provided", () => {
+      const { getByTestId } = render(
+        <Input
+          rightElement={<Text testID="right-element">Right</Text>}
+          testID="test-input"
+          value=""
+        />,
+      );
+      expect(getByTestId("right-element")).toBeTruthy();
+    });
+  });
+
+  describe("Copy button", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("renders copy button on the left when specified", () => {
+      const { getByText } = render(
+        <Input
+          copyButton={{ position: "left", showLabel: true }}
+          value="test"
+        />,
+      );
+      expect(getByText("Copy")).toBeTruthy();
+    });
+
+    it("renders copy button on the right when specified", () => {
+      const { getByText } = render(
+        <Input
+          copyButton={{ position: "right", showLabel: true }}
+          value="test"
+        />,
+      );
+      expect(getByText("Copy")).toBeTruthy();
+    });
+
+    it("copies text to clipboard when copy button is pressed", () => {
+      const { getByText } = render(
+        <Input
+          copyButton={{ position: "right", showLabel: true }}
+          value="test value"
+        />,
+      );
+
+      fireEvent.press(getByText("Copy"));
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(Clipboard.setString).toHaveBeenCalledWith("test value");
+    });
+  });
+
+  describe("Input interactions", () => {
+    it("calls onChangeText when text changes", () => {
+      const { getByTestId } = render(
+        <Input testID="test-input" value="" onChangeText={onChangeTextMock} />,
+      );
+
+      fireEvent.changeText(getByTestId("test-input"), "new value");
+      expect(onChangeTextMock).toHaveBeenCalledWith("new value");
+    });
+
+    it("handles disabled state", () => {
+      const { getByTestId } = render(
+        <Input testID="test-input" value="" editable={false} />,
+      );
+
+      const inputContainer = getByTestId("test-input-container");
+      expect(inputContainer.props.style).toMatchObject({
+        backgroundColor: THEME.colors.background.secondary,
+      });
+    });
+  });
+
+  describe("Messages", () => {
+    it("renders note message when provided", () => {
+      const { getByText } = render(<Input note="Helper text" value="" />);
+      expect(getByText("Helper text")).toBeTruthy();
+    });
+
+    it("renders success message when provided", () => {
+      const { getByText } = render(
+        <Input success="Success message" value="" />,
+      );
+      expect(getByText("Success message")).toBeTruthy();
+    });
+  });
+
+  describe("Password input", () => {
+    it("toggles secure text entry when isPassword is true", () => {
+      const { getByTestId } = render(
+        <Input isPassword testID="test-input" value="" />,
+      );
+      const input = getByTestId("test-input");
+      expect(input.props.secureTextEntry).toBe(true);
+    });
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,6 +94,7 @@ export default [
       ],
 
       "react/require-default-props": "off",
+      "react/jsx-props-no-spreading": "off",
       "import/prefer-default-export": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-call": "off",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1567,6 +1567,27 @@ PODS:
     - React-logger (= 0.77.1)
     - React-perflogger (= 0.77.1)
     - React-utils (= 0.77.1)
+  - RNCClipboard (1.16.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNScreens (4.7.0):
     - DoubleConversion
     - glog
@@ -1728,6 +1749,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1872,6 +1894,8 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNSVG:
@@ -1947,6 +1971,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 41e9fb63606c32cce924653d2d410cb01ec81286
   ReactCodegen: d9a09a7f7eee93f54d0b4135d5ca66b31b0c42a5
   ReactCommon: 08f4808f02ff115884e870e5cfea689703ff759a
+  RNCClipboard: 43008eed69827e56e1fbeb06473208fdebed8f5f
   RNScreens: 49c7306c0b2d9e4a0da0988b99bfd7e5b33dbd3b
   RNSVG: 877cd57c2db63dc9f1fd1bbb5e95506ccd481df6
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.9",
+    "@react-native-clipboard/clipboard": "^1.16.1",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -36,8 +36,6 @@ export const HomeScreen = () => {
           note="Minimum 8 characters"
           value={passwordValue}
           onChangeText={setPasswordValue}
-          error="Password is too short"
-          success="Password is valid"
         />
 
         <View style={{ height: 40 }} />

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -1,9 +1,11 @@
 import ClipboardIcon from "assets/icons/clipboard.svg";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { Button } from "components/sds/Button";
+import { Input } from "components/sds/Input";
 import { PALETTE, THEME } from "config/theme";
 import { fs, px, pxValue } from "helpers/dimensions";
-import React from "react";
+import React, { useState } from "react";
+import { View } from "react-native";
 import styled from "styled-components/native";
 
 const Container = styled.View`
@@ -19,25 +21,42 @@ const ScreenText = styled.Text`
   margin-bottom: ${px(50)};
 `;
 
-export const HomeScreen = () => (
-  <BaseLayout>
-    <Container>
-      <ScreenText>Home</ScreenText>
+export const HomeScreen = () => {
+  const [passwordValue, setPasswordValue] = useState("");
 
-      <Button
-        secondary
-        lg
-        isFullWidth
-        icon={
-          <ClipboardIcon
-            width={pxValue(16)}
-            height={pxValue(16)}
-            stroke={PALETTE.dark.gray["09"]}
-          />
-        }
-      >
-        Test Button with Icon
-      </Button>
-    </Container>
-  </BaseLayout>
-);
+  return (
+    <BaseLayout>
+      <Container>
+        <ScreenText>Home</ScreenText>
+
+        <Input
+          isPassword
+          placeholder="Type your password"
+          fieldSize="lg"
+          note="Minimum 8 characters"
+          value={passwordValue}
+          onChangeText={setPasswordValue}
+          error="Password is too short"
+          success="Password is valid"
+        />
+
+        <View style={{ height: 40 }} />
+
+        <Button
+          secondary
+          lg
+          isFullWidth
+          icon={
+            <ClipboardIcon
+              width={pxValue(16)}
+              height={pxValue(16)}
+              stroke={PALETTE.dark.gray["09"]}
+            />
+          }
+        >
+          Test Button with Icon
+        </Button>
+      </Container>
+    </BaseLayout>
+  );
+};

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -141,6 +141,74 @@ const FieldNoteWrapper = styled.View`
 // Component
 // =============================================================================
 
+/**
+ * Input component for text entry with various styling and functionality options.
+ *
+ * @example
+ * Basic usage:
+ * ```tsx
+ * <Input
+ *   value={text}
+ *   onChangeText={setText}
+ *   placeholder="Enter text..."
+ * />
+ * ```
+ *
+ * @example
+ * With label and validation:
+ * ```tsx
+ * <Input
+ *   label="Email Address"
+ *   labelSuffix="(required)"
+ *   value={email}
+ *   onChangeText={setEmail}
+ *   error={!isValidEmail(email) && "Please enter a valid email"}
+ *   keyboardType="email-address"
+ * />
+ * ```
+ *
+ * @example
+ * Password input with side element:
+ * ```tsx
+ * <Input
+ *   label="Password"
+ *   value={password}
+ *   onChangeText={setPassword}
+ *   isPassword
+ *   rightElement={<Icon name="eye" onPress={togglePasswordVisibility} />}
+ * />
+ * ```
+ *
+ * @example
+ * With copy button and helper text:
+ * ```tsx
+ * <Input
+ *   value={walletAddress}
+ *   copyButton={{ position: "right", showLabel: true }}
+ *   note="Click the copy button to copy the address"
+ *   editable={false}
+ * />
+ * ```
+ *
+ * @param {InputProps} props - The component props
+ * @param {string} [props.fieldSize="md"] - Size variant of the input field ("sm" | "md" | "lg")
+ * @param {string | ReactNode} [props.label] - Label text or component to display above the input
+ * @param {string | ReactNode} [props.labelSuffix] - Additional text to display after the label
+ * @param {boolean} [props.isLabelUppercase] - Whether to transform the label text to uppercase
+ * @param {boolean} [props.isError] - Whether to show error styling
+ * @param {boolean} [props.isPassword] - Whether the input is for password entry
+ * @param {JSX.Element} [props.leftElement] - Element to render on the left side of the input
+ * @param {JSX.Element} [props.rightElement] - Element to render on the right side of the input
+ * @param {string | ReactNode} [props.note] - Helper text to display below the input
+ * @param {string | ReactNode} [props.error] - Error message to display below the input
+ * @param {string | ReactNode} [props.success] - Success message to display below the input
+ * @param {Object} [props.copyButton] - Configuration for the copy button
+ * @param {string} props.value - The input value
+ * @param {Function} [props.onChangeText] - Callback when text changes
+ * @param {string} [props.placeholder] - Placeholder text
+ * @param {boolean} [props.editable=true] - Whether the input is editable
+ * @param {string} [props.testID] - Test ID for testing
+ */
 export const Input: React.FC<InputProps> = ({
   fieldSize = "md",
   label,

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -41,6 +41,7 @@ export type InputSize = keyof typeof INPUT_SIZES;
 
 export interface InputProps {
   id?: string;
+  testID?: string;
   fieldSize?: InputSize;
   label?: string | React.ReactNode;
   labelSuffix?: string | React.ReactNode;
@@ -157,6 +158,7 @@ export const Input: React.FC<InputProps> = ({
   onChangeText,
   placeholder,
   editable = true,
+  testID,
   ...props
 }) => {
   const handleCopy = () => {
@@ -192,6 +194,7 @@ export const Input: React.FC<InputProps> = ({
       )}
 
       <InputContainer
+        testID={testID ? `${testID}-container` : undefined}
         $fieldSize={fieldSize}
         $isError={isError || !!error}
         $isDisabled={!editable}
@@ -202,6 +205,7 @@ export const Input: React.FC<InputProps> = ({
         )}
 
         <StyledTextInput
+          testID={testID}
           $fieldSize={fieldSize}
           $hasLeftElement={!!leftElement || copyButton?.position === "left"}
           $hasRightElement={!!rightElement || copyButton?.position === "right"}

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -55,9 +55,9 @@ export interface InputProps {
   /** Password input preset with show/hide button */
   isPassword?: boolean;
   /** Left side element of the input */
-  leftElement?: React.ReactNode;
+  leftElement?: JSX.Element;
   /** Right side element of the input */
-  rightElement?: React.ReactNode;
+  rightElement?: JSX.Element;
   /** Note message of the input */
   note?: string | React.ReactNode;
   /** Error message of the input */
@@ -141,9 +141,9 @@ const StyledTextInput = styled.TextInput<
   color: ${THEME.colors.text.primary};
 `;
 
-const SideElement = styled.View<Pick<StyledProps, "position">>`
+const SideElement = styled.View<{ position: "left" | "right" }>`
   justify-content: center;
-  margin-${({ position }: Pick<StyledProps, "position">) => position}: ${px(8)};
+  margin-${({ position }) => position}: ${px(8)};
 `;
 
 const FieldNote = styled(Text)<Pick<StyledProps, "$variant">>`

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -237,6 +237,12 @@ export const Input: React.FC<InputProps> = ({
     Clipboard.setString(value);
   };
 
+  const getLabelSize = () => ({
+    xs: fieldSize === "sm",
+    sm: fieldSize === "md",
+    md: fieldSize === "lg",
+  });
+
   const renderCopyButton = (position: "left" | "right") => (
     <TouchableOpacity onPress={handleCopy}>
       <SideElement position={position}>
@@ -248,15 +254,13 @@ export const Input: React.FC<InputProps> = ({
   return (
     <Container $fieldSize={fieldSize}>
       {label && (
-        <Text
-          sm={fieldSize === "sm"}
-          md={fieldSize === "md"}
-          lg={fieldSize === "lg"}
-          color={THEME.colors.text.primary}
-        >
+        <Text {...getLabelSize()} color={THEME.colors.text.secondary}>
           {isLabelUppercase ? label.toString().toUpperCase() : label}
           {labelSuffix && (
-            <Text color={THEME.colors.text.secondary}> {labelSuffix}</Text>
+            <Text {...getLabelSize()} color={THEME.colors.text.secondary}>
+              {" "}
+              {labelSuffix}
+            </Text>
           )}
         </Text>
       )}

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -122,9 +122,8 @@ const InputContainer = styled.View<
   }};
   border-radius: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
     px(INPUT_SIZES[$fieldSize].borderRadius)};
-  padding: 0
-    ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
-      px(INPUT_SIZES[$fieldSize].paddingHorizontal)};
+  padding-horizontal: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+    px(INPUT_SIZES[$fieldSize].paddingHorizontal)};
 `;
 
 const StyledTextInput = styled.TextInput<
@@ -135,27 +134,17 @@ const StyledTextInput = styled.TextInput<
     fs(INPUT_SIZES[$fieldSize].fontSize)};
   line-height: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
     px(INPUT_SIZES[$fieldSize].lineHeight)};
-  padding: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
-      px(INPUT_SIZES[$fieldSize].paddingVertical)}
-    0;
+  padding-vertical: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+    px(INPUT_SIZES[$fieldSize].paddingVertical)};
   color: ${THEME.colors.text.primary};
 `;
 
 const SideElement = styled.View<{ position: "left" | "right" }>`
   justify-content: center;
-  margin-${({ position }) => position}: ${px(8)};
+  margin-${({ position }: { position: "left" | "right" }) => position}: ${px(8)};
 `;
 
-const FieldNote = styled(Text)<Pick<StyledProps, "$variant">>`
-  color: ${({ $variant }: Pick<StyledProps, "$variant">) => {
-    if ($variant === "error") {
-      return THEME.colors.status.error;
-    }
-    if ($variant === "success") {
-      return THEME.colors.status.success;
-    }
-    return THEME.colors.text.secondary;
-  }};
+const FieldNoteWrapper = styled.View`
   margin-top: ${px(4)};
 `;
 
@@ -243,16 +232,26 @@ export const Input: React.FC<InputProps> = ({
         {copyButton?.position === "right" && renderCopyButton("right")}
       </InputContainer>
 
-      {note && <FieldNote sm>{note}</FieldNote>}
+      {note && (
+        <FieldNoteWrapper>
+          <Text sm color={THEME.colors.text.secondary}>
+            {note}
+          </Text>
+        </FieldNoteWrapper>
+      )}
       {error && (
-        <FieldNote sm $variant="error">
-          {error}
-        </FieldNote>
+        <FieldNoteWrapper>
+          <Text sm color={THEME.colors.status.error}>
+            {error}
+          </Text>
+        </FieldNoteWrapper>
       )}
       {success && (
-        <FieldNote sm $variant="success">
-          {success}
-        </FieldNote>
+        <FieldNoteWrapper>
+          <Text sm color={THEME.colors.status.success}>
+            {success}
+          </Text>
+        </FieldNoteWrapper>
       )}
     </Container>
   );

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -1,0 +1,259 @@
+import Clipboard from "@react-native-clipboard/clipboard";
+import { Text } from "components/sds/Typography";
+import { THEME } from "config/theme";
+import { fs, px } from "helpers/dimensions";
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import styled from "styled-components/native";
+
+// =============================================================================
+// Constants and types
+// =============================================================================
+
+const INPUT_SIZES = {
+  sm: {
+    fontSize: 12,
+    lineHeight: 18,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    gap: 6,
+    borderRadius: 4,
+  },
+  md: {
+    fontSize: 14,
+    lineHeight: 20,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    gap: 6,
+    borderRadius: 6,
+  },
+  lg: {
+    fontSize: 16,
+    lineHeight: 24,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    gap: 8,
+    borderRadius: 8,
+  },
+} as const;
+
+export type InputSize = keyof typeof INPUT_SIZES;
+
+export interface InputProps {
+  /** ID of the input should be unique */
+  id?: string;
+  /** Size of the input */
+  fieldSize?: InputSize;
+  /** Label of the input */
+  label?: string | React.ReactNode;
+  /** Adds suffix to the label */
+  labelSuffix?: string | React.ReactNode;
+  /** Make label uppercase */
+  isLabelUppercase?: boolean;
+  /** Input error without a message */
+  isError?: boolean;
+  /** Password input preset with show/hide button */
+  isPassword?: boolean;
+  /** Left side element of the input */
+  leftElement?: React.ReactNode;
+  /** Right side element of the input */
+  rightElement?: React.ReactNode;
+  /** Note message of the input */
+  note?: string | React.ReactNode;
+  /** Error message of the input */
+  error?: string | React.ReactNode;
+  /** Success message of the input */
+  success?: string | React.ReactNode;
+  /** Copy button options */
+  copyButton?: {
+    position: "left" | "right";
+    showLabel?: boolean;
+  };
+  value?: string;
+  onChangeText?: (text: string) => void;
+  placeholder?: string;
+  secureTextEntry?: boolean;
+  editable?: boolean;
+  autoCapitalize?: "none" | "sentences" | "words" | "characters";
+  keyboardType?:
+    | "default"
+    | "number-pad"
+    | "decimal-pad"
+    | "numeric"
+    | "email-address"
+    | "phone-pad";
+}
+
+// =============================================================================
+// Styled components
+// =============================================================================
+
+interface StyledProps {
+  $fieldSize: InputSize;
+  $isError?: boolean;
+  $isDisabled?: boolean;
+  $hasLeftElement?: boolean;
+  $hasRightElement?: boolean;
+  position?: "left" | "right";
+  $variant?: "error" | "success";
+}
+
+const Container = styled.View<Pick<StyledProps, "$fieldSize">>`
+  width: 100%;
+  gap: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+    px(INPUT_SIZES[$fieldSize].gap)};
+`;
+
+const InputContainer = styled.View<
+  Pick<StyledProps, "$fieldSize" | "$isError" | "$isDisabled">
+>`
+  flex-direction: row;
+  align-items: center;
+  background-color: ${({ $isDisabled }: Pick<StyledProps, "$isDisabled">) =>
+    $isDisabled
+      ? THEME.colors.background.secondary
+      : THEME.colors.background.default};
+  border-width: 1px;
+  border-color: ${({ $isError }: Pick<StyledProps, "$isError">) => {
+    if ($isError) {
+      return THEME.colors.status.error;
+    }
+    return THEME.colors.border.default;
+  }};
+  border-radius: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+    px(INPUT_SIZES[$fieldSize].borderRadius)};
+  padding: 0
+    ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+      px(INPUT_SIZES[$fieldSize].paddingHorizontal)};
+`;
+
+const StyledTextInput = styled.TextInput<
+  Pick<StyledProps, "$fieldSize" | "$hasLeftElement" | "$hasRightElement">
+>`
+  flex: 1;
+  font-size: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+    fs(INPUT_SIZES[$fieldSize].fontSize)};
+  line-height: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+    px(INPUT_SIZES[$fieldSize].lineHeight)};
+  padding: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+      px(INPUT_SIZES[$fieldSize].paddingVertical)}
+    0;
+  color: ${THEME.colors.text.primary};
+`;
+
+const SideElement = styled.View<Pick<StyledProps, "position">>`
+  justify-content: center;
+  margin-${({ position }: Pick<StyledProps, "position">) => position}: ${px(8)};
+`;
+
+const FieldNote = styled(Text)<Pick<StyledProps, "$variant">>`
+  color: ${({ $variant }: Pick<StyledProps, "$variant">) => {
+    if ($variant === "error") {
+      return THEME.colors.status.error;
+    }
+    if ($variant === "success") {
+      return THEME.colors.status.success;
+    }
+    return THEME.colors.text.secondary;
+  }};
+  margin-top: ${px(4)};
+`;
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export const Input: React.FC<InputProps> = ({
+  fieldSize = "md",
+  label,
+  labelSuffix,
+  isLabelUppercase,
+  isError,
+  isPassword,
+  leftElement,
+  rightElement,
+  note,
+  error,
+  success,
+  copyButton,
+  value = "",
+  onChangeText,
+  placeholder,
+  editable = true,
+  ...props
+}) => {
+  const handleCopy = () => {
+    if (!value) {
+      return;
+    }
+
+    Clipboard.setString(value);
+  };
+
+  const renderCopyButton = (position: "left" | "right") => (
+    <TouchableOpacity onPress={handleCopy}>
+      <SideElement position={position}>
+        <Text sm>{copyButton?.showLabel ? "Copy" : "📋"}</Text>
+      </SideElement>
+    </TouchableOpacity>
+  );
+
+  return (
+    <Container $fieldSize={fieldSize}>
+      {label && (
+        <Text
+          sm={fieldSize === "sm"}
+          md={fieldSize === "md"}
+          lg={fieldSize === "lg"}
+          color={THEME.colors.text.primary}
+        >
+          {isLabelUppercase ? label.toString().toUpperCase() : label}
+          {labelSuffix && (
+            <Text color={THEME.colors.text.secondary}> {labelSuffix}</Text>
+          )}
+        </Text>
+      )}
+
+      <InputContainer
+        $fieldSize={fieldSize}
+        $isError={isError || !!error}
+        $isDisabled={!editable}
+      >
+        {copyButton?.position === "left" && renderCopyButton("left")}
+        {leftElement && (
+          <SideElement position="left">{leftElement}</SideElement>
+        )}
+
+        <StyledTextInput
+          $fieldSize={fieldSize}
+          $hasLeftElement={!!leftElement || copyButton?.position === "left"}
+          $hasRightElement={!!rightElement || copyButton?.position === "right"}
+          value={value}
+          onChangeText={onChangeText}
+          placeholder={placeholder}
+          placeholderTextColor={THEME.colors.text.secondary}
+          secureTextEntry={isPassword}
+          editable={editable}
+          {...props}
+        />
+
+        {rightElement && (
+          <SideElement position="right">{rightElement}</SideElement>
+        )}
+        {copyButton?.position === "right" && renderCopyButton("right")}
+      </InputContainer>
+
+      {note && <FieldNote sm>{note}</FieldNote>}
+      {error && (
+        <FieldNote sm $variant="error">
+          {error}
+        </FieldNote>
+      )}
+      {success && (
+        <FieldNote sm $variant="success">
+          {success}
+        </FieldNote>
+      )}
+    </Container>
+  );
+};

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -40,31 +40,18 @@ const INPUT_SIZES = {
 export type InputSize = keyof typeof INPUT_SIZES;
 
 export interface InputProps {
-  /** ID of the input should be unique */
   id?: string;
-  /** Size of the input */
   fieldSize?: InputSize;
-  /** Label of the input */
   label?: string | React.ReactNode;
-  /** Adds suffix to the label */
   labelSuffix?: string | React.ReactNode;
-  /** Make label uppercase */
   isLabelUppercase?: boolean;
-  /** Input error without a message */
   isError?: boolean;
-  /** Password input preset with show/hide button */
   isPassword?: boolean;
-  /** Left side element of the input */
   leftElement?: JSX.Element;
-  /** Right side element of the input */
   rightElement?: JSX.Element;
-  /** Note message of the input */
   note?: string | React.ReactNode;
-  /** Error message of the input */
   error?: string | React.ReactNode;
-  /** Success message of the input */
   success?: string | React.ReactNode;
-  /** Copy button options */
   copyButton?: {
     position: "left" | "right";
     showLabel?: boolean;
@@ -130,12 +117,13 @@ const StyledTextInput = styled.TextInput<
   Pick<StyledProps, "$fieldSize" | "$hasLeftElement" | "$hasRightElement">
 >`
   flex: 1;
-  font-size: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
+  height: ${({ $fieldSize }: { $fieldSize: InputSize }) =>
+    px(
+      INPUT_SIZES[$fieldSize].lineHeight +
+        2 * INPUT_SIZES[$fieldSize].paddingVertical,
+    )};
+  font-size: ${({ $fieldSize }: { $fieldSize: InputSize }) =>
     fs(INPUT_SIZES[$fieldSize].fontSize)};
-  line-height: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
-    px(INPUT_SIZES[$fieldSize].lineHeight)};
-  padding-vertical: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
-    px(INPUT_SIZES[$fieldSize].paddingVertical)};
   color: ${THEME.colors.text.primary};
 `;
 

--- a/src/components/sds/Typography/index.tsx
+++ b/src/components/sds/Typography/index.tsx
@@ -78,6 +78,7 @@ interface TypographyBaseProps extends SizeProps, WeightProps, ColorProps {
   children: React.ReactNode;
   size?: TextSize;
   weight?: FontWeight;
+  testID?: string;
 }
 
 const DISPLAY_SIZES = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,6 +1539,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@react-native-clipboard/clipboard@^1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.16.1.tgz#d92753bf3f850541f8250ad1705c787c6a246f1b"
+  integrity sha512-YdSwSS3P4IiJq5nW0iv3qpntDAzBf/xoew2zRPGJ6SJZr/Lhk4aWyR506EWl6BID+iQy7xQmzHXZYR5H4apM6g==
+
 "@react-native-community/cli-clean@15.1.3":
   version "15.1.3"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-15.1.3.tgz#cc177378d9c903737fbc1f22d7aa712a61d562be"


### PR DESCRIPTION
This PR adds a reusable `Input` component ported from SDS.

We'll be using it to collect user's password on the [onboarding flow](https://www.figma.com/design/KwkHXQxbNmDllwermJtnRu/Freighter-Mobile?node-id=2232-21068&m=dev).

We can use it like this:
```
<Input
  isPassword
  placeholder="Type your password"
  fieldSize="lg"
  note="Minimum 8 characters"
  value={passwordValue}
  onChangeText={setPasswordValue}
/>
```

The Input component file has a comprehensive [JSDoc with more code samples](https://github.com/stellar/freighter-mobile/pull/7/files#diff-8df7d44dc3d7b40ac73b3bc33db98242cd27cd4a95445a2d886a21766cfaed16R144-R211).

### Inputting the password
https://github.com/user-attachments/assets/37289bd2-76f5-46dc-9248-494e5e26e6cb

### Other states
<img width="978" alt="Screenshot 2025-02-27 at 16 10 44" src="https://github.com/user-attachments/assets/a58ab5cb-2e32-4a0b-a19a-7fea9de60b2a" />
<img width="976" alt="Screenshot 2025-02-27 at 16 10 59" src="https://github.com/user-attachments/assets/ca56f078-0918-472f-9394-326740692a2c" />
<img width="977" alt="Screenshot 2025-02-27 at 16 11 26" src="https://github.com/user-attachments/assets/68f0baad-d3e6-4d8c-a021-e86bab7c594f" />
<img width="979" alt="Screenshot 2025-02-27 at 16 21 05" src="https://github.com/user-attachments/assets/5109481b-415f-411e-9f2e-7a0b5616b900" />
