### PR TITLE
Fix infinity loop on new accounts

### DIFF
--- a/__tests__/components/BalancesList.test.tsx
+++ b/__tests__/components/BalancesList.test.tsx
@@ -7,7 +7,15 @@ import React from "react";
 
 // Mock the stores
 jest.mock("ducks/balances", () => ({
-  useBalancesStore: jest.fn(),
+  useBalancesStore: jest.fn(() => ({
+    fetchAccountBalances: jest.fn(),
+    startPolling: jest.fn(),
+    stopPolling: jest.fn(),
+    pricedBalances: {},
+    isLoading: false,
+    error: null,
+    isFunded: false,
+  })),
 }));
 
 jest.mock("ducks/prices", () => ({

--- a/src/components/FriendbotButton.tsx
+++ b/src/components/FriendbotButton.tsx
@@ -1,7 +1,8 @@
 import { Button } from "components/sds/Button";
 import { NETWORKS } from "config/constants";
+import { useBalancesStore } from "ducks/balances";
+import { debug } from "helpers/debug";
 import useAppTranslation from "hooks/useAppTranslation";
-import { useBalancesList } from "hooks/useBalancesList";
 import React, { useState } from "react";
 import { fundAccount } from "services/friendbot";
 
@@ -13,17 +14,19 @@ export const FriendbotButton = ({
   network: NETWORKS;
 }) => {
   const { t } = useAppTranslation();
-
   const [isLoading, setIsLoading] = useState(false);
-
-  const { handleRefresh } = useBalancesList({ publicKey, network });
+  const { fetchAccountBalances } = useBalancesStore();
 
   const handleFundAccount = async () => {
     setIsLoading(true);
-    await fundAccount(publicKey, network);
-    setIsLoading(false);
-
-    handleRefresh();
+    try {
+      await fundAccount(publicKey, network);
+      await fetchAccountBalances({ publicKey, network });
+    } catch (error) {
+      debug("FriendbotButton", "Error funding account:", error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (

--- a/src/hooks/useBalancesList.ts
+++ b/src/hooks/useBalancesList.ts
@@ -1,7 +1,7 @@
 import { NETWORKS } from "config/constants";
 import { PricedBalance } from "config/types";
 import { useBalancesStore } from "ducks/balances";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface UseBalancesListResult {
   balanceItems: Array<PricedBalance & { id: string }>;
@@ -91,12 +91,16 @@ export const useBalancesList = ({
   }, [fetchAccountBalances, publicKey, network]);
 
   // Convert balances object to array
-  const balanceItems = Object.entries(pricedBalances).map(
-    ([id, balance]) =>
-      ({
-        id,
-        ...balance,
-      }) as PricedBalance & { id: string },
+  const balanceItems = useMemo(
+    () =>
+      Object.entries(pricedBalances).map(
+        ([id, balance]) =>
+          ({
+            id,
+            ...balance,
+          }) as PricedBalance & { id: string },
+      ),
+    [pricedBalances],
   );
 
   // Only show error if we're not in the initial loading state and there is an error


### PR DESCRIPTION
Calling `handleRefresh` from `useBalancesList` in `FriendbotButton` was triggering an infinity loop. This PR fixes that by removing `useBalancesList` from `FriendbotButton` and making a single call to `fetchAccountBalances` from `useBalancesStore` like it was originally implemented.

### Before fix
https://github.com/user-attachments/assets/37bc6806-d548-424c-b737-510b1d640520

### After fix
https://github.com/user-attachments/assets/0e8e8811-5b68-4c43-a9f2-55aabbe1eda8