### PR TITLE
Prevent erasing bootsplash files on gradle-clean

### DIFF
--- a/scripts/gradle-clean
+++ b/scripts/gradle-clean
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-rm -rf ./android/app/src/main/res/drawable-* || true
-rm -rf ./android/app/src/main/res/raw || true
 (cd android && ./gradlew clean || true) && cd ..


### PR DESCRIPTION
We don't need to remove `/drawable-*` on `gradle-clean` script as it's erasing the images we use on splash screen.
Also the `/raw` folder currently doesn't exist so let's keep the script clean.