### PR TITLE
fix: Rebrand "Create account" as "Sent" or "Account funded"

### DIFF
--- a/src/components/screens/HistoryScreen/mappers/createAccount.tsx
+++ b/src/components/screens/HistoryScreen/mappers/createAccount.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { AssetIcon } from "components/AssetIcon";
 import TransactionDetailsContent from "components/screens/HistoryScreen/TransactionDetailsContent";
 import {
   TransactionDetails,
@@ -12,6 +13,7 @@ import Avatar, { AvatarSizes } from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { NATIVE_TOKEN_CODE } from "config/constants";
+import { AssetTypeWithCustomToken } from "config/types";
 import { formatAssetAmount } from "helpers/formatAmount";
 import { truncateAddress } from "helpers/stellar";
 import { ThemeColors } from "hooks/useColors";
@@ -53,13 +55,25 @@ export const mapCreateAccountHistoryItem = ({
     <Icon.ArrowCircleUp size={16} color={themeColors.foreground.primary} />
   );
 
+  const IconComponent = isRecipient ? null : (
+    <AssetIcon
+      token={{
+        type: AssetTypeWithCustomToken.NATIVE,
+        code: NATIVE_TOKEN_CODE,
+      }}
+      size="lg"
+    />
+  );
+
   const transactionDetails: TransactionDetails = {
     operation,
-    transactionTitle: t("history.transactionHistory.createAccount"),
+    transactionTitle: isRecipient
+      ? t("history.transactionHistory.accountFunded")
+      : NATIVE_TOKEN_CODE,
     transactionType: TransactionType.CREATE_ACCOUNT,
     fee,
     status: TransactionStatus.SUCCESS,
-    IconComponent: null,
+    IconComponent,
     ActionIconComponent,
     externalUrl: `${stellarExpertUrl}/op/${operation.id}`,
     createAccountDetails: {
@@ -71,14 +85,16 @@ export const mapCreateAccountHistoryItem = ({
 
   return {
     transactionDetails,
-    rowText: t("history.transactionHistory.createAccount"),
+    rowText: isRecipient
+      ? t("history.transactionHistory.accountFunded")
+      : NATIVE_TOKEN_CODE,
     dateText: date,
     amountText: formattedAmount,
     actionText: isRecipient
       ? t("history.transactionHistory.received")
       : t("history.transactionHistory.sent"),
     ActionIconComponent,
-    IconComponent: null,
+    IconComponent,
     transactionStatus: TransactionStatus.SUCCESS,
     isAddingFunds: isRecipient,
   };

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -189,6 +189,7 @@
     "transactionHistory": {
       "transaction": "Transaction",
       "createAccount": "Create account",
+      "accountFunded": "Account funded",
       "addedTrustline": "Added trustline",
       "removedTrustline": "Removed trustline",
       "received": "Received",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -178,6 +178,7 @@
     "transactionHistory": {
       "transaction": "Transação",
       "createAccount": "Criar conta",
+      "accountFunded": "Conta financiada",
       "addedTrustline": "Trustline adicionada",
       "removedTrustline": "Trustline removida",
       "received": "Recebido",


### PR DESCRIPTION
Rebranding "Create account" at history screen

# What's new:
- Changed "Create account" at history screen to "Account funded"
- Changed "Create account" at history screen when sending to a non created account to "XLM"

## iOS 

<img width="389" alt="image" src="https://github.com/user-attachments/assets/0bde2799-d02f-4c3b-8a8a-fd57332fd17e" />
<img width="354" alt="image" src="https://github.com/user-attachments/assets/6aeb5f4a-1c51-4182-bb26-509a52db5d9b" />

## Android 🤖

<img width="364" alt="image" src="https://github.com/user-attachments/assets/bed66f48-b682-46bc-86c1-4c3bbad09661" />
<img width="365" alt="image" src="https://github.com/user-attachments/assets/f1b56669-6f5e-442d-9fc9-4954d19dfb1d" />

Closes: #164 