### PR TITLE
Improve UX for Balances + Prices fetching

### DIFF
--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -47,6 +47,14 @@ interface TabIconProps {
 
 const TabIcon = ({ route, focused, color }: TabIconProps) => {
   const IconComponent = TAB_ICONS[route.name];
+  return (
+    <TabIconWrapper focused={focused}>
+      <IconComponent size={TAB_ICON_SIZE} color={color} />
+    </TabIconWrapper>
+  );
+};
+
+export const TabNavigator = () => {
   const publicKey = TEST_PUBLIC_KEY;
   const networkDetails = TEST_NETWORK_DETAILS;
 
@@ -57,39 +65,33 @@ const TabIcon = ({ route, focused, color }: TabIconProps) => {
   useFetchAssetIcons(networkDetails.networkUrl);
 
   return (
-    <TabIconWrapper focused={focused}>
-      <IconComponent size={TAB_ICON_SIZE} color={color} />
-    </TabIconWrapper>
+    <MainTab.Navigator
+      initialRouteName={MAIN_TAB_ROUTES.TAB_HOME}
+      screenOptions={({ route }) => ({
+        // eslint-disable-next-line react/no-unstable-nested-components
+        tabBarIcon: (props) => <TabIcon route={route} {...props} />,
+        headerShown: false,
+        tabBarShowLabel: false,
+        tabBarActiveTintColor: THEME.colors.tab.active,
+        tabBarInactiveTintColor: THEME.colors.tab.inactive,
+        tabBarStyle: {
+          backgroundColor: THEME.colors.background.default,
+          borderColor: THEME.colors.border.default,
+          borderTopWidth: pxValue(1),
+          borderStyle: "solid",
+          paddingHorizontal: pxValue(72),
+        },
+      })}
+    >
+      <MainTab.Screen
+        name={MAIN_TAB_ROUTES.TAB_HISTORY}
+        component={HistoryScreen}
+      />
+      <MainTab.Screen name={MAIN_TAB_ROUTES.TAB_HOME} component={HomeScreen} />
+      <MainTab.Screen
+        name={MAIN_TAB_ROUTES.TAB_DISCOVERY}
+        component={DiscoveryScreen}
+      />
+    </MainTab.Navigator>
   );
 };
-
-export const TabNavigator = () => (
-  <MainTab.Navigator
-    initialRouteName={MAIN_TAB_ROUTES.TAB_HOME}
-    screenOptions={({ route }) => ({
-      // eslint-disable-next-line react/no-unstable-nested-components
-      tabBarIcon: (props) => <TabIcon route={route} {...props} />,
-      headerShown: false,
-      tabBarShowLabel: false,
-      tabBarActiveTintColor: THEME.colors.tab.active,
-      tabBarInactiveTintColor: THEME.colors.tab.inactive,
-      tabBarStyle: {
-        backgroundColor: THEME.colors.background.default,
-        borderColor: THEME.colors.border.default,
-        borderTopWidth: pxValue(1),
-        borderStyle: "solid",
-        paddingHorizontal: pxValue(72),
-      },
-    })}
-  >
-    <MainTab.Screen
-      name={MAIN_TAB_ROUTES.TAB_HISTORY}
-      component={HistoryScreen}
-    />
-    <MainTab.Screen name={MAIN_TAB_ROUTES.TAB_HOME} component={HomeScreen} />
-    <MainTab.Screen
-      name={MAIN_TAB_ROUTES.TAB_DISCOVERY}
-      component={DiscoveryScreen}
-    />
-  </MainTab.Navigator>
-);


### PR DESCRIPTION
This PR implements a 3sec timeout for the prices fetching similar to what we have on the extension.

Included in this PR:
- `Await` for **both** `balances and prices` requests to finish before `displaying the balances` list so that the balances appear with prices right from the bat
- In case the `prices` request takes `more than 3 seconds` to finish then the app displays the `balances right away` without the prices
   - The prices request `keeps processing on the background` and the `balances are updated` as soon as the prices are ready
   - This same 3 secs behavior is applied to the "pull to refresh" action
- Simplify the "pull to refresh" logic
- Extract complex logic out of the `useBalancesStore` store to a local `fetchPricedBalances` function
- Fix balances and assets being fetched on `TabIcon` rendering due to a merge conflict mistake

### Regular scenario with quick fetching
https://github.com/user-attachments/assets/c180a8b4-19b4-4d12-9ce4-e0a91a24369f

### Edge case scenario with prices taking 6 secs to complete fetching
https://github.com/user-attachments/assets/4a4ca528-10d1-4146-8107-63167c00bfc1
