### PR TITLE
Add new method and event to WC namespaces

### DIFF
--- a/__tests__/components/screens/SettingsScreen/PreferencesScreen.test.tsx
+++ b/__tests__/components/screens/SettingsScreen/PreferencesScreen.test.tsx
@@ -74,7 +74,7 @@ describe("PreferencesScreen", () => {
 
       expect(analytics.setAnalyticsEnabled).toHaveBeenCalledTimes(1);
       expect(analytics.setAnalyticsEnabled).toHaveBeenCalledWith(true);
-    });
+    }, 15000);
 
     it("disables analytics when toggle is pressed while enabled", async () => {
       mockUseAnalyticsStore.mockReturnValue({

--- a/src/ducks/walletKit.ts
+++ b/src/ducks/walletKit.ts
@@ -52,6 +52,9 @@ export enum StellarRpcChains {
 export enum StellarRpcMethods {
   SIGN_XDR = "stellar_signXDR",
   SIGN_AND_SUBMIT_XDR = "stellar_signAndSubmitXDR",
+
+  // This is actually a Ethereum RPC method, but it's being used by Allbridge
+  // so let's just recognize it as a valid method so we don't reject their connection
   PERSONAL_SIGN = "personal_sign",
 }
 

--- a/src/ducks/walletKit.ts
+++ b/src/ducks/walletKit.ts
@@ -39,19 +39,27 @@ export enum WalletKitEventTypes {
 }
 
 /**
- * Enum representing supported Stellar RPC methods
- */
-export enum StellarRpcMethods {
-  SIGN_XDR = "stellar_signXDR",
-  SIGN_AND_SUBMIT_XDR = "stellar_signAndSubmitXDR",
-}
-
-/**
  * Enum representing supported Stellar chains
  */
 export enum StellarRpcChains {
   PUBLIC = "stellar:pubnet",
   TESTNET = "stellar:testnet",
+}
+
+/**
+ * Enum representing supported Stellar RPC methods
+ */
+export enum StellarRpcMethods {
+  SIGN_XDR = "stellar_signXDR",
+  SIGN_AND_SUBMIT_XDR = "stellar_signAndSubmitXDR",
+  PERSONAL_SIGN = "personal_sign",
+}
+
+/**
+ * Enum representing supported Stellar events
+ */
+export enum StellarRpcEvents {
+  ACCOUNTS_CHANGED = "accountsChanged",
 }
 
 /**

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -16,6 +16,7 @@ import { logger } from "config/logger";
 import {
   ActiveSessions,
   StellarRpcChains,
+  StellarRpcEvents,
   StellarRpcMethods,
   WALLET_KIT_METADATA,
   WALLET_KIT_PROJECT_ID,
@@ -33,7 +34,11 @@ import { analytics } from "services/analytics";
 const stellarNamespaceMethods = [
   StellarRpcMethods.SIGN_XDR,
   StellarRpcMethods.SIGN_AND_SUBMIT_XDR,
+  StellarRpcMethods.PERSONAL_SIGN,
 ];
+
+/** Supported Stellar RPC events for WalletKit */
+const stellarNamespaceEvents = [StellarRpcEvents.ACCOUNTS_CHANGED];
 
 /** Global WalletKit instance */
 // eslint-disable-next-line import/no-mutable-exports
@@ -143,10 +148,10 @@ export const approveSessionProposal = async ({
       proposal: params,
       supportedNamespaces: {
         stellar: {
-          methods: stellarNamespaceMethods,
-          chains: [activeChain],
-          events: [],
           accounts: [activeAccount],
+          chains: [activeChain],
+          methods: stellarNamespaceMethods,
+          events: stellarNamespaceEvents,
         },
       },
     });

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -34,6 +34,9 @@ import { analytics } from "services/analytics";
 const stellarNamespaceMethods = [
   StellarRpcMethods.SIGN_XDR,
   StellarRpcMethods.SIGN_AND_SUBMIT_XDR,
+
+  // This is actually a Ethereum RPC method, but it's being used by Allbridge
+  // so let's just recognize it as a valid method so we don't reject their connection
   StellarRpcMethods.PERSONAL_SIGN,
 ];
 


### PR DESCRIPTION
Related: #153 

Although we don't give support for `accountsChanged` event yet let's add it to the list of supported events so we don't reject connections with dApps that are listing it.

This PR is also adding a new RPC method called `personal_sign` which is actually a [Ethereum RPC method](https://docs.reown.com/advanced/multichain/rpc-reference/ethereum-rpc#personal-sign) that is being listed by Allbridge under the `stellar` namespace. It's possible they are using it with some custom implementation with other wallets so let's just recognize it so we don't reject their connection proposals which contains a valid `stellar_signXDR` RPC method.