### PR TITLE
v0.7.23

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,8 +83,8 @@ android {
         applicationId "org.stellar.freighterwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 12
-        versionName "0.6.22"
+        versionCode 13
+        versionName "0.7.23"
     }
     signingConfigs {
         debug {

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
@@ -310,7 +310,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.22;
+				MARKETING_VERSION = 0.7.23;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -333,7 +333,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -341,7 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.22;
+				MARKETING_VERSION = 0.7.23;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
:sparkles: **New Features**

- **Discover**
  - The app now has an `in-app browser` on the third tab where you can connect and sign transactions from Stellar `dApps` without leaving the mobile app
- **Analytics**
  - The mobile app is now sending events to `Amplitude`, it should be mimicking all extension events
  - It is also sending some extra props in all events like:
    - `network`: TESTNET | PUBLIC
    - `platform`: Android | iOS
    - `platformVersion`: Android or iOS OS version
    - `connectionType`: Internet connectivity (wifi, cellular, etc.)
    - `appVersion`: e.g.: 0.7.23
    - `buildVersion`: e.g.: 13
    - `bundleId`: org.stellar.freighterwallet
- **Protocol 23 support**
  - The `stellar-sdk` package has been upgraded to `v14.0.0-rc.3 `
- **Skip recovery phrase modal**
  - Users are now alerted of the risks about not properly saving your recovery phrase and skipping its verification
- **Send and Swap buttons on Token Details screen**
  - Users can now send and swap directly from token details screen
- **New route for Wallet Connect**
  - You can now access your connected apps on Home screen's right header button
- **New app logo**
  - App logo has been updated to its beautiful purple version 



:hammer_and_wrench: **Fixes & Improvements**

- Fix responsiveness of top bar buttons
- Fix Send to Contracts on Mainnet
- Fix numeric keyboard for small screens
- Fix Classic tokens icon and name for Soroban transactions on History screen
- Pricing delta is now represented using `+/-` signs instead of arrows
- Upgrade `stellar-hd-wallet` to latest `v1.0.2`
- Upgrade `react-native-crypto` to latest `v2.2.1`
- Several other minor UI polishes and bug fixes