### PR TITLE
Set bundle identifier to `org.stellar.freightermobile`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,7 +77,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace "com.freightermobile"
+    namespace "org.stellar.freightermobile"
     defaultConfig {
         applicationId "org.stellar.freightermobile"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,7 +79,7 @@ android {
 
     namespace "com.freightermobile"
     defaultConfig {
-        applicationId "com.freightermobile"
+        applicationId "org.stellar.freightermobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/src/main/java/com/freightermobile/MainActivity.kt
+++ b/android/app/src/main/java/com/freightermobile/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.freightermobile
+package org.stellar.freightermobile
 
 // this import is needed for the onCreate override function
 import android.os.Bundle;

--- a/android/app/src/main/java/com/freightermobile/MainApplication.kt
+++ b/android/app/src/main/java/com/freightermobile/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.freightermobile
+package org.stellar.freightermobile
 
 import android.app.Application
 import com.facebook.react.PackageList

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -315,7 +315,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.stellar.freightermobile;
 				PRODUCT_NAME = "freighter-mobile";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -344,7 +344,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.stellar.freightermobile;
 				PRODUCT_NAME = "freighter-mobile";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
This is the bundle identifier we will be using to publish Freighter mobile on both Apple App Store and Google Play.