### PR TITLE
Remove duplicate pxValue wrappers

### DIFF
--- a/src/components/layout/OnboardLayout.tsx
+++ b/src/components/layout/OnboardLayout.tsx
@@ -4,7 +4,7 @@ import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Display, Text } from "components/sds/Typography";
 import { PALETTE, THEME } from "config/theme";
-import { px, pxValue } from "helpers/dimensions";
+import { px } from "helpers/dimensions";
 import { t } from "i18next";
 import React from "react";
 import { Platform } from "react-native";
@@ -100,9 +100,7 @@ const DefaultFooter: React.FC<DefaultFooterProps> = ({
         isFullWidth
         testID="clipboard-button"
         onPress={onPressClipboardButton as () => void}
-        icon={
-          <Icon.Clipboard size={pxValue(16)} color={PALETTE.dark.gray["09"]} />
-        }
+        icon={<Icon.Clipboard size={16} color={PALETTE.dark.gray["09"]} />}
       >
         {t("onboarding.pastFromClipboard")}
       </Button>

--- a/src/components/screens/RecoveryPhraseScreen.tsx
+++ b/src/components/screens/RecoveryPhraseScreen.tsx
@@ -7,7 +7,7 @@ import { Text } from "components/sds/Typography";
 import { AUTH_STACK_ROUTES, AuthStackParamList } from "config/routes";
 import { PALETTE, THEME } from "config/theme";
 import { useAuthenticationStore } from "ducks/auth";
-import { px, pxValue } from "helpers/dimensions";
+import { px } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import React, { useCallback, useState } from "react";
 import { generateMnemonic } from "stellar-hd-wallet";
@@ -140,9 +140,7 @@ export const RecoveryPhraseScreen: React.FC<RecoveryPhraseScreenProps> = ({
         lg
         isFullWidth
         onPress={handleCopy}
-        icon={
-          <Icon.Copy01 size={pxValue(16)} color={PALETTE.dark.gray["09"]} />
-        }
+        icon={<Icon.Copy01 size={16} color={PALETTE.dark.gray["09"]} />}
       >
         {t("recoveryPhraseScreen.copyButtonText")}
       </Button>


### PR DESCRIPTION
The `Icon` component already wraps `size` with `px` so we don't need to wrap it when creating the component