### PR TITLE
feat: add view on stellar.expert button and change skip to cancel in rename modal

### DIFF
--- a/src/components/screens/HomeScreen/AccountItemRow.tsx
+++ b/src/components/screens/HomeScreen/AccountItemRow.tsx
@@ -3,8 +3,10 @@ import ContextMenuButton, { MenuItem } from "components/ContextMenuButton";
 import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
+import { NETWORKS } from "config/constants";
 import { Account } from "config/types";
 import { truncateAddress } from "helpers/stellar";
+import { getStellarExpertUrl } from "helpers/stellarExpert";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React from "react";
@@ -44,7 +46,7 @@ const AccountItemRow: React.FC<AccountItemRowProps> = ({
   });
 
   const handleViewOnExplorer = async () => {
-    const url = `https://stellar.expert/explorer/public/account/${account.publicKey}`;
+    const url = `${getStellarExpertUrl(NETWORKS.PUBLIC)}/account/${account.publicKey}`;
     await Linking.openURL(url);
   };
 

--- a/src/components/screens/HomeScreen/RenameAccountModal.tsx
+++ b/src/components/screens/HomeScreen/RenameAccountModal.tsx
@@ -85,7 +85,7 @@ const RenameAccountModal: React.FC<RenameAccountModalProps> = ({
             onPress={() => setModalVisible(false)}
             disabled={isRenamingAccount}
           >
-            {t("renameAccountModal.cancel")}
+            {t("common.cancel")}
           </Button>
         </View>
         <View className="flex-1">

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -41,7 +41,6 @@
   },
   "renameAccountModal": {
     "currentName": "Current name",
-    "cancel": "Cancel",
     "saveName": "Save name",
     "nameInputPlaceholder": "Enter a name for your account"
   },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -42,7 +42,6 @@
   },
   "renameAccountModal": {
     "currentName": "Nome atual",
-    "cancel": "Cancelar",
     "saveName": "Salvar nome",
     "nameInputPlaceholder": "Digite um nome para sua carteira"
   },


### PR DESCRIPTION
Making some tweaks at account details

# What's new:
- Added a new button to wallet options that takes the user to stellar.expert website
- Changed the button from skip to cancel at rename wallet

## iOS 


https://github.com/user-attachments/assets/908429e1-be1f-40dd-adf6-e9465b7be696


## Android 🤖


https://github.com/user-attachments/assets/33e14425-f877-469b-9154-d050ce7eeea1


Closes: #124 