### PR TITLE
Create ImportWallet screen

### DIFF
--- a/__tests__/components/screens/ImportWalletScreen.test.tsx
+++ b/__tests__/components/screens/ImportWalletScreen.test.tsx
@@ -1,0 +1,75 @@
+import Clipboard from "@react-native-clipboard/clipboard";
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import { ImportWalletScreen } from "components/screens/ImportWalletScreen";
+import { AUTH_STACK_ROUTES } from "config/routes";
+import { renderWithProviders } from "helpers/testUtils";
+import React from "react";
+
+describe("ImportWalletScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders correctly", () => {
+    const { getByPlaceholderText, getByText } = renderWithProviders(
+      <ImportWalletScreen
+        navigation={{ replace: jest.fn() } as never}
+        route={{} as never}
+      />,
+    );
+
+    expect(getByPlaceholderText("Enter recovery phrase")).toBeTruthy();
+    expect(getByText("Import Wallet")).toBeTruthy();
+  });
+
+  it("does not navigate when recoveryPhrase is empty", () => {
+    const mockReplace = jest.fn();
+    const { getByText } = renderWithProviders(
+      <ImportWalletScreen
+        navigation={{ replace: jest.fn() } as never}
+        route={{} as never}
+      />,
+    );
+
+    const continueButton = getByText("Import wallet");
+    fireEvent.press(continueButton);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("navigates when recoveryPhrase is entered", () => {
+    const mockReplace = jest.fn();
+    const { getByText, getByPlaceholderText } = renderWithProviders(
+      <ImportWalletScreen
+        navigation={{ replace: mockReplace } as never}
+        route={{} as never}
+      />,
+    );
+
+    const textarea = getByPlaceholderText("Enter recovery phrase");
+    fireEvent.changeText(textarea, "sample recovery phrase");
+
+    const continueButton = getByText("Import wallet");
+    fireEvent.press(continueButton);
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTH_STACK_ROUTES.WELCOME_SCREEN);
+  });
+
+  it("updates the recovery phrase when pasting from clipboard", async () => {
+    (Clipboard.getString as jest.Mock).mockResolvedValue(
+      "clipboard recovery phrase",
+    );
+    const { getByTestId, getByDisplayValue } = renderWithProviders(
+      <ImportWalletScreen
+        navigation={{ replace: jest.fn() } as never}
+        route={{} as never}
+      />,
+    );
+
+    const clipboardButton = getByTestId("clipboard-button");
+    fireEvent.press(clipboardButton);
+
+    await waitFor(() => {
+      expect(getByDisplayValue("clipboard recovery phrase")).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/components/sds/Textarea.test.tsx
+++ b/__tests__/components/sds/Textarea.test.tsx
@@ -22,7 +22,7 @@ describe("Textarea", () => {
           paddingHorizontal: 10,
           gap: 6,
           borderRadius: 4,
-          lines: 3,
+          lines: 2,
         },
         md: {
           fontSize: 14,
@@ -31,7 +31,7 @@ describe("Textarea", () => {
           paddingHorizontal: 12,
           gap: 8,
           borderRadius: 6,
-          lines: 5,
+          lines: 3,
         },
         lg: {
           fontSize: 16,
@@ -40,7 +40,7 @@ describe("Textarea", () => {
           paddingHorizontal: 14,
           gap: 8,
           borderRadius: 8,
-          lines: 7,
+          lines: 4,
         },
       };
 
@@ -65,12 +65,16 @@ describe("Textarea", () => {
       const { getByTestId } = renderWithProviders(
         <Textarea testID="test-textarea" value="" />,
       );
+      const MD_SIZE_NUMBER_OF_LINES = 3;
       const textarea = getByTestId("test-textarea");
 
       expect(textarea.props.style).toMatchObject({
-        height: pxValue(5 * 28),
+        height: pxValue(MD_SIZE_NUMBER_OF_LINES * 28),
       });
-      expect(textarea.props).toHaveProperty("numberOfLines", 5);
+      expect(textarea.props).toHaveProperty(
+        "numberOfLines",
+        MD_SIZE_NUMBER_OF_LINES,
+      );
     });
   });
 

--- a/src/components/layout/OnboardLayout.tsx
+++ b/src/components/layout/OnboardLayout.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Button } from "components/sds/Button";
+import Icon from "components/sds/Icon";
 import { Display, Text } from "components/sds/Typography";
-import { THEME } from "config/theme";
-import { px } from "helpers/dimensions";
+import { PALETTE, THEME } from "config/theme";
+import { px, pxValue } from "helpers/dimensions";
 import { t } from "i18next";
 import React from "react";
 import {
@@ -24,6 +25,8 @@ interface OnboardLayoutProps {
   onPressDefaultActionButton?: () => void;
   isDefaultActionButtonDisabled?: boolean;
   defaultActionButtonText?: string;
+  hasClipboardButton?: boolean;
+  onPressClipboardButton?: () => Promise<void>;
 }
 
 interface StyledProps {
@@ -89,10 +92,16 @@ const StyledScrollView = styled(ScrollView).attrs(
   background-color: ${THEME.colors.background.default};
 `;
 
+const StyledFooterButtonContainer = styled.View`
+  gap: ${px(12)};
+`;
+
 interface DefaultFooterProps {
   onPressDefaultActionButton?: () => void;
   isDefaultActionButtonDisabled?: boolean;
   defaultActionButtonText?: string;
+  hasClipboardButton?: boolean;
+  onPressClipboardButton?: () => Promise<void>;
 }
 
 /**
@@ -109,20 +118,40 @@ interface DefaultFooterProps {
  * @param {() => void} [props.onPressDefaultActionButton] - Callback when the action button is pressed.
  * @param {boolean} [props.isDefaultActionButtonDisabled] - Flag to disable the action button.
  * @param {string} [props.defaultActionButtonText="Continue"] - Text to display on the action button.
+ * @param {boolean} [props.hasClipboardButton] - Flag to display a clipboard button in the footer.
+ * @param {() => void} [props.onPressClipboardButton] - Callback when the clipboard button is pressed.
  */
 const DefaultFooter: React.FC<DefaultFooterProps> = ({
   onPressDefaultActionButton,
   isDefaultActionButtonDisabled,
   defaultActionButtonText = t("onboarding.continue"),
+  hasClipboardButton = false,
+  onPressClipboardButton,
 }) => (
-  <Button
-    tertiary
-    lg
-    onPress={onPressDefaultActionButton}
-    disabled={isDefaultActionButtonDisabled}
-  >
-    {defaultActionButtonText}
-  </Button>
+  <StyledFooterButtonContainer>
+    {hasClipboardButton && (
+      <Button
+        secondary
+        lg
+        isFullWidth
+        testID="clipboard-button"
+        onPress={onPressClipboardButton as () => void}
+        icon={
+          <Icon.Clipboard size={pxValue(16)} color={PALETTE.dark.gray["09"]} />
+        }
+      >
+        {t("onboarding.pastFromClipboard")}
+      </Button>
+    )}
+    <Button
+      tertiary
+      lg
+      onPress={onPressDefaultActionButton}
+      disabled={isDefaultActionButtonDisabled}
+    >
+      {defaultActionButtonText}
+    </Button>
+  </StyledFooterButtonContainer>
 );
 
 /**
@@ -150,6 +179,8 @@ const DefaultFooter: React.FC<DefaultFooterProps> = ({
  * @param {() => void} [props.onPressDefaultActionButton] - Optional callback for the default action button press.
  * @param {boolean} [props.isDefaultActionButtonDisabled] - Optional flag to disable the default action button.
  * @param {string} [props.defaultActionButtonText="Continue"] - Optional text for the default action button.
+ * @param {boolean} [props.hasClipboardButton] - Optional flag to display a clipboard button in the footer.
+ * @param {() => Promise<void>} [props.onPressClipboardButton] - Optional callback for the clipboard button press.
  */
 export const OnboardLayout = ({
   children,
@@ -160,6 +191,8 @@ export const OnboardLayout = ({
   onPressDefaultActionButton,
   isDefaultActionButtonDisabled,
   defaultActionButtonText,
+  hasClipboardButton,
+  onPressClipboardButton,
 }: OnboardLayoutProps) => {
   const insets = useSafeAreaInsets();
 
@@ -183,6 +216,8 @@ export const OnboardLayout = ({
                 onPressDefaultActionButton={onPressDefaultActionButton}
                 isDefaultActionButtonDisabled={isDefaultActionButtonDisabled}
                 defaultActionButtonText={defaultActionButtonText}
+                hasClipboardButton={hasClipboardButton}
+                onPressClipboardButton={onPressClipboardButton}
               />
             )}
           </FooterContainer>

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -1,10 +1,8 @@
-import ClipboardIcon from "assets/icons/clipboard.svg";
 import { BaseLayout } from "components/layout/BaseLayout";
-import { Button } from "components/sds/Button";
 import { Input } from "components/sds/Input";
 import { Text } from "components/sds/Typography";
-import { PALETTE, THEME } from "config/theme";
-import { fs, px, pxValue } from "helpers/dimensions";
+import { THEME } from "config/theme";
+import { fs, px } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import React, { useState } from "react";
 import { View } from "react-native";
@@ -56,21 +54,6 @@ export const HomeScreen = () => {
         </Text>
 
         <View style={{ height: 40 }} />
-
-        <Button
-          secondary
-          lg
-          isFullWidth
-          icon={
-            <ClipboardIcon
-              width={pxValue(16)}
-              height={pxValue(16)}
-              stroke={PALETTE.dark.gray["09"]}
-            />
-          }
-        >
-          {t("onboarding.testButton")}
-        </Button>
       </Container>
     </BaseLayout>
   );

--- a/src/components/screens/ImportWalletScreen.tsx
+++ b/src/components/screens/ImportWalletScreen.tsx
@@ -1,0 +1,52 @@
+import Clipboard from "@react-native-clipboard/clipboard";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { OnboardLayout } from "components/layout/OnboardLayout";
+import Icon from "components/sds/Icon";
+import { Textarea } from "components/sds/Textarea";
+import { AUTH_STACK_ROUTES, AuthStackParamList } from "config/routes";
+import useAppTranslation from "hooks/useAppTranslation";
+import React, { useState } from "react";
+
+type ImportWalletScreenProps = NativeStackScreenProps<
+  AuthStackParamList,
+  typeof AUTH_STACK_ROUTES.IMPORT_WALLET_SCREEN
+>;
+
+export const ImportWalletScreen: React.FC<ImportWalletScreenProps> = ({
+  navigation,
+}) => {
+  const [recoveryPhrase, setRecoveryPhrase] = useState("");
+  const { t } = useAppTranslation();
+
+  const handleContinue = () => {
+    // TODO: Navigate to the next screen after authentication is implemented
+    navigation.replace(AUTH_STACK_ROUTES.WELCOME_SCREEN);
+  };
+
+  const onPressPasteFromClipboard = async () => {
+    const clipboardText = await Clipboard.getString();
+    setRecoveryPhrase(clipboardText);
+  };
+
+  const canContinue = !!recoveryPhrase;
+
+  return (
+    <OnboardLayout
+      icon={<Icon.Download01 circle />}
+      title={t("importWalletScreen.title")}
+      isDefaultActionButtonDisabled={!canContinue}
+      defaultActionButtonText={t("importWalletScreen.defaultActionButtonText")}
+      onPressDefaultActionButton={handleContinue}
+      hasClipboardButton
+      onPressClipboardButton={onPressPasteFromClipboard}
+    >
+      <Textarea
+        fieldSize="lg"
+        placeholder={t("importWalletScreen.textAreaPlaceholder")}
+        note={t("importWalletScreen.textAreaNote")}
+        value={recoveryPhrase}
+        onChangeText={setRecoveryPhrase}
+      />
+    </OnboardLayout>
+  );
+};

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -3,7 +3,7 @@ import { Text } from "components/sds/Typography";
 import { THEME } from "config/theme";
 import { fs, px } from "helpers/dimensions";
 import React from "react";
-import { TouchableOpacity } from "react-native";
+import { Platform, TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
 
 // =============================================================================
@@ -93,6 +93,14 @@ const StyledTextInput = styled.TextInput<
   font-size: ${({ $fieldSize }: { $fieldSize: InputSize }) =>
     fs(INPUT_SIZES[$fieldSize].fontSize)};
   color: ${THEME.colors.text.primary};
+  font-family: ${Platform.select({
+    ios: "Inter-Variable",
+    android: "Inter-Regular",
+  })};
+  font-weight: ${Platform.select({
+    ios: "400",
+    android: "normal",
+  })};
 `;
 
 const SideElement = styled.View<{ position: "left" | "right" }>`

--- a/src/components/sds/Textarea/index.tsx
+++ b/src/components/sds/Textarea/index.tsx
@@ -17,7 +17,7 @@ const TEXTAREA_SIZES = {
     paddingHorizontal: 10,
     gap: 6,
     borderRadius: 4,
-    lines: 3,
+    lines: 2,
   },
   md: {
     fontSize: 14,
@@ -26,7 +26,7 @@ const TEXTAREA_SIZES = {
     paddingHorizontal: 12,
     gap: 8,
     borderRadius: 6,
-    lines: 5,
+    lines: 3,
   },
   lg: {
     fontSize: 16,
@@ -35,7 +35,7 @@ const TEXTAREA_SIZES = {
     paddingHorizontal: 14,
     gap: 8,
     borderRadius: 8,
-    lines: 7,
+    lines: 4,
   },
 } as const;
 
@@ -81,6 +81,7 @@ const StyledTextInput = styled.TextInput<Pick<StyledProps, "$fieldSize">>`
     px(TEXTAREA_SIZES[$fieldSize].paddingHorizontal)};
   padding-vertical: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
     px(TEXTAREA_SIZES[$fieldSize].paddingVertical)};
+  font-family: "Inter-Regular";
 `;
 
 const FieldNoteWrapper = styled.View`

--- a/src/components/sds/Textarea/index.tsx
+++ b/src/components/sds/Textarea/index.tsx
@@ -2,7 +2,7 @@ import { Text } from "components/sds/Typography";
 import { THEME } from "config/theme";
 import { fs, px } from "helpers/dimensions";
 import React from "react";
-import { TextInput } from "react-native";
+import { Platform, TextInput } from "react-native";
 import styled from "styled-components/native";
 
 export interface TextareaProps
@@ -81,7 +81,14 @@ const StyledTextInput = styled.TextInput<Pick<StyledProps, "$fieldSize">>`
     px(TEXTAREA_SIZES[$fieldSize].paddingHorizontal)};
   padding-vertical: ${({ $fieldSize }: Pick<StyledProps, "$fieldSize">) =>
     px(TEXTAREA_SIZES[$fieldSize].paddingVertical)};
-  font-family: "Inter-Regular";
+  font-family: ${Platform.select({
+    ios: "Inter-Variable",
+    android: "Inter-Regular",
+  })};
+  font-weight: ${Platform.select({
+    ios: "400",
+    android: "normal",
+  })};
 `;
 
 const FieldNoteWrapper = styled.View`

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -39,11 +39,17 @@
     "defaultActionButtonText": "Continue",
     "footerNoteText": "Make sure you keep this in a safe\nplace before continuing"
   },
+  "importWalletScreen": {
+    "title": "Import Wallet",
+    "textAreaPlaceholder": "Enter recovery phrase",
+    "textAreaNote": "Phrases are usually 12 or 24 words",
+    "defaultActionButtonText": "Import wallet"
+  },
   "onboarding": {
     "continue": "Continue",
-    "testButton": "Test Button with Icon",
     "typePassword": "Type your password",
-    "typePasswordNote": "Minimum 8 characters"
+    "typePasswordNote": "Minimum 8 characters",
+    "pastFromClipboard": "Paste from clipboard"
   },
   "discovery": {
     "title": "Discovery"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -39,11 +39,17 @@
     "defaultActionButtonText": "Continuar",
     "footerNoteText": "Certifique-se de guardá-la em um lugar seguro\nantes de continuar"
   },
+  "importWalletScreen": {
+    "title": "Importar Carteira",
+    "textAreaPlaceholder": "Digite a frase de recuperação",
+    "textAreaNote": "As frases de recuperação geralmente têm 12 ou 24 palavras",
+    "defaultActionButtonText": "Importar carteira"
+  },
   "onboarding": {
     "continue": "Continuar",
-    "testButton": "Botão de teste com ícone",
     "typePassword": "Digite sua senha",
-    "typePasswordNote": "Mínimo de 8 caracteres"
+    "typePasswordNote": "Mínimo de 8 caracteres",
+    "pastFromClipboard": "Colar da área de transferência"
   },
   "discovery": {
     "title": "Explorar"

--- a/src/navigators/AuthNavigator.tsx
+++ b/src/navigators/AuthNavigator.tsx
@@ -3,19 +3,14 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import CustomNavigationHeader from "components/CustomNavigationHeader";
 import { ChoosePasswordScreen } from "components/screens/ChoosePasswordScreen";
 import { ConfirmPasswordScreen } from "components/screens/ConfirmPasswordScreen";
+import { ImportWalletScreen } from "components/screens/ImportWalletScreen";
 import { RecoveryPhraseAlertScreen } from "components/screens/RecoveryPhraseAlertScreen";
 import { RecoveryPhraseScreen } from "components/screens/RecoveryPhraseScreen";
 import { WelcomeScreen } from "components/screens/WelcomeScreen";
 import { AUTH_STACK_ROUTES, AuthStackParamList } from "config/routes";
-import { THEME } from "config/theme";
 import React from "react";
-import { View } from "react-native";
 
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
-
-const BlankScreen = () => (
-  <View style={{ flex: 1, backgroundColor: THEME.colors.background.default }} />
-);
 
 export const AuthNavigator = () => (
   <AuthStack.Navigator
@@ -49,7 +44,7 @@ export const AuthNavigator = () => (
     />
     <AuthStack.Screen
       name={AUTH_STACK_ROUTES.IMPORT_WALLET_SCREEN}
-      component={BlankScreen}
+      component={ImportWalletScreen}
     />
   </AuthStack.Navigator>
 );


### PR DESCRIPTION
This PR introduces the ImportWallet screen, which enables users to securely import their seed phrase and log into the app.

closes #18 

[importwallet.webm](https://github.com/user-attachments/assets/9760f3c8-e209-4f89-bcf0-fc01164bfb27)

https://github.com/user-attachments/assets/fa59f297-8188-4de6-adb4-71a3a4b2dae3

