### PR TITLE
Add Friendbot button

### DIFF
--- a/__tests__/components/BalancesList.test.tsx
+++ b/__tests__/components/BalancesList.test.tsx
@@ -222,7 +222,7 @@ describe("BalancesList", () => {
       const { getByText } = renderWithProviders(
         <BalancesList publicKey={testPublicKey} network={NETWORKS.TESTNET} />,
       );
-      expect(getByText("No balances found")).toBeTruthy();
+      expect(getByText("Fund with Friendbot")).toBeTruthy();
     });
 
     it("should render the list of balances correctly", () => {

--- a/__tests__/components/RecoveryPhraseWarningBox.test.tsx
+++ b/__tests__/components/RecoveryPhraseWarningBox.test.tsx
@@ -23,7 +23,7 @@ describe("RecoveryPhraseWarningBox", () => {
         "Stellar Development Foundation will never ever ask for your phrase",
       ),
     ).toBeTruthy();
-    expect(getByText("If you lose, we can't recover it")).toBeTruthy();
+    expect(getByText("If you lose it, we can't recover it")).toBeTruthy();
   });
 
   it("renders all five warning items", () => {

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -1,4 +1,5 @@
 import { AssetIcon } from "components/AssetIcon";
+import { FriendbotButton } from "components/FriendbotButton";
 import { Text } from "components/sds/Typography";
 import { NETWORKS } from "config/constants";
 import { THEME } from "config/theme";
@@ -107,6 +108,12 @@ export const BalancesList: React.FC<BalancesListProps> = ({
     fetchAccountBalances,
   } = useBalancesStore();
 
+  const noBalances = Object.keys(pricedBalances).length === 0;
+
+  const isTestNetwork = [NETWORKS.TESTNET, NETWORKS.FUTURENET].includes(
+    network,
+  );
+
   // Set isMounting to false after the component mounts.
   // This is used to prevent the "no balances" state from showing
   // for a fraction of second while the store is setting the
@@ -150,23 +157,35 @@ export const BalancesList: React.FC<BalancesListProps> = ({
     );
   }
 
-  // If no balances or loading, show empty state
-  if (Object.keys(pricedBalances).length === 0) {
+  // If no balances and still loading, show the spinner
+  if (noBalances && (isBalancesLoading || isMounting)) {
     return (
       <ListWrapper>
         <ListTitle>
           <Text medium>{t("balancesList.title")}</Text>
         </ListTitle>
 
-        {isBalancesLoading || isMounting ? (
-          <Spinner
-            testID="balances-list-spinner"
-            size="large"
-            color={THEME.colors.secondary}
-          />
-        ) : (
-          <Text md>{t("balancesList.empty")}</Text>
+        <Spinner
+          testID="balances-list-spinner"
+          size="large"
+          color={THEME.colors.secondary}
+        />
+      </ListWrapper>
+    );
+  }
+
+  // If still no balances after fetching, then show the empty state
+  if (noBalances) {
+    return (
+      <ListWrapper>
+        <ListTitle>
+          <Text medium>{t("balancesList.title")}</Text>
+        </ListTitle>
+
+        {isTestNetwork && (
+          <FriendbotButton publicKey={publicKey} network={network} />
         )}
+        {!isTestNetwork && <Text md>{t("balancesList.empty")}</Text>}
       </ListWrapper>
     );
   }

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -12,7 +12,7 @@ import {
   formatPercentageAmount,
 } from "helpers/formatAmount";
 import useAppTranslation from "hooks/useAppTranslation";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { FlatList, RefreshControl } from "react-native";
 import styled from "styled-components/native";
 
@@ -98,6 +98,7 @@ export const BalancesList: React.FC<BalancesListProps> = ({
 }) => {
   const { t } = useAppTranslation();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isMounting, setIsMounting] = useState(true);
 
   const {
     pricedBalances,
@@ -105,6 +106,16 @@ export const BalancesList: React.FC<BalancesListProps> = ({
     error: balancesError,
     fetchAccountBalances,
   } = useBalancesStore();
+
+  // Set isMounting to false after the component mounts.
+  // This is used to prevent the "no balances" state from showing
+  // for a fraction of second while the store is setting the
+  // isBalancesLoading flag. We could revisit this after
+  // we finish implementing the auth flow as it could be
+  // naturally solved by that.
+  useEffect(() => {
+    setIsMounting(false);
+  }, []);
 
   /**
    * Handles manual refresh via pull-to-refresh gesture
@@ -147,7 +158,7 @@ export const BalancesList: React.FC<BalancesListProps> = ({
           <Text medium>{t("balancesList.title")}</Text>
         </ListTitle>
 
-        {isBalancesLoading ? (
+        {isBalancesLoading || isMounting ? (
           <Spinner
             testID="balances-list-spinner"
             size="large"

--- a/src/components/FriendbotButton.tsx
+++ b/src/components/FriendbotButton.tsx
@@ -1,0 +1,38 @@
+import { Button } from "components/sds/Button";
+import { NETWORKS } from "config/constants";
+import { useBalancesStore } from "ducks/balances";
+import useAppTranslation from "hooks/useAppTranslation";
+import React, { useState } from "react";
+import { fundAccount } from "services/friendbot";
+
+export const FriendbotButton = ({
+  publicKey,
+  network,
+}: {
+  publicKey: string;
+  network: NETWORKS;
+}) => {
+  const { t } = useAppTranslation();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { fetchAccountBalances } = useBalancesStore();
+
+  const handleFundAccount = async () => {
+    setIsLoading(true);
+    await fundAccount(publicKey, network);
+    setIsLoading(false);
+
+    // Refresh the balances
+    await fetchAccountBalances({
+      publicKey,
+      network,
+    });
+  };
+
+  return (
+    <Button isFullWidth isLoading={isLoading} onPress={handleFundAccount}>
+      {t("friendbotButton.title")}
+    </Button>
+  );
+};

--- a/src/components/screens/HistoryScreen.tsx
+++ b/src/components/screens/HistoryScreen.tsx
@@ -73,7 +73,7 @@ export const HistoryScreen = () => {
 
         <ButtonContainer>
           <Button isFullWidth onPress={handleLogout}>
-            <Text>Logout</Text>
+            {t("logout")}
           </Button>
         </ButtonContainer>
       </Container>

--- a/src/components/sds/Button/index.tsx
+++ b/src/components/sds/Button/index.tsx
@@ -229,7 +229,7 @@ interface ButtonProps extends VariantProps, SizeProps {
   isFullWidth?: boolean;
   disabled?: boolean;
   squared?: boolean;
-  onPress?: () => void;
+  onPress?: () => void | Promise<void>;
   testID?: string;
 }
 

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -72,7 +72,7 @@
     "ifYouForgetYourPassword": "If you forget your password, use the recovery phrase to access your wallet",
     "dontShareWithAnyone": "Don't share this phrase with anyone",
     "neverAskForYourPhrase": "Stellar Development Foundation will never ever ask for your phrase",
-    "ifYouLose": "If you lose, we can't recover it"
+    "ifYouLose": "If you lose it, we can't recover it"
   },
   "authStore": {
     "error": {

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -92,5 +92,9 @@
     "title": "Tokens",
     "error": "Error loading balances",
     "empty": "No balances found"
-  }
+  },
+  "friendbotButton": {
+    "title": "Fund with Friendbot"
+  },
+  "logout": "Log out"
 }

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -92,5 +92,9 @@
     "title": "Tokens",
     "error": "Erro ao carregar saldos",
     "empty": "Nenhum saldo encontrado"
-  }
+  },
+  "friendbotButton": {
+    "title": "Adicionar saldo com Friendbot"
+  },
+  "logout": "Sair"
 }

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -4,7 +4,7 @@ import { bigize } from "helpers/bigize";
 import { createApiService } from "services/apiFactory";
 
 // Create a dedicated API service for backend operations
-export const backendApi = createApiService({
+const backendApi = createApiService({
   baseURL: INDEXER_URL,
 });
 

--- a/src/services/friendbot.ts
+++ b/src/services/friendbot.ts
@@ -1,0 +1,28 @@
+import { FRIENDBOT_URLS, NETWORKS } from "config/constants";
+import { logger } from "config/logger";
+import { createApiService } from "services/apiFactory";
+
+// Create a dedicated API service for backend operations
+const friendBotTestnet = createApiService({
+  baseURL: FRIENDBOT_URLS.TESTNET,
+});
+
+const friendBotFuturenet = createApiService({
+  baseURL: FRIENDBOT_URLS.FUTURENET,
+});
+
+export const fundAccount = async (publicKey: string, network: NETWORKS) => {
+  if (![NETWORKS.TESTNET, NETWORKS.FUTURENET].includes(network)) {
+    logger.error("friendbot", "Unsupported network", network);
+    return;
+  }
+
+  const friendBot =
+    network === NETWORKS.FUTURENET ? friendBotFuturenet : friendBotTestnet;
+
+  try {
+    await friendBot.get(`?addr=${encodeURIComponent(publicKey)}`);
+  } catch (error) {
+    logger.error("friendbot", "Error funding account", error);
+  }
+};


### PR DESCRIPTION
Closes https://github.com/stellar/freighter-mobile/issues/69

This PR adds the `FriendbotButton` component which should only be shown and used on `Testnet` (or Futurenet once we add support for it) to fund recently created accounts with `10000 XLM`.

This PR also fixes a small UI glitch that was causing the empty state to briefly blink for a fraction of second before displaying the balances spinner.

<img width="400" alt="Screenshot 2025-03-31 at 16 33 01" src="https://github.com/user-attachments/assets/73adf76f-da94-4115-bcc8-47407f259e3d" />

### iOS
https://github.com/user-attachments/assets/d2b8ce0e-1fbb-4c77-8dfc-77016f485388

### Android
[android-friendbot.webm](https://github.com/user-attachments/assets/c9d5061c-4b6f-469f-9802-d758e8e9e920)
