### PR TITLE
Several UI tweaks

### DIFF
--- a/__tests__/components/sds/Input.test.tsx
+++ b/__tests__/components/sds/Input.test.tsx
@@ -39,15 +39,15 @@ describe("Input", () => {
       });
     });
 
-    it("defaults to medium size", () => {
+    it("defaults to large size", () => {
       const { getByTestId } = renderWithProviders(
         <Input testID="test-input" value="" />,
       );
       const input = getByTestId("test-input");
 
       expect(input.props.style).toMatchObject({
-        fontSize: fsValue(14), // md size
-        height: pxValue(38), // lineHeight(20) + 3 * paddingVertical(6)
+        fontSize: fsValue(16), // lg size
+        height: pxValue(48), // lineHeight(24) + 3 * paddingVertical(8)
       });
     });
   });

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:theme="@style/BootTheme">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/ios/freighter-mobile/Info.plist
+++ b/ios/freighter-mobile/Info.plist
@@ -42,8 +42,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/src/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.tsx
+++ b/src/components/screens/ChangeNetworkScreen/NetworkSettingsScreen.tsx
@@ -32,7 +32,7 @@ const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
     isTestnet(selectedNetwork) || isFuturenet(selectedNetwork);
 
   return (
-    <BaseLayout insets={{ top: false }}>
+    <BaseLayout useKeyboardAvoidingView insets={{ top: false }}>
       <View className="flex flex-col gap-9 mt-3">
         <View className="flex flex-col gap-[16px] bg-background-secondary rounded-[16px] p-[16px]">
           <View className="flex flex-row items-center gap-2">

--- a/src/components/screens/ChoosePasswordScreen.tsx
+++ b/src/components/screens/ChoosePasswordScreen.tsx
@@ -45,6 +45,7 @@ export const ChoosePasswordScreen: React.FC<ChoosePasswordScreenProps> = ({
       onPressDefaultActionButton={handleContinue}
     >
       <Input
+        autoCapitalize="none"
         isPassword
         placeholder={t("choosePasswordScreen.passwordInputPlaceholder")}
         fieldSize="lg"

--- a/src/components/screens/ConfirmPasswordScreen.tsx
+++ b/src/components/screens/ConfirmPasswordScreen.tsx
@@ -60,6 +60,7 @@ export const ConfirmPasswordScreen: React.FC<ConfirmPasswordScreenProps> = ({
       onPressDefaultActionButton={handleContinue}
     >
       <Input
+        autoCapitalize="none"
         isPassword
         placeholder={t("confirmPasswordScreen.passwordInputPlaceholder")}
         fieldSize="lg"

--- a/src/components/screens/HomeScreen/RenameAccountModal.tsx
+++ b/src/components/screens/HomeScreen/RenameAccountModal.tsx
@@ -69,7 +69,6 @@ const RenameAccountModal: React.FC<RenameAccountModalProps> = ({
           leftElement={
             <Icon.UserCircle size={16} color={themeColors.foreground.primary} />
           }
-          autoCapitalize="none"
           value={accountName}
           onChangeText={setAccountName}
           autoCorrect={false}

--- a/src/components/screens/ImportSecretKeyScreen.tsx
+++ b/src/components/screens/ImportSecretKeyScreen.tsx
@@ -71,7 +71,7 @@ const ImportSecretKeyScreen: React.FC<ImportSecretKeyScreenProps> = ({
     secretKey.length > 0 && password.length > 0 && isAwareChecked;
 
   return (
-    <BaseLayout insets={{ top: false }}>
+    <BaseLayout useKeyboardAvoidingView insets={{ top: false }}>
       <View className="flex-1 pt-5">
         <View>
           <Icon.Download01 themeColor="pink" size={24} withBackground />

--- a/src/components/screens/SendScreen/SendSearchContacts.tsx
+++ b/src/components/screens/SendScreen/SendSearchContacts.tsx
@@ -133,9 +133,11 @@ const SendSearchContacts: React.FC<SendSearchContactsProps> = ({
           />
 
           {searchError && (
-            <Text sm secondary className="mt-2 text-red-500">
-              {searchError}
-            </Text>
+            <View className="mt-4">
+              <Text sm secondary>
+                {searchError}
+              </Text>
+            </View>
           )}
         </View>
 

--- a/src/components/screens/SendScreen/screens/TransactionFeeScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionFeeScreen.tsx
@@ -65,7 +65,7 @@ const TransactionFeeScreen: React.FC<TransactionFeeScreenProps> = ({
         <View>
           <View className="flex-row items-center gap-2">
             <Input
-              fieldSize="md"
+              fieldSize="lg"
               value={localFee}
               onChangeText={setLocalFee}
               keyboardType="numeric"

--- a/src/components/screens/SendScreen/screens/TransactionTimeoutScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTimeoutScreen.tsx
@@ -48,7 +48,7 @@ const TransactionTimeoutScreen: React.FC<TransactionTimeoutScreenProps> = ({
       <View className="flex-1 justify-between">
         <View className="flex-col gap-2">
           <Input
-            fieldSize="md"
+            fieldSize="lg"
             value={localTimeout}
             onChangeText={setLocalTimeout}
             keyboardType="numeric"

--- a/src/components/screens/SettingsScreen/SecurityScreen/ShowRecoveryPhraseScreen/ShowRecoveryPhraseScreen.tsx
+++ b/src/components/screens/SettingsScreen/SecurityScreen/ShowRecoveryPhraseScreen/ShowRecoveryPhraseScreen.tsx
@@ -95,6 +95,7 @@ const ShowRecoveryPhraseScreen: React.FC<ShowRecoveryPhraseScreenProps> = ({
 
         <View className="mb-6">
           <Input
+            fieldSize="lg"
             label={t("showRecoveryPhraseScreen.password")}
             placeholder={t("showRecoveryPhraseScreen.passwordInputPlaceholder")}
             value={password}

--- a/src/components/screens/SettingsScreen/SecurityScreen/ShowRecoveryPhraseScreen/ShowRecoveryPhraseScreen.tsx
+++ b/src/components/screens/SettingsScreen/SecurityScreen/ShowRecoveryPhraseScreen/ShowRecoveryPhraseScreen.tsx
@@ -49,7 +49,7 @@ const ShowRecoveryPhraseScreen: React.FC<ShowRecoveryPhraseScreenProps> = ({
   };
 
   return (
-    <BaseLayout insets={{ top: false }}>
+    <BaseLayout useKeyboardAvoidingView insets={{ top: false }}>
       <View className="flex-1">
         <View className="bg-background-tertiary rounded-xl mt-4 mb-6">
           <View className="p-4">

--- a/src/components/screens/SettingsScreen/SecurityScreen/ShowRecoveryPhraseScreen/ShowRecoveryPhraseScreen.tsx
+++ b/src/components/screens/SettingsScreen/SecurityScreen/ShowRecoveryPhraseScreen/ShowRecoveryPhraseScreen.tsx
@@ -9,7 +9,7 @@ import { useAuthenticationStore } from "ducks/auth";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useState } from "react";
-import { View } from "react-native";
+import { View, ScrollView } from "react-native";
 
 type ShowRecoveryPhraseScreenProps = NativeStackScreenProps<
   SettingsStackParamList,
@@ -49,77 +49,90 @@ const ShowRecoveryPhraseScreen: React.FC<ShowRecoveryPhraseScreenProps> = ({
   };
 
   return (
-    <BaseLayout useKeyboardAvoidingView insets={{ top: false }}>
+    <BaseLayout
+      useKeyboardAvoidingView
+      useSafeArea
+      insets={{ top: false, bottom: false }}
+    >
       <View className="flex-1">
-        <View className="bg-background-tertiary rounded-xl mt-4 mb-6">
-          <View className="p-4">
-            <View className="mb-4">
-              <Text secondary>{t("showRecoveryPhraseScreen.keepSafe")}</Text>
-            </View>
-            <View className="mb-6">
-              <Text secondary>
-                {t("showRecoveryPhraseScreen.accessWarning")}
-              </Text>
-            </View>
-
-            <View className="flex flex-col gap-6">
-              <View className="flex-row items-center gap-3">
-                <Icon.Lock01 size={24} color={themeColors.lime[10]} />
-                <View className="flex-1">
-                  <Text sm color={themeColors.white}>
-                    {t("showRecoveryPhraseScreen.yourRecoveryPhrase")}
-                  </Text>
-                </View>
+        <ScrollView
+          className="flex-1"
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View className="bg-background-tertiary rounded-xl mt-4 mb-6">
+            <View className="p-4">
+              <View className="mb-4">
+                <Text secondary>{t("showRecoveryPhraseScreen.keepSafe")}</Text>
+              </View>
+              <View className="mb-6">
+                <Text secondary>
+                  {t("showRecoveryPhraseScreen.accessWarning")}
+                </Text>
               </View>
 
-              <View className="flex-row items-center gap-3">
-                <Icon.EyeOff size={24} color={themeColors.lime[10]} />
-                <View className="flex-1">
-                  <Text sm color={themeColors.white}>
-                    {t("showRecoveryPhraseScreen.dontShareWithAnyone")}
-                  </Text>
+              <View className="flex flex-col gap-6">
+                <View className="flex-row items-center gap-3">
+                  <Icon.Lock01 size={24} color={themeColors.lime[10]} />
+                  <View className="flex-1">
+                    <Text sm color={themeColors.white}>
+                      {t("showRecoveryPhraseScreen.yourRecoveryPhrase")}
+                    </Text>
+                  </View>
                 </View>
-              </View>
 
-              <View className="flex-row items-center gap-3">
-                <Icon.XSquare size={24} color={themeColors.lime[10]} />
-                <View className="flex-1">
-                  <Text sm color={themeColors.white}>
-                    {t("showRecoveryPhraseScreen.neverAskForYourPhrase")}
-                  </Text>
+                <View className="flex-row items-center gap-3">
+                  <Icon.EyeOff size={24} color={themeColors.lime[10]} />
+                  <View className="flex-1">
+                    <Text sm color={themeColors.white}>
+                      {t("showRecoveryPhraseScreen.dontShareWithAnyone")}
+                    </Text>
+                  </View>
+                </View>
+
+                <View className="flex-row items-center gap-3">
+                  <Icon.XSquare size={24} color={themeColors.lime[10]} />
+                  <View className="flex-1">
+                    <Text sm color={themeColors.white}>
+                      {t("showRecoveryPhraseScreen.neverAskForYourPhrase")}
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
           </View>
-        </View>
 
-        <View className="mb-6">
-          <Input
-            fieldSize="lg"
-            label={t("showRecoveryPhraseScreen.password")}
-            placeholder={t("showRecoveryPhraseScreen.passwordInputPlaceholder")}
-            value={password}
-            onChangeText={(text) => {
-              setPassword(text);
-              setError(undefined);
-            }}
-            secureTextEntry
-            testID="password-input"
-            error={error}
-          />
-        </View>
+          <View className="mb-6">
+            <Input
+              autoCapitalize="none"
+              fieldSize="lg"
+              label={t("showRecoveryPhraseScreen.password")}
+              placeholder={t(
+                "showRecoveryPhraseScreen.passwordInputPlaceholder",
+              )}
+              value={password}
+              onChangeText={(text) => {
+                setPassword(text);
+                setError(undefined);
+              }}
+              secureTextEntry
+              testID="password-input"
+              error={error}
+            />
+          </View>
 
-        <View className="flex-1" />
+          <Button
+            tertiary
+            lg
+            onPress={handleShowRecoveryPhrase}
+            testID="show-recovery-phrase-button"
+            isLoading={isLoading}
+          >
+            {t("showRecoveryPhraseScreen.showPhrase")}
+          </Button>
 
-        <Button
-          tertiary
-          lg
-          onPress={handleShowRecoveryPhrase}
-          testID="show-recovery-phrase-button"
-          isLoading={isLoading}
-        >
-          {t("showRecoveryPhraseScreen.showPhrase")}
-        </Button>
+          <View className="mb-10" />
+        </ScrollView>
       </View>
     </BaseLayout>
   );

--- a/src/components/screens/SettingsScreen/SecurityScreen/YourRecoveryPhraseScreen/YourRecoveryPhraseScreen.tsx
+++ b/src/components/screens/SettingsScreen/SecurityScreen/YourRecoveryPhraseScreen/YourRecoveryPhraseScreen.tsx
@@ -62,7 +62,7 @@ const YourRecoveryPhraseScreen: React.FC<YourRecoveryPhraseScreenProps> = ({
         <Button
           tertiary
           lg
-          onPress={() => navigation.goBack()}
+          onPress={() => navigation.popToTop()}
           testID="done-button"
         >
           {t("common.done")}

--- a/src/components/screens/ValidateRecoveryPhraseScreen.tsx
+++ b/src/components/screens/ValidateRecoveryPhraseScreen.tsx
@@ -82,6 +82,7 @@ export const ValidateRecoveryPhraseScreen: React.FC<
       isLoading={isLoading || isSigningUp}
     >
       <Input
+        autoCapitalize="none"
         isPassword
         placeholder={t("validateRecoveryPhraseScreen.inputPlaceholder")}
         fieldSize="lg"

--- a/src/components/sds/Input/index.tsx
+++ b/src/components/sds/Input/index.tsx
@@ -268,7 +268,7 @@ interface InputProps {
 export const Input = React.forwardRef<TextInput, InputProps>(
   (
     {
-      fieldSize = "md",
+      fieldSize = "lg",
       label,
       labelSuffix,
       isLabelUppercase,

--- a/src/components/templates/InputPasswordTemplate.tsx
+++ b/src/components/templates/InputPasswordTemplate.tsx
@@ -56,7 +56,7 @@ const InputPasswordTemplate: React.FC<InputPasswordTemplateProps> = ({
         <View className="items-center">
           {showLogo && <FreighterLogo width={px(48)} height={px(48)} />}
         </View>
-        <View className="items-center justify-center bg-background-tertiary rounded-2xl p-8 gap-2">
+        <View className="items-center justify-center bg-background-tertiary rounded-2xl p-8 gap-2 mt-4">
           <Avatar size="xl" publicAddress={publicKey ?? ""} />
           <Display xs semiBold>
             {title ?? t("lockScreen.title")}
@@ -92,7 +92,7 @@ const InputPasswordTemplate: React.FC<InputPasswordTemplateProps> = ({
             </Button>
           </View>
         </View>
-        <View>
+        <View className="mt-4">
           {handleLogout && (
             <Button secondary lg onPress={handleLogout}>
               {t("lockScreen.forgotPasswordButtonText")}

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -471,8 +471,8 @@
   "sendRecipient": {
     "error": {
       "invalidAddressFormat": "Invalid Stellar address format",
-      "sendToSelf": "Cannot send to yourself",
-      "sendToSelfFederation": "Cannot send to yourself (resolved federation address)",
+      "sendToSelf": "You can not send to yourself",
+      "sendToSelfFederation": "You can not send to yourself (resolved federation address)",
       "federationNotFound": "Federation address not found or resolution failed",
       "destinationAccountStatus": "Failed to check destination account status",
       "unexpectedSearchError": "An unexpected error occurred during search"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -516,12 +516,5 @@
     "title": "Sua Frase de Recuperação",
     "securityNote": "Essas palavras são as chaves da sua carteira—guarde-as com segurança para manter seus fundos protegidos.",
     "copyButton": "Copiar para a área de transferência"
-  },
-  "tokenDetailsScreen": {
-    "sorobanToken": "Token Soroban",
-    "priceChange": "{{percentage}}%",
-    "balance": "Saldo",
-    "value": "Valor",
-    "listHeader": "Sua atividade de {{tokenName}}"
   }
 }

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -39,7 +39,6 @@ const ToastContainer = styled.View`
   right: 0;
   z-index: 1000;
   align-items: center;
-  pointer-events: none;
 `;
 
 interface ToastWrapperProps {


### PR DESCRIPTION
This PR implements several UI tweaks and bug fixes as listed below.


- Add top spacing on "You can not send to yourself" error message.
<img width="561" alt="Screenshot 2025-06-16 at 15 36 24" src="https://github.com/user-attachments/assets/a7a360e2-08bf-4bc8-9367-dc2029bf6901" />

- Allow `swipe up to dismiss toasts`. Users can now also hold a toast on screen for as long as they want.

https://github.com/user-attachments/assets/74cebb52-3ec3-4127-9a39-96d6fb8f61e0

- `Avoid hiding input field with keyboard` on "Show recovery phrase" screen.
- Go all the way back to initial `Settings` screen when `Done` is tapped on "Show recovery phrase" screen.
*Note: first video shows "before fix", second video shows "after fix" for the above 2 changes.

https://github.com/user-attachments/assets/56adf63a-2e05-4f62-8f6d-4cf6ffdc6d72

https://github.com/user-attachments/assets/b7d7d9ee-d3c1-47cb-8058-0c799e3c37e4

- Always use `input` component of size `lg` since the `md` size gets cut in some Android devices.
    - The app is already displaying `lg` input fields in 90% of cases so sticking to `lg` also increases consistency. We can revisit this in case we have a screen that strictly requires an input of `md` size.
*Note: first video shows "before fix", second video shows "after fix" for the above change.

https://github.com/user-attachments/assets/c2b783e5-824a-4b66-a088-4ccbd3655139

https://github.com/user-attachments/assets/e029d1e0-8486-4bf5-8a6e-ec0b96223810

- Only `capitalize keyboard` where it makes sense.
    - E.g. we shouldn't capitalize on password inputs, but should capitalize on rename account input.
- Lock app in `portrait orientation` mode
