### PR TITLE
v0.6.22

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,8 +83,8 @@ android {
         applicationId "org.stellar.freighterwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
-        versionName "0.5.22"
+        versionCode 12
+        versionName "0.6.22"
     }
     signingConfigs {
         debug {

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
@@ -310,7 +310,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.5.22;
+				MARKETING_VERSION = 0.6.22;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -333,7 +333,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -341,7 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.5.22;
+				MARKETING_VERSION = 0.6.22;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
:sparkles: New Features

- Swap
  - You can now swap between your classic assets
- Welcome Banner
    - Display an educative banner after account creation letting users know they need to fund their account with XLM before being able to use it
- Wallet Connect Deep-linking
   - Allow deep-linking to Freighter mobile app directly from Wallet Connect's wallet list (we'll only have Freighter mobile listed though after it's publicly released)

:hammer_and_wrench: Fixes & Improvements

- Account session management for Wallet Connect's connections
   - dApp connections are now handled separately per account and network
   - Handle "Wallet locked" state through informative toasts and event persistency
   - Ensure all sessions from all accounts are disconnected when users log out
- Rebrand "Create account" transaction as a regular "Send" transaction for the sender
- Rebrand "Create account" transaction as "Account funded" for the receiver
- Default account creation to `Mainnet` instead of `Testnet`
- Respects what the user last selected as `Network` option even after logging out