### PR TITLE
v0.5.22

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,8 +83,8 @@ android {
         applicationId "org.stellar.freighterwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
-        versionName "0.4.22"
+        versionCode 10
+        versionName "0.5.22"
     }
     signingConfigs {
         debug {

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
@@ -310,7 +310,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.22;
+				MARKETING_VERSION = 0.5.22;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -333,7 +333,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -341,7 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.22;
+				MARKETING_VERSION = 0.5.22;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
:hammer_and_wrench: Fixes & Improvements

- Allow `swipe up to dismiss toasts`. Users can now also hold a toast on screen for as long as they want.
- `Avoid hiding input field with keyboard` on "Show recovery phrase" screen.
- Go all the way back to initial `Settings` screen when `Done` is tapped on "Show recovery phrase" screen.
- Add top spacing on "You can not send to yourself" error message.
- Consistent size for `input` components across the app.
- Only `capitalize keyboard` where it makes sense.
    - E.g. we shouldn't capitalize on password inputs, but should capitalize on rename account input.
- Lock app in `portrait orientation` mode
- Replace mentions of `buy` with `add` since we are not buying XLM but rather adding them from another wallet