### PR TITLE
Poll balances and prices every 30 secs

### DIFF
--- a/src/hooks/usePricedBalancesPolling.ts
+++ b/src/hooks/usePricedBalancesPolling.ts
@@ -1,0 +1,39 @@
+import { NETWORKS } from "config/constants";
+import { useBalancesStore } from "ducks/balances";
+import { useEffect } from "react";
+
+interface UsePricedBalancesPollingParams {
+  publicKey: string;
+  network: NETWORKS;
+}
+
+/**
+ * Hook to manage polling of priced balances
+ * Automatically starts polling when mounted and stops when unmounted
+ *
+ * @param params - Parameters for the polling
+ * @param params.publicKey - The public key to fetch balances for
+ * @param params.network - The network to fetch balances from
+ */
+export const usePricedBalancesPolling = ({
+  publicKey,
+  network,
+}: UsePricedBalancesPollingParams) => {
+  const { startPolling, stopPolling } = useBalancesStore();
+
+  useEffect(() => {
+    // Start polling when component mounts
+    startPolling({
+      publicKey,
+      network,
+    });
+
+    // Cleanup polling when component unmounts
+    return () => {
+      // Previous polling (if any) will be automatically stopped by React
+      // before this effect runs again with new publicKey or network values
+      stopPolling();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [publicKey, network]);
+};

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -9,6 +9,7 @@ import { THEME } from "config/theme";
 import { px, pxValue } from "helpers/dimensions";
 import { useFetchAssetIcons } from "hooks/useFetchAssetIcons";
 import { useFetchPricedBalances } from "hooks/useFetchPricedBalances";
+import { usePricedBalancesPolling } from "hooks/usePricedBalancesPolling";
 import React from "react";
 import styled from "styled-components/native";
 
@@ -63,6 +64,12 @@ export const TabNavigator = () => {
 
   // Fetch icons whenever balances are updated
   useFetchAssetIcons(networkDetails.networkUrl);
+
+  // Start polling for balance and price updates
+  usePricedBalancesPolling({
+    publicKey: TEST_PUBLIC_KEY,
+    network: TEST_NETWORK_DETAILS.network,
+  });
 
   return (
     <MainTab.Navigator


### PR DESCRIPTION
This PR adds a polling task which fetches balances and prices every 30 secs so we make sure users are always looking at recent data.

It will:
- Start polling when user logs in
- Keeps polling on the background regardless of which tab te user is on
- Stop polling when user logs out
- Stop polling from previous public key or network as soon as the user changes it
- Start polling from new public key or network as soon as the user changes it

### Polling sample using 4s of interval 
https://github.com/user-attachments/assets/db99d0d3-57f5-4e64-827a-efdbd51b6ea5