### PR TITLE
Fix broken link for Wallet Connect icon

### DIFF
--- a/src/ducks/walletKit.ts
+++ b/src/ducks/walletKit.ts
@@ -15,7 +15,7 @@ export const WALLET_KIT_METADATA = {
   name: "Freighter",
   description: "Freighter, a stellar wallet for everyone",
   url: "https://freighter.app",
-  icons: ["https://tinyurl.com/freighter-mobile-icon"],
+  icons: ["https://stellar.creit.tech/wallet-icons/freighter.png"],
 };
 
 /**


### PR DESCRIPTION
The previous icon link expired, so let's use this one from wallets kit which won't expire to prevent displaying a broken image.
We should update it again before releasing the Beta version as we'll have a [rebranded icon](https://stellarfoundation.slack.com/archives/C03347FNAHK/p1749680443910289?thread_ts=1749675559.072739&cid=C03347FNAHK).

### Before fix
<img width="753" alt="Screenshot 2025-06-10 at 17 57 37" src="https://github.com/user-attachments/assets/1e3c15dc-990c-4ed3-9961-8014f75d2f41" />
<img width="629" alt="Screenshot 2025-06-10 at 17 59 18" src="https://github.com/user-attachments/assets/4ebabd19-7c98-419f-b82a-24144a55a444" />
<img width="678" alt="Screenshot 2025-06-10 at 18 00 58" src="https://github.com/user-attachments/assets/3726e47b-9286-45ce-a56c-e2d58318bd4f" />

### After fix
<img width="1569" alt="Screenshot 2025-06-11 at 15 38 46" src="https://github.com/user-attachments/assets/7b537bca-4adb-48da-bc71-76b3d2287c35" />
<img width="627" alt="Screenshot 2025-06-11 at 15 39 11" src="https://github.com/user-attachments/assets/f2a264fd-f67a-47eb-93cc-754e97459e78" />
<img width="675" alt="Screenshot 2025-06-11 at 15 39 48" src="https://github.com/user-attachments/assets/3715fed7-0464-4f96-ae20-67c7e117c8dd" />