### PR TITLE
v0.8.23

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,8 +83,8 @@ android {
         applicationId "org.stellar.freighterwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 14
-        versionName "0.7.23"
+        versionCode 15
+        versionName "0.8.23"
     }
     signingConfigs {
         debug {

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
@@ -328,7 +328,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.7.23;
+				MARKETING_VERSION = 0.8.23;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -351,7 +351,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -359,7 +359,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.7.23;
+				MARKETING_VERSION = 0.8.23;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
:sparkles: **New Features**

- **New UX for Wallet Connect**
  - `Deep-link` is now available! You should be able to search for "Freighter" on WalletConnect's list of wallets
  - You can now `disconnect from a single dApp` on the `Connected Apps` screen
  - You can now quickly scan QR codes from Home navigation bar
- **Blockaid scanning**
  - Increased `security` when `Adding new Tokens` or `connecting to dApp domains` through Blockaid scanning
  - *We will cover other areas like dApp transaction signing, Token search results, Send, Swap and Balances in following releases

:hammer_and_wrench: **Fixes & Improvements**

- Fix `No Internet Connection` red banner appearing on every app launch
- New app logo on all screens including the splash screen
- Clear webview cache to ensure users are always seeing latest dApp versions
- Add iOS permission request for analytics tracking
- Add Discover disclaimer
- Improve handling of spendable XLM funds on Swap
- Improve  responsiveness of Swap layout
- Better support for liquidity pool on history
- Prevent immediate row highlight when scrolling lists
- Several other minor UI polishes and bug fixes