### PR TITLE
Splash screen not hiding on Auth error

### DIFF
--- a/src/navigators/RootNavigator.tsx
+++ b/src/navigators/RootNavigator.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { STORAGE_KEYS } from "config/constants";
+import { logger } from "config/logger";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
 import { isHashKeyValid } from "hooks/useGetActiveAccount";
@@ -35,11 +36,14 @@ export const RootNavigator = () => {
           STORAGE_KEYS.ACTIVE_ACCOUNT_ID,
         );
         setHasAccount(!!activeAccountId);
-
-        // Hide the splash screen after initialization
-        await RNBootSplash.hide({ fade: true });
-        setInitializing(false);
       } catch (error) {
+        logger.error(
+          "RootNavigator.validateAuth",
+          "Error initializing the app",
+          error,
+        );
+      } finally {
+        await RNBootSplash.hide({ fade: true });
         setInitializing(false);
       }
     };
@@ -47,7 +51,7 @@ export const RootNavigator = () => {
     validateAuth();
   }, [getIsAuthenticated]);
 
-  // Show nothing while initializing
+  // Show loading screen while initializing
   if (initializing) {
     return null;
   }


### PR DESCRIPTION
First bug! 🥳 

The splash screen was not hiding if the auth check fails. This PR adds a `finally` on the `try/catch` block that will hide the splash screen even with an error. 