### PR TITLE
Prevent immediate row highlight when scrolling lists

### DIFF
--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -1,5 +1,6 @@
 import { AssetIcon } from "components/AssetIcon";
 import { Text } from "components/sds/Typography";
+import { DEFAULT_PRESS_DELAY } from "config/constants";
 import { THEME } from "config/theme";
 import { PricedBalance } from "config/types";
 import { isLiquidityPool } from "helpers/balances";
@@ -91,7 +92,11 @@ export const DefaultRightContent: React.FC<{ balance: PricedBalance }> = ({
 
 const renderContent = (children: ReactNode, onPress?: () => void) => {
   if (onPress) {
-    return <TouchableOpacity onPress={onPress}>{children}</TouchableOpacity>;
+    return (
+      <TouchableOpacity onPress={onPress} delayPressIn={DEFAULT_PRESS_DELAY}>
+        {children}
+      </TouchableOpacity>
+    );
   }
 
   return children;

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,4 +1,5 @@
 import { Text } from "components/sds/Typography";
+import { DEFAULT_PRESS_DELAY } from "config/constants";
 import { THEME } from "config/theme";
 import React from "react";
 import { View, TouchableOpacity } from "react-native";
@@ -38,6 +39,7 @@ export const List: React.FC<ListProps> = ({
         <TouchableOpacity
           disabled={!item.onPress}
           onPress={item.onPress}
+          delayPressIn={DEFAULT_PRESS_DELAY}
           testID={item.testID}
           className={`flex-row gap-3 ${compact ? "py-2" : "p-4"} ${
             item.description ? "items-start" : "items-center"

--- a/src/components/screens/DiscoveryScreen/components/DiscoveryHomepage.tsx
+++ b/src/components/screens/DiscoveryScreen/components/DiscoveryHomepage.tsx
@@ -1,7 +1,11 @@
 import { App } from "components/sds/App";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
-import { DEFAULT_PADDING, BROWSER_CONSTANTS } from "config/constants";
+import {
+  DEFAULT_PADDING,
+  BROWSER_CONSTANTS,
+  DEFAULT_PRESS_DELAY,
+} from "config/constants";
 import { DiscoverProtocol } from "config/types";
 import { useBrowserTabsStore, BrowserTab } from "ducks/browserTabs";
 import { useProtocolsStore } from "ducks/protocols";
@@ -84,6 +88,7 @@ const HorizontalListSection: React.FC<HorizontalListSectionProps> = React.memo(
           <TouchableOpacity
             className="mr-3 items-center"
             onPress={() => onItemPress(siteUrl)}
+            delayPressIn={DEFAULT_PRESS_DELAY}
           >
             <View
               className="w-[76px] h-[76px] rounded-xl justify-center items-center mb-2"

--- a/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
+++ b/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
@@ -2,7 +2,11 @@ import { CustomHeaderButton } from "components/layout/CustomHeaderButton";
 import { TabPreview } from "components/screens/DiscoveryScreen/components";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
-import { BROWSER_CONSTANTS, DEFAULT_PADDING } from "config/constants";
+import {
+  BROWSER_CONSTANTS,
+  DEFAULT_PADDING,
+  DEFAULT_PRESS_DELAY,
+} from "config/constants";
 import { useBrowserTabsStore } from "ducks/browserTabs";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -80,6 +84,7 @@ const TabOverview: React.FC<TabOverviewProps> = React.memo(
             <TouchableOpacity
               key={tab.id}
               onPress={() => onSwitchTab(tab.id)}
+              delayPressIn={DEFAULT_PRESS_DELAY}
               className={BROWSER_CONSTANTS.TAB_PREVIEW_TILE_SIZE}
             >
               <TabPreview

--- a/src/components/screens/HistoryScreen/HistoryItem.tsx
+++ b/src/components/screens/HistoryScreen/HistoryItem.tsx
@@ -10,6 +10,7 @@ import {
 } from "components/screens/HistoryScreen/helpers";
 import { mapHistoryItemData } from "components/screens/HistoryScreen/mappers";
 import { Text } from "components/sds/Typography";
+import { DEFAULT_PRESS_DELAY } from "config/constants";
 import useColors from "hooks/useColors";
 import React, { useEffect, useState } from "react";
 import { View, TouchableOpacity } from "react-native";
@@ -78,6 +79,7 @@ const HistoryItem: React.FC<HistoryItemProps> = ({
       onPress={() => {
         handleTransactionDetails(historyItem.transactionDetails);
       }}
+      delayPressIn={DEFAULT_PRESS_DELAY}
       className="mb-4 flex-row justify-between items-center flex-0"
     >
       <View className="flex-row items-center flex-1">

--- a/src/components/screens/HomeScreen/AccountItemRow.tsx
+++ b/src/components/screens/HomeScreen/AccountItemRow.tsx
@@ -4,6 +4,7 @@ import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { AnalyticsEvent } from "config/analyticsConfig";
+import { DEFAULT_PRESS_DELAY } from "config/constants";
 import { Account } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
 import { truncateAddress } from "helpers/stellar";
@@ -78,6 +79,7 @@ const AccountItemRow: React.FC<AccountItemRowProps> = ({
       <TouchableOpacity
         className="flex-row justify-between items-center flex-1"
         onPress={() => handleSelectAccount(account.publicKey)}
+        delayPressIn={DEFAULT_PRESS_DELAY}
       >
         <View className="flex-row items-center flex-1">
           <Avatar

--- a/src/components/screens/SendScreen/components/ContactRow.tsx
+++ b/src/components/screens/SendScreen/components/ContactRow.tsx
@@ -1,6 +1,7 @@
 import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
+import { DEFAULT_PRESS_DELAY } from "config/constants";
 import { truncateAddress } from "helpers/stellar";
 import useColors from "hooks/useColors";
 import React from "react";
@@ -38,6 +39,7 @@ export const ContactRow: React.FC<ContactRowProps> = ({
     <TouchableOpacity
       className={`flex-row w-full h-[44px] justify-between items-center ${className || ""}`}
       onPress={onPress}
+      delayPressIn={DEFAULT_PRESS_DELAY}
       testID={testID}
     >
       <View className="flex-row items-center flex-1 mr-4">

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,6 +10,9 @@ export const DEFAULT_RECOMMENDED_STELLAR_FEE = "100";
 
 export const TOGGLE_ANIMATION_DURATION = 400;
 
+// This is used to prevent rows from highlighting when the user is scrolling
+export const DEFAULT_PRESS_DELAY = 80;
+
 // Transaction fee constants
 export const NATIVE_TOKEN_CODE = "XLM";
 export const MIN_TRANSACTION_FEE = "0.00001";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,7 +11,7 @@ export const DEFAULT_RECOMMENDED_STELLAR_FEE = "100";
 export const TOGGLE_ANIMATION_DURATION = 400;
 
 // This is used to prevent rows from highlighting when the user is scrolling
-export const DEFAULT_PRESS_DELAY = 80;
+export const DEFAULT_PRESS_DELAY = 100;
 
 // Transaction fee constants
 export const NATIVE_TOKEN_CODE = "XLM";

--- a/src/services/analytics/core.ts
+++ b/src/services/analytics/core.ts
@@ -127,7 +127,6 @@ export const setAnalyticsUserId = (userId: string | null): void => {
  * - effectiveType: Cellular quality (slow-2g, 2g, 3g, 4g) when on cellular
  */
 const buildCommonContext = (): Record<string, unknown> => {
-  const { network } = useAuthenticationStore.getState();
   const { connectionType, effectiveType } = useNetworkStore.getState();
   const { network, account } = useAuthenticationStore.getState();
 


### PR DESCRIPTION
This PR tweaks the scrolling experience by removing the immediate row highlight when scrolling through lists, it does that by adding a minimum `delayPressIn` of `100 ms`. This delay helps to differentiate between a tap and a scroll gesture.

### Before

https://github.com/user-attachments/assets/f13a1b0d-b83e-45cc-9cef-b23988137845

### After

https://github.com/user-attachments/assets/64fd15fc-253a-456f-9a53-4d91ed825128
