### PR TITLE
Added public address to event tracking

### DIFF
--- a/src/services/analytics/core.ts
+++ b/src/services/analytics/core.ts
@@ -129,8 +129,10 @@ export const setAnalyticsUserId = (userId: string | null): void => {
 const buildCommonContext = (): Record<string, unknown> => {
   const { network } = useAuthenticationStore.getState();
   const { connectionType, effectiveType } = useNetworkStore.getState();
+  const { account } = useAuthenticationStore.getState();
 
   const context: Record<string, unknown> = {
+    publicKey: account?.publicKey ?? "N/A",
     platform: Platform.OS,
     platformVersion: Platform.Version,
     network: network.toUpperCase(), // Stellar network (TESTNET, PUBLIC, FUTURENET)


### PR DESCRIPTION
Added public address of the currently active account to the common context for analytics events
<img width="1340" height="617" alt="Screenshot 2025-07-30 at 16 48 26" src="https://github.com/user-attachments/assets/7c3c190d-8e8d-4df6-8660-586439af163d" />
