### PR TITLE
Remove unused iOS location flag

### DIFF
--- a/ios/freighter-mobile/Info.plist
+++ b/ios/freighter-mobile/Info.plist
@@ -44,8 +44,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Freighter needs access to your Camera to scan QR codes.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Inter-Bold.ttf</string>


### PR DESCRIPTION
This flag has been added on the initial commit which created the default RN project. This is needed for geo-location services which we are not using and App Store Connect is complaining about it because we haven't added a description to it (`<string></string>`).

So let's remove it for now, we can add it back later in case we start using geo-location services.