### PR TITLE
FIX: copy notifications being stacked

### DIFF
--- a/__tests__/hooks/useClipboard.test.tsx
+++ b/__tests__/hooks/useClipboard.test.tsx
@@ -42,6 +42,7 @@ describe("useClipboard", () => {
     expect(mockShowToast).toHaveBeenCalledWith({
       title: "Copied to clipboard!",
       variant: "success",
+      toastId: "copy-toast",
     });
   });
 
@@ -60,6 +61,7 @@ describe("useClipboard", () => {
     expect(mockShowToast).toHaveBeenCalledWith({
       title: customMessage,
       variant: "success",
+      toastId: "copy-toast",
     });
   });
 
@@ -77,6 +79,7 @@ describe("useClipboard", () => {
     expect(mockShowToast).toHaveBeenCalledWith({
       title: "Copied to clipboard!",
       variant: "primary",
+      toastId: "copy-toast",
     });
   });
 
@@ -112,6 +115,7 @@ describe("useClipboard", () => {
     expect(mockShowToast).toHaveBeenCalledWith({
       title: "Failed to copy to clipboard",
       variant: "error",
+      toastId: "copy-error-toast",
     });
   });
 });

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -51,11 +51,13 @@ export const useClipboard = (): UseClipboardResult => {
         showToast({
           title: options.notificationMessage || t("common.copied"),
           variant: options.toastVariant || "success",
+          toastId: "copy-toast",
         });
       } catch (error) {
         showToast({
           title: t("clipboard.failed"),
           variant: "error",
+          toastId: "copy-error-toast",
         });
       }
     },

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -22,6 +22,8 @@ export interface ToastOptions {
   message?: string;
   /** Duration in milliseconds before auto-dismissing (default: 3000) */
   duration?: number;
+  /** Optional ID for the toast. If a toast with the same ID already exists, it will be replaced */
+  toastId?: string;
 }
 
 interface ToastContextType {
@@ -54,6 +56,7 @@ const ToastWrapper = styled.View<ToastWrapperProps>`
 
 interface ToastPropsWithId extends ToastProps {
   id: string;
+  toastId?: string;
 }
 
 /**
@@ -67,6 +70,13 @@ interface ToastPropsWithId extends ToastProps {
  *   variant: "success",
  *   title: "Success!",
  *   message: "Your action was completed successfully.",
+ * });
+ *
+ * // Show a toast with a specific ID (will replace existing toast with same ID)
+ * showToast({
+ *   variant: "success",
+ *   title: "Copied!",
+ *   toastId: "copy-toast"
  * });
  */
 export const useToast = (): ToastContextType => {
@@ -97,9 +107,19 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
     const newToast: ToastPropsWithId = {
       ...options,
       id: Date.now().toString(),
+      toastId: options.toastId,
     };
 
-    setToasts((currentToasts) => [...currentToasts, newToast]);
+    setToasts((currentToasts) => {
+      // If we have a toastId, remove any existing toast with the same ID
+      if (options.toastId) {
+        const filteredToasts = currentToasts.filter(
+          (toast) => toast.toastId !== options.toastId,
+        );
+        return [...filteredToasts, newToast];
+      }
+      return [...currentToasts, newToast];
+    });
   }, []);
 
   const handleDismiss = useCallback((toast: ToastPropsWithId) => {


### PR DESCRIPTION
Implement security screen and show recovery phrase screen

# What's new:
- New button on settings that leads to security screen
- New screen for security settings
- New screen that leads to screen with recovery phrase
- New screen showing recovery phrase

## iOS 


https://github.com/user-attachments/assets/2b232030-a6bd-4c02-bd10-46e3c1f484a7


## Android 🤖


https://github.com/user-attachments/assets/51c80818-d7d4-4cc2-b5d1-4bc9fdf861a6


Closes: #100 