### PR TITLE
Switch networks settings details

### DIFF
--- a/__tests__/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.test.tsx
+++ b/__tests__/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.test.tsx
@@ -1,0 +1,101 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { screen } from "@testing-library/react-native";
+import NetworkSettingsScreen from "components/screens/ChangeNetworkScreen/NetworkSettingsScreen";
+import {
+  FRIENDBOT_URLS,
+  NETWORK_NAMES,
+  NETWORK_URLS,
+  NETWORKS,
+  mapNetworkToNetworkDetails,
+} from "config/constants";
+import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
+import { renderWithProviders } from "helpers/testUtils";
+import React from "react";
+
+type NetworkSettingsScreenProps = NativeStackScreenProps<
+  SettingsStackParamList,
+  typeof SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN
+>;
+
+const mockNavigate = jest.fn();
+const mockRoute = (network: NETWORKS) => ({
+  key: "NetworkSettingsScreen",
+  name: SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN,
+  params: {
+    selectedNetwork: network,
+  },
+});
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+} as unknown as NetworkSettingsScreenProps["navigation"];
+
+jest.mock("hooks/useAppTranslation", () => () => ({
+  t: (key: string) => {
+    const translations: Record<string, string> = {
+      "networkSettingsScreen.networkName": "Network Name",
+      "networkSettingsScreen.horizonUrl": "Horizon URL",
+      "networkSettingsScreen.passphrase": "Passphrase",
+      "networkSettingsScreen.friendbotUrl": "Friendbot URL",
+      "networkSettingsScreen.friendbotPlaceholder": "Enter Friendbot URL",
+    };
+    return translations[key] || key;
+  },
+}));
+
+describe("NetworkSettingsScreen", () => {
+  it("renders correctly with Testnet details", () => {
+    renderWithProviders(
+      <NetworkSettingsScreen
+        route={
+          mockRoute(NETWORKS.TESTNET) as NetworkSettingsScreenProps["route"]
+        }
+        navigation={mockNavigation}
+      />,
+    );
+
+    expect(screen.getByText(NETWORK_NAMES[NETWORKS.TESTNET])).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(NETWORK_NAMES[NETWORKS.TESTNET]),
+    ).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(NETWORK_URLS[NETWORKS.TESTNET]),
+    ).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(
+        mapNetworkToNetworkDetails(NETWORKS.TESTNET).networkPassphrase,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(FRIENDBOT_URLS[NETWORKS.TESTNET]),
+    ).toBeTruthy();
+  });
+
+  it("renders correctly with Public network details and friendbot placeholder", () => {
+    renderWithProviders(
+      <NetworkSettingsScreen
+        route={
+          mockRoute(NETWORKS.PUBLIC) as NetworkSettingsScreenProps["route"]
+        }
+        navigation={mockNavigation}
+      />,
+    );
+
+    expect(screen.getByText(NETWORK_NAMES[NETWORKS.PUBLIC])).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(NETWORK_NAMES[NETWORKS.PUBLIC]),
+    ).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(NETWORK_URLS[NETWORKS.PUBLIC]),
+    ).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText(
+        mapNetworkToNetworkDetails(NETWORKS.PUBLIC).networkPassphrase,
+      ),
+    ).toBeTruthy();
+
+    expect(screen.getByPlaceholderText("Enter Friendbot URL")).toBeTruthy();
+  });
+});

--- a/__tests__/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.test.tsx
+++ b/__tests__/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.test.tsx
@@ -58,18 +58,18 @@ describe("NetworkSettingsScreen", () => {
 
     expect(screen.getByText(NETWORK_NAMES[NETWORKS.TESTNET])).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(NETWORK_NAMES[NETWORKS.TESTNET]),
+      screen.getByDisplayValue(NETWORK_NAMES[NETWORKS.TESTNET]),
     ).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(NETWORK_URLS[NETWORKS.TESTNET]),
+      screen.getByDisplayValue(NETWORK_URLS[NETWORKS.TESTNET]),
     ).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(
+      screen.getByDisplayValue(
         mapNetworkToNetworkDetails(NETWORKS.TESTNET).networkPassphrase,
       ),
     ).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(FRIENDBOT_URLS[NETWORKS.TESTNET]),
+      screen.getByDisplayValue(FRIENDBOT_URLS[NETWORKS.TESTNET]),
     ).toBeTruthy();
   });
 
@@ -85,13 +85,13 @@ describe("NetworkSettingsScreen", () => {
 
     expect(screen.getByText(NETWORK_NAMES[NETWORKS.PUBLIC])).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(NETWORK_NAMES[NETWORKS.PUBLIC]),
+      screen.getByDisplayValue(NETWORK_NAMES[NETWORKS.PUBLIC]),
     ).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(NETWORK_URLS[NETWORKS.PUBLIC]),
+      screen.getByDisplayValue(NETWORK_URLS[NETWORKS.PUBLIC]),
     ).toBeTruthy();
     expect(
-      screen.getByPlaceholderText(
+      screen.getByDisplayValue(
         mapNetworkToNetworkDetails(NETWORKS.PUBLIC).networkPassphrase,
       ),
     ).toBeTruthy();

--- a/__tests__/hooks/useNetworkColors.test.tsx
+++ b/__tests__/hooks/useNetworkColors.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { NETWORKS } from "config/constants";
+import useColors, { ThemeColors } from "hooks/useColors";
+import useNetworkColors from "hooks/useNetworkColors";
+
+jest.mock("hooks/useColors");
+
+const mockPartialThemeColors: Partial<ThemeColors> = {
+  pink: { "9": "mockPink9" } as ThemeColors["pink"],
+  lime: { "9": "mockLime9" } as ThemeColors["lime"],
+  mint: { "9": "mockMint9" } as ThemeColors["mint"],
+};
+
+const mockUseColors = useColors as jest.MockedFunction<typeof useColors>;
+
+describe("useNetworkColors", () => {
+  it("should return the correct colors for each network", () => {
+    mockUseColors.mockReturnValue({
+      themeColors: mockPartialThemeColors as ThemeColors,
+    });
+
+    const { result } = renderHook(() => useNetworkColors());
+
+    expect(result.current[NETWORKS.TESTNET]).toBe(
+      mockPartialThemeColors.pink?.[9],
+    );
+    expect(result.current[NETWORKS.PUBLIC]).toBe(
+      mockPartialThemeColors.lime?.[9],
+    );
+    expect(result.current[NETWORKS.FUTURENET]).toBe(
+      mockPartialThemeColors.mint?.[9],
+    );
+  });
+});

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -15,11 +15,16 @@ interface ListItemProps {
 interface ListProps {
   items: ListItemProps[];
   variant?: "filled" | "transparent";
+  className?: string;
 }
 
-export const List: React.FC<ListProps> = ({ items, variant = "filled" }) => (
+export const List: React.FC<ListProps> = ({
+  items,
+  variant = "filled",
+  className,
+}) => (
   <View
-    className={`${variant === "filled" ? "bg-background-secondary rounded-[12px]" : ""}`}
+    className={`${variant === "filled" ? "bg-background-secondary rounded-[12px]" : ""} ${className}`}
   >
     {items.map((item, index) => (
       <React.Fragment key={item.title}>

--- a/src/components/screens/ChangeNetworkScreen/ChangeNetworkScreen.tsx
+++ b/src/components/screens/ChangeNetworkScreen/ChangeNetworkScreen.tsx
@@ -2,15 +2,21 @@
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import BottomSheet from "components/BottomSheet";
+import { List } from "components/List";
 import { BaseLayout } from "components/layout/BaseLayout";
 import ChangeNetworkBottomSheetContent from "components/screens/ChangeNetworkScreen/ChangeNetworkBottomSheet";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
-import { mapNetworkToNetworkDetails, NETWORKS } from "config/constants";
+import {
+  mapNetworkToNetworkDetails,
+  NETWORK_NAMES,
+  NETWORKS,
+} from "config/constants";
 import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
+import useNetworkColors from "hooks/useNetworkColors";
 import React, { useMemo, useRef } from "react";
 import { Pressable, View } from "react-native";
 
@@ -19,21 +25,45 @@ type ChangeNetworkScreenProps = NativeStackScreenProps<
   typeof SETTINGS_ROUTES.CHANGE_NETWORK_SCREEN
 >;
 
-const ChangeNetworkScreen: React.FC<ChangeNetworkScreenProps> = () => {
+const ChangeNetworkScreen: React.FC<ChangeNetworkScreenProps> = ({
+  navigation,
+}) => {
   const { t } = useAppTranslation();
   const { themeColors } = useColors();
   const selectNetworkBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const { network: activeNetwork, selectNetwork } = useAuthenticationStore();
+  const networkColors = useNetworkColors();
   const activeNetworkDetails = useMemo(
     () => mapNetworkToNetworkDetails(activeNetwork),
     [activeNetwork],
   );
 
-  const networkColors = {
-    [NETWORKS.TESTNET]: themeColors.pink[9],
-    [NETWORKS.PUBLIC]: themeColors.lime[9],
-    [NETWORKS.FUTURENET]: themeColors.mint[9],
-  };
+  const networkSettingsListItems = [
+    {
+      icon: <Icon.Globe02 size={20} color={networkColors[NETWORKS.PUBLIC]} />,
+      title: NETWORK_NAMES.PUBLIC,
+      onPress: () => {
+        navigation.navigate(SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN, {
+          selectedNetwork: NETWORKS.PUBLIC,
+        });
+      },
+      trailingContent: (
+        <Icon.ChevronRight size={24} color={themeColors.foreground.primary} />
+      ),
+    },
+    {
+      icon: <Icon.Globe02 size={20} color={networkColors[NETWORKS.TESTNET]} />,
+      title: NETWORK_NAMES.TESTNET,
+      onPress: () => {
+        navigation.navigate(SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN, {
+          selectedNetwork: NETWORKS.TESTNET,
+        });
+      },
+      trailingContent: (
+        <Icon.ChevronRight size={24} color={themeColors.foreground.primary} />
+      ),
+    },
+  ];
 
   return (
     <BaseLayout insets={{ top: false }}>
@@ -53,25 +83,37 @@ const ChangeNetworkScreen: React.FC<ChangeNetworkScreenProps> = () => {
           selectNetworkBottomSheetModalRef.current?.dismiss()
         }
       />
-      <View className="flex flex-col mt-3">
-        <Text secondary sm medium>
-          {t("changeNetworkScreen.currentNetwork")}
-        </Text>
-        <Pressable
-          className="flex flex-row items-center justify-between gap-2 px-4 py-3 rounded-lg border border-border-primary mt-2"
-          onPress={() => selectNetworkBottomSheetModalRef.current?.present()}
-        >
-          <View className="flex flex-row items-center gap-2">
-            <View
-              className="w-2 h-2 rounded-full"
-              style={{ backgroundColor: networkColors[activeNetwork] }}
+      <View className="flex flex-col gap-9 mt-3">
+        <View className="flex flex-col">
+          <Text secondary sm medium>
+            {t("changeNetworkScreen.currentNetwork")}
+          </Text>
+          <Pressable
+            className="flex flex-row items-center justify-between gap-2 px-4 py-3 rounded-lg border border-border-primary mt-2"
+            onPress={() => selectNetworkBottomSheetModalRef.current?.present()}
+          >
+            <View className="flex flex-row items-center gap-2">
+              <View
+                className="w-2 h-2 rounded-full"
+                style={{ backgroundColor: networkColors[activeNetwork] }}
+              />
+              <Text primary md medium>
+                {activeNetworkDetails.networkName}
+              </Text>
+            </View>
+            <Icon.ChevronDown
+              size={16}
+              color={themeColors.foreground.primary}
             />
-            <Text primary md medium>
-              {activeNetworkDetails.networkName}
-            </Text>
-          </View>
-          <Icon.ChevronDown size={16} color={themeColors.foreground.primary} />
-        </Pressable>
+          </Pressable>
+        </View>
+
+        <View className="flex flex-col">
+          <Text secondary sm medium>
+            {t("changeNetworkScreen.networkSettings")}
+          </Text>
+          <List className="mt-5" items={networkSettingsListItems} />
+        </View>
       </View>
     </BaseLayout>
   );

--- a/src/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.tsx
+++ b/src/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.tsx
@@ -1,0 +1,85 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { BaseLayout } from "components/layout/BaseLayout";
+import Icon from "components/sds/Icon";
+import { Input } from "components/sds/Input";
+import { Text } from "components/sds/Typography";
+import {
+  FRIENDBOT_URLS,
+  NETWORK_NAMES,
+  NETWORK_URLS,
+  mapNetworkToNetworkDetails,
+} from "config/constants";
+import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
+import { isFuturenet, isTestnet } from "helpers/networks";
+import useAppTranslation from "hooks/useAppTranslation";
+import useNetworkColors from "hooks/useNetworkColors";
+import React from "react";
+import { View } from "react-native";
+
+type NetworkSettingsScreenProps = NativeStackScreenProps<
+  SettingsStackParamList,
+  typeof SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN
+>;
+
+const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
+  route,
+}) => {
+  const { selectedNetwork } = route.params;
+  const networkColors = useNetworkColors();
+  const { t } = useAppTranslation();
+
+  const isTestnetOrFuturenet =
+    isTestnet(selectedNetwork) || isFuturenet(selectedNetwork);
+
+  return (
+    <BaseLayout insets={{ top: false }}>
+      <View className="flex flex-col gap-9 mt-3">
+        <View className="flex flex-col gap-[16px] bg-background-secondary rounded-[16px] p-[16px]">
+          <View className="flex flex-row items-center gap-2">
+            <Icon.Globe02 size={24} color={networkColors[selectedNetwork]} />
+            <Text md semiBold>
+              {NETWORK_NAMES[selectedNetwork]}
+            </Text>
+          </View>
+          <Text sm secondary medium numberOfLines={1}>
+            {NETWORK_URLS[selectedNetwork]}
+          </Text>
+        </View>
+
+        {/* TODO: Make fields editable when we add custom network support */}
+        <Input
+          fieldSize="lg"
+          placeholder={NETWORK_NAMES[selectedNetwork]}
+          label={t("networkSettingsScreen.networkName")}
+          editable={false}
+        />
+        <Input
+          fieldSize="lg"
+          placeholder={NETWORK_URLS[selectedNetwork]}
+          label={t("networkSettingsScreen.horizonUrl")}
+          editable={false}
+        />
+        <Input
+          fieldSize="lg"
+          placeholder={
+            mapNetworkToNetworkDetails(selectedNetwork).networkPassphrase
+          }
+          label={t("networkSettingsScreen.passphrase")}
+          editable={false}
+        />
+        <Input
+          fieldSize="lg"
+          placeholder={
+            isTestnetOrFuturenet
+              ? FRIENDBOT_URLS[selectedNetwork as keyof typeof FRIENDBOT_URLS]
+              : t("networkSettingsScreen.friendbotPlaceholder")
+          }
+          label={t("networkSettingsScreen.friendbotUrl")}
+          editable={false}
+        />
+      </View>
+    </BaseLayout>
+  );
+};
+
+export default NetworkSettingsScreen;

--- a/src/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.tsx
+++ b/src/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.tsx
@@ -49,30 +49,29 @@ const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
         {/* TODO: Make fields editable when we add custom network support */}
         <Input
           fieldSize="lg"
-          placeholder={NETWORK_NAMES[selectedNetwork]}
+          value={NETWORK_NAMES[selectedNetwork]}
           label={t("networkSettingsScreen.networkName")}
           editable={false}
         />
         <Input
           fieldSize="lg"
-          placeholder={NETWORK_URLS[selectedNetwork]}
+          value={NETWORK_URLS[selectedNetwork]}
           label={t("networkSettingsScreen.horizonUrl")}
           editable={false}
         />
         <Input
           fieldSize="lg"
-          placeholder={
-            mapNetworkToNetworkDetails(selectedNetwork).networkPassphrase
-          }
+          value={mapNetworkToNetworkDetails(selectedNetwork).networkPassphrase}
           label={t("networkSettingsScreen.passphrase")}
           editable={false}
         />
         <Input
           fieldSize="lg"
-          placeholder={
+          placeholder={t("networkSettingsScreen.friendbotPlaceholder")}
+          value={
             isTestnetOrFuturenet
               ? FRIENDBOT_URLS[selectedNetwork as keyof typeof FRIENDBOT_URLS]
-              : t("networkSettingsScreen.friendbotPlaceholder")
+              : ""
           }
           label={t("networkSettingsScreen.friendbotUrl")}
           editable={false}

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -94,14 +94,18 @@ const InputContainer = styled.View<
 `;
 
 const StyledTextInput = styled.TextInput<
-  Pick<StyledProps, "$fieldSize" | "$hasLeftElement" | "$hasRightElement">
+  Pick<
+    StyledProps,
+    "$fieldSize" | "$hasLeftElement" | "$hasRightElement" | "$isDisabled"
+  >
 >`
   flex: 1;
   height: ${({ $fieldSize }: { $fieldSize: InputSize }) =>
     getInputHeight($fieldSize)};
   font-size: ${({ $fieldSize }: { $fieldSize: InputSize }) =>
     fs(INPUT_SIZES[$fieldSize].fontSize)};
-  color: ${THEME.colors.text.primary};
+  color: ${({ $isDisabled }: Pick<StyledProps, "$isDisabled">) =>
+    $isDisabled ? THEME.colors.text.secondary : THEME.colors.text.primary};
   font-family: ${Platform.select({
     ios: "Inter-Variable",
     android: "Inter-Regular",
@@ -336,6 +340,7 @@ export const Input: React.FC<InputProps> = ({
           $hasRightElement={
             !!rightElement || copyButton?.position === "right" || !!endButton
           }
+          $isDisabled={!editable}
           value={value}
           onChangeText={onChangeText}
           placeholder={placeholder}
@@ -344,6 +349,7 @@ export const Input: React.FC<InputProps> = ({
           placeholderTextColor={THEME.colors.text.secondary}
           secureTextEntry={isPassword}
           editable={editable}
+          selection={!editable && value ? { start: 0, end: 0 } : undefined}
           {...props}
         />
 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,3 +1,5 @@
+import { NETWORKS } from "config/constants";
+
 export const ROOT_NAVIGATOR_ROUTES = {
   AUTH_STACK: "AuthStack",
   MAIN_TAB_STACK: "MainTabStack",
@@ -36,6 +38,7 @@ export const MANAGE_ASSETS_ROUTES = {
 export const SETTINGS_ROUTES = {
   SETTINGS_SCREEN: "SettingsScreen",
   CHANGE_NETWORK_SCREEN: "ChangeNetworkScreen",
+  NETWORK_SETTINGS_SCREEN: "NetworkSettingsScreen",
 } as const;
 
 export const MANAGE_WALLETS_ROUTES = {
@@ -100,6 +103,9 @@ export type ManageAssetsStackParamList = {
 export type SettingsStackParamList = {
   [SETTINGS_ROUTES.SETTINGS_SCREEN]: undefined;
   [SETTINGS_ROUTES.CHANGE_NETWORK_SCREEN]: undefined;
+  [SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN]: {
+    selectedNetwork: NETWORKS;
+  };
 };
 
 export type ManageWalletsStackParamList = {

--- a/src/hooks/useNetworkColors.ts
+++ b/src/hooks/useNetworkColors.ts
@@ -1,0 +1,16 @@
+import { NETWORKS } from "config/constants";
+import useColors from "hooks/useColors";
+
+const useNetworkColors = () => {
+  const { themeColors } = useColors();
+
+  const networkColors = {
+    [NETWORKS.TESTNET]: themeColors.pink[9],
+    [NETWORKS.PUBLIC]: themeColors.lime[9],
+    [NETWORKS.FUTURENET]: themeColors.mint[9],
+  };
+
+  return networkColors;
+};
+
+export default useNetworkColors;

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -52,7 +52,16 @@
   },
   "changeNetworkScreen": {
     "title": "Switch Network",
-    "currentNetwork": "Current network"
+    "currentNetwork": "Current network",
+    "networkSettings": "Network Settings"
+  },
+  "networkSettingsScreen": {
+    "title": "Network Settings",
+    "networkName": "Network Name",
+    "horizonUrl": "Horizon RPC URL",
+    "passphrase": "Passphrase",
+    "friendbotUrl": "Friendbot URL",
+    "friendbotPlaceholder": "Enter Friendbot URL"
   },
   "welcomeScreen": {
     "createNewWallet": "Create a new wallet",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -55,6 +55,14 @@
     "title": "Mudar Rede",
     "currentNetwork": "Rede atual"
   },
+  "networkSettingsScreen": {
+    "title": "Configurações de Rede",
+    "networkName": "Nome da Rede",
+    "horizonUrl": "URL RPC do Horizon",
+    "passphrase": "Frase Secreta",
+    "friendbotUrl": "URL do Friendbot",
+    "friendbotPlaceholder": "Insira a URL do Friendbot"
+  },
   "welcomeScreen": {
     "createNewWallet": "Criar uma nova carteira",
     "iAlreadyHaveWallet": "Já tenho uma carteira",
@@ -197,7 +205,11 @@
   "balancesList": {
     "title": "Tokens",
     "error": "Erro ao carregar saldos",
-    "empty": "Nenhum saldo encontrado"
+    "empty": "Nenhum saldo encontrado",
+    "unfundedAccount": {
+      "message": "Para começar a usar esta conta, financie-a com pelo menos 1 XLM.",
+      "learnMore": "Saiba mais"
+    }
   },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"
@@ -374,8 +386,12 @@
     "firstTimeSend": "Primeiro envio",
     "status": "Status",
     "statusSuccess": "Sucesso",
+    "statusFailed": "Falhou",
+    "statusPending": "Pendente",
     "rate": "Taxa",
     "fee": "Comissão",
+    "transactionHash": "Hash da Transação",
+    "couldNotBeSentTo": "não pôde ser enviado para",
     "viewOnExpert": "Ver no stellar.expert"
   },
   "dappRequestBottomSheetContent": {

--- a/src/navigators/SettingsNavigator.tsx
+++ b/src/navigators/SettingsNavigator.tsx
@@ -2,6 +2,7 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import CustomNavigationHeader from "components/CustomNavigationHeader";
 import ChangeNetworkScreen from "components/screens/ChangeNetworkScreen";
+import NetworkSettingsScreen from "components/screens/ChangeNetworkScreen/NetworkSettingsScreen";
 import { SettingsScreen } from "components/screens/SettingsScreen";
 import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -30,6 +31,13 @@ export const SettingsStackNavigator = () => {
         component={ChangeNetworkScreen}
         options={{
           headerTitle: t("settings.network"),
+        }}
+      />
+      <SettingsStack.Screen
+        name={SETTINGS_ROUTES.NETWORK_SETTINGS_SCREEN}
+        component={NetworkSettingsScreen}
+        options={{
+          headerTitle: t("networkSettingsScreen.title"),
         }}
       />
     </SettingsStack.Navigator>


### PR DESCRIPTION
Network settings Screen

# What's included:
  - Updated `List` component to receive additional `classNames`
  - Extracted network colors to the new `useNetworkColors` hook
  - Added `NetworkSettingsScreen`

## iOS 
| <img src="https://github.com/user-attachments/assets/e2c441ea-f982-4d92-8979-0846a97f56e9" width="100%"  /> | <img src="https://github.com/user-attachments/assets/0793ebe8-cc39-435e-bcc2-3f1a843dd589" width="100%"  /> | <img src="https://github.com/user-attachments/assets/47cdfcc4-6f21-446f-bfff-c276fc0cdf4e" width="100%"  /> |
| :--: | :--: | :--: | 
| **Change network screen** | **Main net details** | **Test net details** |  

## Android 🤖
| <img src="https://github.com/user-attachments/assets/d739bf62-4007-4b9d-97bd-1729ed3068b8" width="100%"  /> | <img src="https://github.com/user-attachments/assets/71cbeddd-54be-4801-a811-f501384c9a24" width="100%"  /> | <img src="https://github.com/user-attachments/assets/e1896210-d18b-4fe2-a912-04321a24aa09" width="100%"  /> |
| :--: | :--: | :--: | 
| **Change network screen** | **Main net details** | **Test net details** |  

closes #126 