### PR TITLE
Use new `/freighter-backend-prd` endpoint

### DIFF
--- a/__tests__/components/BalancesList.test.tsx
+++ b/__tests__/components/BalancesList.test.tsx
@@ -249,7 +249,7 @@ describe("BalancesList", () => {
 
       await waitFor(() => {
         expect(mockFetchAccountBalances).toHaveBeenCalledWith({
-          publicKey: "GBNMQBDE2BPGG7QMNZTKA5VMKMSUNBQMMADANNMPS6VNRUYIVAU5TJRQ",
+          publicKey: "GAZAJVMMEWVIQRP6RXQYTVAITE7SC2CBHALQTVW2N4DYBYPWZUH5VJGG",
           network: NETWORKS.TESTNET,
         });
       });

--- a/__tests__/ducks/prices.test.ts
+++ b/__tests__/ducks/prices.test.ts
@@ -114,7 +114,7 @@ describe("prices duck", () => {
 
     // Setup default mock returns
     mockGetTokenIdentifiersFromBalances.mockReturnValue(mockTokenIdentifiers);
-    mockFetchTokenPrices.mockResolvedValue({ data: mockPrices });
+    mockFetchTokenPrices.mockResolvedValue(mockPrices);
   });
 
   describe("initial state", () => {

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -95,8 +95,7 @@ type BalanceItem = PricedBalance & { id: string };
  */
 export const BalancesList: React.FC = () => {
   // TODO: Hardcoded values for testing, we'll get this from the wallet context
-  const publicKey = "GBNMQBDE2BPGG7QMNZTKA5VMKMSUNBQMMADANNMPS6VNRUYIVAU5TJRQ"; // with LP
-  // const publicKey = "GBDQO6LWQJBMWWPZV3SVGEFGX5CIBMPHQKU7HJZPWQWV6EWI6DKRP5WB"; // with Soroban Token
+  const publicKey = "GAZAJVMMEWVIQRP6RXQYTVAITE7SC2CBHALQTVW2N4DYBYPWZUH5VJGG"; // with LP
   const network = NETWORKS.TESTNET;
 
   const [isRefreshing, setIsRefreshing] = useState(false);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,7 +5,7 @@ const PASSWORD_MIN_LENGTH = 8;
 
 export { PASSWORD_MIN_LENGTH };
 
-export const INDEXER_URL = "https://freighter-backend.stellar.org/api/v1";
+export const INDEXER_URL = "https://freighter-backend-prd.stellar.org/api/v1";
 
 export enum FRIENDBOT_URLS {
   TESTNET = "https://friendbot.stellar.org",

--- a/src/ducks/prices.ts
+++ b/src/ducks/prices.ts
@@ -72,7 +72,7 @@ export const usePricesStore = create<PricesState>((set, get) => ({
       const response = await fetchTokenPrices({ tokens });
 
       set({
-        prices: response.data,
+        prices: response,
         isLoading: false,
         lastUpdated: Date.now(),
       });

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -116,7 +116,8 @@ export const fetchTokenPrices = async ({
   /*
   // ========================================================
   // Uncomment this to simulate token-prices response
-  // This may be useful for testing the UI with token prices we still don't have available
+  // This may be useful for testing the UI with token prices on Testnet
+  // as the /token-prices endpoint only returns prices for Mainnet
 
   // Simulate network delay
   // eslint-disable-next-line no-promise-executor-return

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -108,12 +108,15 @@ export interface FetchTokenPricesParams {
  */
 export const fetchTokenPrices = async ({
   tokens,
-}: FetchTokenPricesParams): Promise<TokenPricesResponse> => {
-  // TODO: Uncomment this once the endpoint is deployed
-  // const { data } = await backendApi.post<TokenPricesResponse>(
-  //   "/token-prices",
-  //   { tokens },
-  // );
+}: FetchTokenPricesParams): Promise<TokenPricesMap> => {
+  const { data } = await backendApi.post<TokenPricesResponse>("/token-prices", {
+    tokens,
+  });
+
+  /*
+  // ========================================================
+  // Uncomment this to simulate token-prices response
+  // This may be useful for testing the UI with token prices we still don't have available
 
   // Simulate network delay
   // eslint-disable-next-line no-promise-executor-return
@@ -122,13 +125,12 @@ export const fetchTokenPrices = async ({
   // This is the backend interface for the prices map
   // We'll convert those values to BigNumber for convenience
   const pricesMap: {
-    [tokenIdentifier: TokenIdentifier]: {
-      currentPrice: string | null;
-      percentagePriceChange24h: number | null;
-    };
-  } = {};
+     [tokenIdentifier: TokenIdentifier]: {
+       currentPrice: string | null;
+       percentagePriceChange24h: number | null;
+     };
+   } = {};
 
-  // Generate FAKE price data for each token
   tokens.forEach((token) => {
     // Special case for stablecoin
     if (token.includes("USD")) {
@@ -144,14 +146,21 @@ export const fetchTokenPrices = async ({
     }
   });
 
-  // Create fake API response structure
-  const fakeResponse = {
-    data: pricesMap,
-  };
+  //========================================================
+  */
+
+  // Make sure it's compliant with the TokenPricesMap type as the backend
+  // returns { "code:issuer" : null } for tokens that are not supported
+  const pricesMap = data.data;
+  tokens.forEach((token) => {
+    if (!pricesMap[token]) {
+      pricesMap[token] = {
+        currentPrice: null,
+        percentagePriceChange24h: null,
+      };
+    }
+  });
 
   // Make sure to convert the response values to BigNumber for convenience
-  return bigize(fakeResponse, [
-    "currentPrice",
-    "percentagePriceChange24h",
-  ]) as TokenPricesResponse;
+  return bigize(pricesMap, ["currentPrice", "percentagePriceChange24h"]);
 };


### PR DESCRIPTION
Included in this PR:
- Move from `freighter-backend.stellar.org/api/v1` to `freighter-backend-prd.stellar.org/api/v1` as [it's live now](https://stellarfoundation.slack.com/archives/C03347FNAHK/p1742591821425799)
- Fetching balances from new endpoint above
- Actually fetch the token prices instead of simulating backend response

Below is a sample for [GAUA7XL5K54CC2DDGP77FJ2YBHRJLT36CPZDXWPM6MP7MANOGG77PNJU](https://stellar.expert/explorer/public/account/GAUA7XL5K54CC2DDGP77FJ2YBHRJLT36CPZDXWPM6MP7MANOGG77PNJU) on `Pubnet`:

<img width="400" alt="Screenshot 2025-03-24 at 10 17 06" src="https://github.com/user-attachments/assets/bdc944b7-592c-45ef-9e47-e9d84aa95189" />

Below is a sample for [GAYF33NNNMI2Z6VNRFXQ64D4E4SF77PM46NW3ZUZEEU5X7FCHAZCMHKU](https://stellar.expert/explorer/testnet/account/GAYF33NNNMI2Z6VNRFXQ64D4E4SF77PM46NW3ZUZEEU5X7FCHAZCMHKU) on `Testnet`:
*The `/token-prices` endpoint is actually[ not supported for Testnet tokens](https://stellarfoundation.slack.com/archives/C03347FNAHK/p1742837138793369?thread_ts=1742836890.436629&cid=C03347FNAHK)

<img width="400" alt="Screenshot 2025-03-24 at 10 18 34" src="https://github.com/user-attachments/assets/d963f794-1c9a-43c9-90e3-c27d89160f18" />
