### PR TITLE
Fix spacing on History list footer

### DIFF
--- a/src/components/screens/HistoryScreen/HistoryList.tsx
+++ b/src/components/screens/HistoryScreen/HistoryList.tsx
@@ -176,6 +176,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1 }}
         ListHeaderComponent={ListHeaderComponent}
+        ListFooterComponent={<View className="h-10" />}
         className={className}
         ListEmptyComponent={
           <View className="flex-1 items-center justify-center px-2 gap-4">

--- a/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
+++ b/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
@@ -83,7 +83,7 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
   }, [fetchData]);
 
   return (
-    <BaseLayout insets={{ top: false }}>
+    <BaseLayout insets={{ top: false, bottom: false }}>
       <View className="flex-1 gap-8 mt-5">
         <TokenBalanceHeader
           tokenId={tokenId}


### PR DESCRIPTION
This PR fixes the spacing and padding on History list footer for both the Token Details history list and the main history list tab. See videos below.

### Before fix
https://github.com/user-attachments/assets/c0c990e4-2d18-4d4e-b324-5263284e100e

### After fix
https://github.com/user-attachments/assets/0ddc348b-da37-4a98-95f9-57d52b339f75