### PR TITLE
Settings - Version label

### DIFF
--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -6,9 +6,10 @@ import Icon from "components/sds/Icon";
 import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
 import { THEME } from "config/theme";
 import { useAuthenticationStore } from "ducks/auth";
+import { getAppVersion } from "helpers/version";
 import useAppTranslation from "hooks/useAppTranslation";
 import React, { useEffect } from "react";
-import { TouchableOpacity } from "react-native";
+import { TouchableOpacity, View } from "react-native";
 
 type SettingsScreenProps = NativeStackScreenProps<
   SettingsStackParamList,
@@ -20,6 +21,7 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
 }) => {
   const { logout } = useAuthenticationStore();
   const { t } = useAppTranslation();
+  const appVersion = getAppVersion();
 
   useEffect(() => {
     navigation.setOptions({
@@ -45,9 +47,20 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
     },
   ];
 
+  const updateListItems = [
+    {
+      icon: <Icon.GitCommit size={24} color={THEME.colors.list.disabled} />,
+      title: t("settings.version", { version: appVersion }),
+      testID: "update-button",
+    },
+  ];
+
   return (
     <BaseLayout insets={{ top: false }}>
-      <List items={listItems} />
+      <View className="flex flex-col gap-6">
+        <List items={listItems} />
+        <List items={updateListItems} />
+      </View>
     </BaseLayout>
   );
 };

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -159,6 +159,7 @@ export const THEME = {
     },
     list: {
       destructive: PALETTE.dark.red["11"],
+      disabled: PALETTE.dark.gray["09"],
     },
   },
   opacity: {

--- a/src/helpers/version.ts
+++ b/src/helpers/version.ts
@@ -1,0 +1,3 @@
+import packageJson from "package.json";
+
+export const getAppVersion = (): string => packageJson.version;

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -16,7 +16,8 @@
   },
   "settings": {
     "title": "Settings",
-    "logout": "Log Out"
+    "logout": "Log Out",
+    "version": "Version {{version}}"
   },
   "welcomeScreen": {
     "createNewWallet": "Create a new wallet",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -16,7 +16,8 @@
   },
   "settings": {
     "title": "Configurações",
-    "logout": "Sair"
+    "logout": "Sair",
+    "version": "Versão {{version}}"
   },
   "welcomeScreen": {
     "createNewWallet": "Criar uma nova carteira",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@react-native/typescript-config/tsconfig.json",
   "compilerOptions": {
     "types": ["styled-components-react-native", "@types/jest"],
-    "baseUrl": "src/"
+    "baseUrl": "src/",
+    "paths": {
+      "package.json": ["../package.json"]
+    }
   },
   "include": [
     "src",


### PR DESCRIPTION
Added the version label to the settings screen
_disclaimer: we are currently getting the version from the package.json_


## iOS 
![Simulator Screenshot - iPhone 16 Pro - 2025-04-14 at 17 42 46](https://github.com/user-attachments/assets/a737517e-f5be-4924-90a0-d0918ae51854)

## Android 🤖
![Screenshot_1744664038](https://github.com/user-attachments/assets/6ca0df74-c4d6-46b8-8f69-13440cffa34f)



closes #63 