### PR TITLE
Better support for liquidity pool on History items

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -2,21 +2,11 @@ import { logos } from "assets/logos";
 import SorobanAssetIcon from "assets/logos/icon-soroban.svg";
 import { Asset, AssetSize } from "components/sds/Asset";
 import { Text } from "components/sds/Typography";
-import {
-  AssetToken,
-  AssetTypeWithCustomToken,
-  Balance,
-  NativeToken,
-} from "config/types";
+import { AssetTypeWithCustomToken, Balance, Token } from "config/types";
 import { useAssetIconsStore } from "ducks/assetIcons";
 import { getTokenIdentifier, isLiquidityPool } from "helpers/balances";
 import React from "react";
 import { useTranslation } from "react-i18next";
-
-/**
- * Union type representing a native XLM token, a non-native Stellar asset, or a Soroban token
- */
-type Token = AssetToken | NativeToken;
 
 /**
  * Props for the AssetIcon component
@@ -67,7 +57,7 @@ export const AssetIcon: React.FC<AssetIconProps> = ({
   const { t } = useTranslation();
 
   // Liquidity pool: show "LP" text
-  if (isLiquidityPool(tokenProp as Balance)) {
+  if (isLiquidityPool(tokenProp)) {
     return (
       <Asset
         variant="single"
@@ -159,7 +149,7 @@ export const AssetIcon: React.FC<AssetIconProps> = ({
   const icon = icons[tokenIdentifier];
   const imageUrl = icon?.imageUrl || "";
 
-  const tokenInitials = token.code.slice(0, 2);
+  const tokenInitials = token.code?.slice(0, 2) || "";
   const renderContent = !imageUrl
     ? () => (
         <Text sm bold secondary>

--- a/src/components/screens/HistoryScreen/mappers/changeTrust.tsx
+++ b/src/components/screens/HistoryScreen/mappers/changeTrust.tsx
@@ -12,6 +12,7 @@ import {
 import Icon from "components/sds/Icon";
 import { ThemeColors } from "hooks/useColors";
 import { t } from "i18next";
+import { capitalize } from "lodash";
 import React from "react";
 
 interface ChangeTrustHistoryItemData {
@@ -77,7 +78,7 @@ export const mapChangeTrustHistoryItem = ({
 
   return {
     transactionDetails,
-    rowText: destAssetCode,
+    rowText: destAssetCode || capitalize(assetType).replaceAll("_", " "),
     actionText,
     dateText: date,
     IconComponent,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -99,6 +99,11 @@ export type AssetToken = {
 };
 
 /**
+ * Union type representing a native XLM token, a non-native Stellar asset, or a Soroban token
+ */
+export type Token = AssetToken | NativeToken;
+
+/**
  * Base balance type with total amount
  * @property {BigNumber} total - The total balance amount
  */

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -18,12 +18,8 @@ import {
   mapNetworkToNetworkDetails,
 } from "config/constants";
 import { logger } from "config/logger";
-import {
-  Balance,
-  NativeBalance,
-  LiquidityPoolBalance,
-  PricedBalance,
-} from "config/types";
+import { Balance, NativeBalance, PricedBalance } from "config/types";
+import { isLiquidityPool } from "helpers/balances";
 import { xlmToStroop } from "helpers/formatAmount";
 import { isContractId, getNativeContractDetails } from "helpers/soroban";
 import { isValidStellarAddress, isSameAccount } from "helpers/stellar";
@@ -55,12 +51,6 @@ export interface BuildSwapTransactionParams {
   network?: NETWORKS;
   senderAddress?: string;
 }
-
-// Type guards for Balance types
-export const isLiquidityPool = (
-  balance: Balance,
-): balance is LiquidityPoolBalance =>
-  "liquidityPoolId" in balance && "reserves" in balance;
 
 export const isNativeBalance = (balance: Balance): balance is NativeBalance =>
   "token" in balance &&


### PR DESCRIPTION
This fixes a crash for users that have recently established a trustline with a Liquidity Pool, like this transaction: https://stellar.expert/explorer/public/tx/240721861695803392#240721861695803393

<img width="559" height="1062" alt="Screenshot 2025-07-30 at 11 00 52" src="https://github.com/user-attachments/assets/f2d22db0-5b80-4e8c-a52d-6f60f77faeff" />
