### PR TITLE
feat: Add Send and Swap buttons to Token Details screen

### DIFF
--- a/src/components/screens/SendScreen/SendSearchContacts.tsx
+++ b/src/components/screens/SendScreen/SendSearchContacts.tsx
@@ -33,13 +33,17 @@ type SendSearchContactsProps = NativeStackScreenProps<
  * @returns {JSX.Element} The rendered component
  */
 const SendSearchContacts: React.FC<SendSearchContactsProps> = ({
+  route,
   navigation,
 }) => {
   const { t } = useAppTranslation();
   const { themeColors } = useColors();
   const { getClipboardText } = useClipboard();
   const [address, setAddress] = useState("");
-  const { saveRecipientAddress, resetSettings } = useTransactionSettingsStore();
+  const { saveRecipientAddress, resetSettings, saveSelectedTokenId } =
+    useTransactionSettingsStore();
+
+  const { tokenId } = route.params || {};
 
   const {
     recentAddresses,
@@ -57,17 +61,32 @@ const SendSearchContacts: React.FC<SendSearchContactsProps> = ({
 
     // Clear any previous search state on component mount
     resetSendRecipient();
-    // Reset transaction settings
-    resetSettings();
-  }, [loadRecentAddresses, resetSendRecipient, resetSettings]);
+
+    if (!tokenId) {
+      resetSettings();
+    }
+
+    if (tokenId) {
+      saveSelectedTokenId(tokenId);
+    }
+  }, [
+    loadRecentAddresses,
+    resetSendRecipient,
+    resetSettings,
+    tokenId,
+    saveSelectedTokenId,
+  ]);
 
   // Reset search input and store state when screen comes into focus
   useFocusEffect(
     React.useCallback(() => {
       setAddress("");
       resetSendRecipient();
-      resetSettings();
-    }, [resetSendRecipient, resetSettings]),
+
+      if (!tokenId) {
+        resetSettings();
+      }
+    }, [resetSendRecipient, resetSettings, tokenId]),
   );
 
   /**
@@ -93,7 +112,11 @@ const SendSearchContacts: React.FC<SendSearchContactsProps> = ({
     // Transaction settings store is for the transaction flow
     saveRecipientAddress(contactAddress);
 
-    navigation.navigate(SEND_PAYMENT_ROUTES.TRANSACTION_TOKEN_SCREEN);
+    if (tokenId) {
+      navigation.navigate(SEND_PAYMENT_ROUTES.TRANSACTION_AMOUNT_SCREEN);
+    } else {
+      navigation.navigate(SEND_PAYMENT_ROUTES.TRANSACTION_TOKEN_SCREEN);
+    }
   };
 
   const handlePasteFromClipboard = () => {

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -8,7 +8,7 @@ import { useAuthenticationStore } from "ducks/auth";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
 import useAppTranslation from "hooks/useAppTranslation";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
-import React from "react";
+import React, { useEffect } from "react";
 import { View } from "react-native";
 
 type TransactionTokenScreenProps = NativeStackScreenProps<
@@ -20,11 +20,17 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
   navigation,
 }) => {
   const { t } = useAppTranslation();
-  const { recipientAddress, saveSelectedTokenId } =
+  const { recipientAddress, saveSelectedTokenId, selectedTokenId } =
     useTransactionSettingsStore();
   const { account } = useGetActiveAccount();
   const { network } = useAuthenticationStore();
   const publicKey = account?.publicKey;
+
+  useEffect(() => {
+    if (selectedTokenId) {
+      navigation.replace(SEND_PAYMENT_ROUTES.TRANSACTION_AMOUNT_SCREEN);
+    }
+  }, [selectedTokenId, navigation]);
 
   const handleTokenPress = (tokenId: string) => {
     saveSelectedTokenId(tokenId);

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -8,7 +8,7 @@ import { useAuthenticationStore } from "ducks/auth";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
 import useAppTranslation from "hooks/useAppTranslation";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
-import React, { useEffect } from "react";
+import React from "react";
 import { View } from "react-native";
 
 type TransactionTokenScreenProps = NativeStackScreenProps<
@@ -20,17 +20,11 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
   navigation,
 }) => {
   const { t } = useAppTranslation();
-  const { recipientAddress, saveSelectedTokenId, selectedTokenId } =
+  const { recipientAddress, saveSelectedTokenId } =
     useTransactionSettingsStore();
   const { account } = useGetActiveAccount();
   const { network } = useAuthenticationStore();
   const publicKey = account?.publicKey;
-
-  useEffect(() => {
-    if (selectedTokenId) {
-      navigation.replace(SEND_PAYMENT_ROUTES.TRANSACTION_AMOUNT_SCREEN);
-    }
-  }, [selectedTokenId, navigation]);
 
   const handleTokenPress = (tokenId: string) => {
     saveSelectedTokenId(tokenId);

--- a/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
+++ b/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
@@ -7,9 +7,13 @@ import { TokenBalanceHeader } from "components/screens/TokenDetailsScreen/compon
 import { Button } from "components/sds/Button";
 import { Text } from "components/sds/Typography";
 import { mapNetworkToNetworkDetails } from "config/constants";
-import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
+import {
+  ROOT_NAVIGATOR_ROUTES,
+  RootStackParamList,
+  SWAP_ROUTES,
+  SEND_PAYMENT_ROUTES,
+} from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
-import { useTransactionSettingsStore } from "ducks/transactionSettings";
 import useAppTranslation from "hooks/useAppTranslation";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
 import { useGetHistoryData } from "hooks/useGetHistoryData";
@@ -33,7 +37,7 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
   const { account } = useGetActiveAccount();
   const { network } = useAuthenticationStore();
   const { t } = useAppTranslation();
-  const { saveSelectedTokenId } = useTransactionSettingsStore();
+  const { width } = Dimensions.get("window");
 
   const { actualTokenDetails, displayTitle } = useTokenDetails({
     tokenId,
@@ -79,20 +83,17 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
 
   const handleSwapPress = () => {
     navigation.navigate(ROOT_NAVIGATOR_ROUTES.SWAP_STACK, {
-      screen: "SwapAmountScreen",
+      screen: SWAP_ROUTES.SWAP_AMOUNT_SCREEN,
       params: { tokenId, tokenSymbol },
     });
   };
 
   const handleSendPress = () => {
-    saveSelectedTokenId(tokenId);
     navigation.navigate(ROOT_NAVIGATOR_ROUTES.SEND_PAYMENT_STACK, {
-      screen: "SendSearchContactsScreen",
-      params: { tokenId, tokenSymbol },
+      screen: SEND_PAYMENT_ROUTES.SEND_SEARCH_CONTACTS_SCREEN,
+      params: { tokenId },
     });
   };
-
-  const { width } = Dimensions.get("window");
 
   return (
     <BaseLayout insets={{ top: false, bottom: false }}>

--- a/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
+++ b/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
@@ -124,7 +124,7 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
         />
       </View>
       <View className="mt-7 pb-3 gap-7">
-        <View className="flex-row gap-3 px-6">
+        <View className="flex-row gap-3">
           <View className="flex-1">
             <Button tertiary lg isFullWidth onPress={handleSwapPress}>
               {t("tokenDetailsScreen.swap")}

--- a/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
+++ b/src/components/screens/TokenDetailsScreen/TokenDetailsScreen.tsx
@@ -4,16 +4,18 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { BaseLayout } from "components/layout/BaseLayout";
 import HistoryList from "components/screens/HistoryScreen/HistoryList";
 import { TokenBalanceHeader } from "components/screens/TokenDetailsScreen/components";
+import { Button } from "components/sds/Button";
 import { Text } from "components/sds/Typography";
 import { mapNetworkToNetworkDetails } from "config/constants";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
+import { useTransactionSettingsStore } from "ducks/transactionSettings";
 import useAppTranslation from "hooks/useAppTranslation";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
 import { useGetHistoryData } from "hooks/useGetHistoryData";
 import useTokenDetails from "hooks/useTokenDetails";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo } from "react";
-import { View } from "react-native";
+import { View, Dimensions } from "react-native";
 
 type TokenDetailsScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -31,6 +33,7 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
   const { account } = useGetActiveAccount();
   const { network } = useAuthenticationStore();
   const { t } = useAppTranslation();
+  const { saveSelectedTokenId } = useTransactionSettingsStore();
 
   const { actualTokenDetails, displayTitle } = useTokenDetails({
     tokenId,
@@ -74,6 +77,23 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
     fetchData({ isRefresh: true });
   }, [fetchData]);
 
+  const handleSwapPress = () => {
+    navigation.navigate(ROOT_NAVIGATOR_ROUTES.SWAP_STACK, {
+      screen: "SwapAmountScreen",
+      params: { tokenId, tokenSymbol },
+    });
+  };
+
+  const handleSendPress = () => {
+    saveSelectedTokenId(tokenId);
+    navigation.navigate(ROOT_NAVIGATOR_ROUTES.SEND_PAYMENT_STACK, {
+      screen: "SendSearchContactsScreen",
+      params: { tokenId, tokenSymbol },
+    });
+  };
+
+  const { width } = Dimensions.get("window");
+
   return (
     <BaseLayout insets={{ top: false, bottom: false }}>
       <View className="flex-1 gap-8 mt-5">
@@ -101,6 +121,24 @@ const TokenDetailsScreen: React.FC<TokenDetailsScreenProps> = ({
               </Text>
             </View>
           }
+        />
+      </View>
+      <View className="mt-7 pb-3 gap-7">
+        <View className="flex-row gap-3 px-6">
+          <View className="flex-1">
+            <Button tertiary lg isFullWidth onPress={handleSwapPress}>
+              {t("tokenDetailsScreen.swap")}
+            </Button>
+          </View>
+          <View className="flex-1">
+            <Button tertiary lg isFullWidth onPress={handleSendPress}>
+              {t("tokenDetailsScreen.send")}
+            </Button>
+          </View>
+        </View>
+        <View
+          className="border-b mb-6 -ml-7 border-border-primary"
+          style={{ width }}
         />
       </View>
     </BaseLayout>

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -166,7 +166,6 @@ export type BuyXLMStackParamList = {
 export type SendPaymentStackParamList = {
   [SEND_PAYMENT_ROUTES.SEND_SEARCH_CONTACTS_SCREEN]: {
     tokenId?: string;
-    tokenSymbol?: string;
   };
   [SEND_PAYMENT_ROUTES.TRANSACTION_TOKEN_SCREEN]: undefined;
   [SEND_PAYMENT_ROUTES.TRANSACTION_AMOUNT_SCREEN]: undefined;

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -89,8 +89,8 @@ export type RootStackParamList = {
     showNavigationAsCloseButton?: boolean;
   };
   [ROOT_NAVIGATOR_ROUTES.BUY_XLM_STACK]: NavigatorScreenParams<BuyXLMStackParamList>;
-  [ROOT_NAVIGATOR_ROUTES.SEND_PAYMENT_STACK]: undefined;
-  [ROOT_NAVIGATOR_ROUTES.SWAP_STACK]: undefined;
+  [ROOT_NAVIGATOR_ROUTES.SEND_PAYMENT_STACK]: NavigatorScreenParams<SendPaymentStackParamList>;
+  [ROOT_NAVIGATOR_ROUTES.SWAP_STACK]: NavigatorScreenParams<SwapStackParamList>;
   [ROOT_NAVIGATOR_ROUTES.TOKEN_DETAILS_SCREEN]: {
     tokenId: string;
     tokenSymbol: string;
@@ -164,7 +164,10 @@ export type BuyXLMStackParamList = {
 };
 
 export type SendPaymentStackParamList = {
-  [SEND_PAYMENT_ROUTES.SEND_SEARCH_CONTACTS_SCREEN]: undefined;
+  [SEND_PAYMENT_ROUTES.SEND_SEARCH_CONTACTS_SCREEN]: {
+    tokenId?: string;
+    tokenSymbol?: string;
+  };
   [SEND_PAYMENT_ROUTES.TRANSACTION_TOKEN_SCREEN]: undefined;
   [SEND_PAYMENT_ROUTES.TRANSACTION_AMOUNT_SCREEN]: undefined;
   [SEND_PAYMENT_ROUTES.TRANSACTION_MEMO_SCREEN]: undefined;

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -229,7 +229,9 @@
     "priceChange": "{{percentage}}%",
     "balance": "Balance",
     "value": "Value",
-    "listHeader": "Your {{tokenName}} activity"
+    "listHeader": "Your {{tokenName}} activity",
+    "swap": "Swap",
+    "send": "Send"
   },
   "recoveryPhraseWarning": {
     "yourRecoveryPhrase": "Your recovery phrase gives you full access to your wallets and funds.",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -218,7 +218,9 @@
     "priceChange": "{{percentage}}%",
     "balance": "Saldo",
     "value": "Valor",
-    "listHeader": "Sua atividade de {{tokenName}}"
+    "listHeader": "Sua atividade de {{tokenName}}",
+    "swap": "Trocar",
+    "send": "Enviar"
   },
   "recoveryPhraseWarning": {
     "yourRecoveryPhrase": "Sua frase de recuperação dá acesso total às suas carteiras e fundos.",


### PR DESCRIPTION
Add Send and Swap buttons to Token Details screen

# What's new:

- Added Send and Swap buttons to TokenDetailsScreen
- Token is automatically pre-selected when navigating from token details to send flow
- Added visual separator line below buttons
- Included translations for both English and Portuguese

## iOS 

https://github.com/user-attachments/assets/ff91290d-840c-47f6-a6ab-42783c7302bb

## Android 🤖

https://github.com/user-attachments/assets/87fa0a14-5469-4361-a45a-bd4092d4cf05

Closes: #174 
