### PR TITLE
[Collectibles] Home UI

### DIFF
--- a/__tests__/components/sds/Avatar.test.tsx
+++ b/__tests__/components/sds/Avatar.test.tsx
@@ -131,8 +131,9 @@ describe("Avatar", () => {
       expect(avatar.props.className).toContain("border-border-primary");
 
       const initials = getByText("JD");
-      expect(initials.props.className).toContain("font-bold");
-      expect(initials.props.className).toContain("text-text-secondary");
+      expect(initials.props.style).toEqual(
+        expect.objectContaining({ fontWeight: "700", color: "#a0a0a0" }),
+      );
     });
 
     it("renders default icon when no publicAddress or userName provided", () => {

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -1,5 +1,6 @@
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { BalanceRow } from "components/BalanceRow";
+import { DefaultListFooter } from "components/DefaultListFooter";
 import { FriendbotButton } from "components/FriendbotButton";
 import { Button } from "components/sds/Button";
 import { Notification } from "components/sds/Notification";
@@ -16,7 +17,7 @@ import { px } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useBalancesList } from "hooks/useBalancesList";
 import React, { ReactNode } from "react";
-import { FlatList, Linking, RefreshControl, View } from "react-native";
+import { FlatList, Linking, RefreshControl } from "react-native";
 import styled from "styled-components/native";
 
 const ListWrapper = styled.View`
@@ -169,7 +170,7 @@ export const BalancesList: React.FC<BalancesListProps> = ({
       <FlatList
         testID="balances-list"
         showsVerticalScrollIndicator={false}
-        ListFooterComponent={<View className="h-10" />}
+        ListFooterComponent={DefaultListFooter}
         data={balanceItems}
         renderItem={({ item }) => (
           <BalanceRow

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -23,13 +23,6 @@ const ListWrapper = styled.View`
   flex: 1;
 `;
 
-const ListTitle = styled.View`
-  margin-bottom: ${px(24)};
-  flex-direction: row;
-  align-items: center;
-  gap: ${px(6)};
-`;
-
 const Spinner = styled.ActivityIndicator`
   margin-top: ${px(24)};
   width: 100%;
@@ -49,7 +42,6 @@ interface BalancesListProps {
   publicKey: string;
   network: NETWORKS;
   searchTerm?: string;
-  customTitle?: string;
   onTokenPress?: (tokenId: string) => void;
   disableNavigation?: boolean;
   renderRightContent?: (balance: PricedBalance) => ReactNode;
@@ -73,7 +65,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   publicKey,
   network,
   searchTerm,
-  customTitle,
   onTokenPress,
   disableNavigation = false,
   renderRightContent,
@@ -107,9 +98,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   if (error) {
     return (
       <ListWrapper>
-        <ListTitle>
-          <Text medium>{customTitle ?? t("balancesList.title")}</Text>
-        </ListTitle>
         <Text md>{t("balancesList.error")}</Text>
       </ListWrapper>
     );
@@ -119,10 +107,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   if (noBalances && isLoading) {
     return (
       <ListWrapper>
-        <ListTitle>
-          <Text medium>{customTitle ?? t("balancesList.title")}</Text>
-        </ListTitle>
-
         <Spinner
           testID="balances-list-spinner"
           size="large"
@@ -136,10 +120,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   if (noBalances && !isFunded) {
     return (
       <ListWrapper>
-        <ListTitle>
-          <Text medium>{customTitle ?? t("balancesList.title")}</Text>
-        </ListTitle>
-
         <NotificationWrapper>
           <Notification
             variant="primary"
@@ -186,9 +166,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
 
   return (
     <ListWrapper>
-      <ListTitle>
-        <Text medium>{customTitle ?? t("balancesList.title")}</Text>
-      </ListTitle>
       <FlatList
         testID="balances-list"
         showsVerticalScrollIndicator={false}

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -24,6 +24,12 @@ const ListWrapper = styled.View`
   flex: 1;
 `;
 
+const SpinnerWrapper = styled(ListWrapper)`
+  align-items: center;
+  justify-content: center;
+  margin-bottom: ${px(55)};
+`;
+
 const Spinner = styled.ActivityIndicator`
   margin-top: ${px(24)};
   width: 100%;
@@ -107,13 +113,13 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   // If no balances and still loading, show the spinner
   if (noBalances && isLoading) {
     return (
-      <ListWrapper>
+      <SpinnerWrapper>
         <Spinner
           testID="balances-list-spinner"
           size="large"
           color={THEME.colors.secondary}
         />
-      </ListWrapper>
+      </SpinnerWrapper>
     );
   }
 

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -2,7 +2,6 @@ import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { BalanceRow } from "components/BalanceRow";
 import { FriendbotButton } from "components/FriendbotButton";
 import { Button } from "components/sds/Button";
-import Icon from "components/sds/Icon";
 import { Notification } from "components/sds/Notification";
 import { Text } from "components/sds/Typography";
 import { CREATE_ACCOUNT_TUTORIAL_URL, NETWORKS } from "config/constants";
@@ -51,7 +50,6 @@ interface BalancesListProps {
   network: NETWORKS;
   searchTerm?: string;
   customTitle?: string;
-  showTitleIcon?: boolean;
   onTokenPress?: (tokenId: string) => void;
   disableNavigation?: boolean;
   renderRightContent?: (balance: PricedBalance) => ReactNode;
@@ -76,7 +74,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   network,
   searchTerm,
   customTitle,
-  showTitleIcon = false,
   onTokenPress,
   disableNavigation = false,
   renderRightContent,
@@ -111,9 +108,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
     return (
       <ListWrapper>
         <ListTitle>
-          {showTitleIcon && (
-            <Icon.Coins03 size={16} color={THEME.colors.text.primary} />
-          )}
           <Text medium>{customTitle ?? t("balancesList.title")}</Text>
         </ListTitle>
         <Text md>{t("balancesList.error")}</Text>
@@ -126,9 +120,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
     return (
       <ListWrapper>
         <ListTitle>
-          {showTitleIcon && (
-            <Icon.Coins03 size={16} color={THEME.colors.text.primary} />
-          )}
           <Text medium>{customTitle ?? t("balancesList.title")}</Text>
         </ListTitle>
 
@@ -146,9 +137,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
     return (
       <ListWrapper>
         <ListTitle>
-          {showTitleIcon && (
-            <Icon.Coins03 size={16} color={THEME.colors.text.primary} />
-          )}
           <Text medium>{customTitle ?? t("balancesList.title")}</Text>
         </ListTitle>
 
@@ -199,9 +187,6 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   return (
     <ListWrapper>
       <ListTitle>
-        {showTitleIcon && (
-          <Icon.Coins03 size={16} color={THEME.colors.text.primary} />
-        )}
         <Text medium>{customTitle ?? t("balancesList.title")}</Text>
       </ListTitle>
       <FlatList

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -115,7 +115,7 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
           <FlatList
             data={collections}
             renderItem={renderCollection}
-            keyExtractor={(collection) => collection.collectionName}
+            keyExtractor={(collection) => collection.collectionAddress}
             showsVerticalScrollIndicator={false}
             ListFooterComponent={DefaultListFooter}
             refreshControl={

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -152,8 +152,9 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
       }
 
       return (
-        <View className="flex-1 pt-4">
-          <Text md secondary>
+        <View className="flex-row items-center justify-center pt-5 gap-2">
+          <Icon.Grid01 size={20} color={themeColors.text.secondary} />
+          <Text md medium secondary>
             {t("collectiblesGrid.empty")}
           </Text>
         </View>
@@ -163,6 +164,7 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
       isLoading,
       error,
       t,
+      themeColors.text.secondary,
       themeColors.secondary,
       renderCollection,
       handleRefresh,

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -64,18 +64,26 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
     const renderCollectibleItem = useCallback(
       ({ item }: { item: Collectible }) => (
         <TouchableOpacity
-          className="w-[165px] h-[165px] rounded-2xl overflow-hidden mr-6"
+          className="w-[165px] h-[165px] rounded-2xl overflow-hidden items-center justify-center mr-6 bg-background-tertiary"
           delayPressIn={DEFAULT_PRESS_DELAY}
           onPress={() => onCollectiblePress?.(item.tokenId)}
         >
-          <Image
-            source={{ uri: item.image }}
-            className="w-full h-full"
-            resizeMode="cover"
-          />
+          {/* Placeholder icon for when the image is not loaded */}
+          <View className="absolute z-1">
+            <Icon.Image01 size={45} color={themeColors.text.secondary} />
+          </View>
+
+          {/* NFT image */}
+          <View className="absolute z-10 w-full h-full">
+            <Image
+              source={{ uri: item.image }}
+              className="w-full h-full"
+              resizeMode="cover"
+            />
+          </View>
         </TouchableOpacity>
       ),
-      [onCollectiblePress],
+      [onCollectiblePress, themeColors.text.secondary],
     );
 
     const renderCollection = useCallback(

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -2,8 +2,9 @@ import { DefaultListFooter } from "components/DefaultListFooter";
 import Spinner from "components/Spinner";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
-import { DEFAULT_PRESS_DELAY } from "config/constants";
+import { DEFAULT_PADDING, DEFAULT_PRESS_DELAY } from "config/constants";
 import { Collectible, Collection } from "ducks/collectibles";
+import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useCollectibles } from "hooks/useCollectibles";
 import useColors from "hooks/useColors";
@@ -81,7 +82,10 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
       // eslint-disable-next-line react/no-unused-prop-types
       ({ item }: { item: Collection }) => (
         <View className="mb-6">
-          <View className="flex-row items-center gap-2 mb-3">
+          <View
+            className="flex-row items-center gap-2 mb-3"
+            style={{ paddingHorizontal: pxValue(DEFAULT_PADDING) }}
+          >
             <Icon.Grid01 size={20} color={themeColors.text.secondary} />
             <Text medium secondary style={{ flex: 1 }}>
               {item.collectionName}
@@ -96,6 +100,9 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
             keyExtractor={(collectible) => collectible.tokenId}
             horizontal
             showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{
+              paddingHorizontal: pxValue(DEFAULT_PADDING),
+            }}
           />
         </View>
       ),

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -131,7 +131,7 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
 
       if (isLoading) {
         return (
-          <View className="flex-1 pt-4">
+          <View className="flex-1 items-center justify-center mb-10">
             <Spinner
               testID="collectibles-grid-spinner"
               size="large"

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -1,0 +1,157 @@
+import { DefaultListFooter } from "components/DefaultListFooter";
+import Spinner from "components/Spinner";
+import Icon from "components/sds/Icon";
+import { Text } from "components/sds/Typography";
+import { DEFAULT_PRESS_DELAY } from "config/constants";
+import { Collectible, Collection } from "ducks/collectibles";
+import useAppTranslation from "hooks/useAppTranslation";
+import { useCollectibles } from "hooks/useCollectibles";
+import useColors from "hooks/useColors";
+import React, { useCallback, useMemo, useEffect } from "react";
+import {
+  TouchableOpacity,
+  View,
+  FlatList,
+  Image,
+  RefreshControl,
+} from "react-native";
+
+interface CollectiblesGridProps {
+  onCollectiblePress?: (collectibleId: string) => void;
+}
+
+/**
+ * CollectiblesGrid Component
+ *
+ * A component that displays collectibles organized by collections in a grid layout.
+ * Features include:
+ * - Groups collectibles by collection
+ * - Displays collection names with item counts
+ * - Shows collectible images in a horizontal scrollable grid
+ * - Handles loading and empty states
+ *
+ * @param {CollectiblesGridProps} props - Component props
+ * @returns {JSX.Element} The collectibles grid component
+ */
+export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
+  ({ onCollectiblePress }) => {
+    const { t } = useAppTranslation();
+    const { themeColors } = useColors();
+    const { collections, isLoading, error, fetchCollectibles } =
+      useCollectibles();
+
+    // Fetch collectibles when component mounts
+    useEffect(() => {
+      fetchCollectibles();
+    }, [fetchCollectibles]);
+
+    const handleRefresh = useCallback(() => {
+      fetchCollectibles();
+    }, [fetchCollectibles]);
+
+    const renderCollectibleItem = useCallback(
+      ({ item }: { item: Collectible }) => (
+        <TouchableOpacity
+          className="w-[165px] h-[165px] rounded-2xl overflow-hidden mr-6"
+          delayPressIn={DEFAULT_PRESS_DELAY}
+          onPress={() => onCollectiblePress?.(item.tokenId)}
+        >
+          <Image
+            source={{ uri: item.image }}
+            className="w-full h-full"
+            resizeMode="cover"
+          />
+        </TouchableOpacity>
+      ),
+      [onCollectiblePress],
+    );
+
+    const renderCollection = useCallback(
+      // eslint-disable-next-line react/no-unused-prop-types
+      ({ item }: { item: Collection }) => (
+        <View className="mb-6">
+          <View className="flex-row items-center gap-2 mb-3">
+            <Icon.Grid01 size={20} color={themeColors.text.secondary} />
+            <Text medium secondary style={{ flex: 1 }}>
+              {item.collectionName}
+            </Text>
+            <Text medium secondary>
+              {item.count}
+            </Text>
+          </View>
+          <FlatList
+            data={item.items}
+            renderItem={renderCollectibleItem}
+            keyExtractor={(collectible) => collectible.tokenId}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+          />
+        </View>
+      ),
+      [renderCollectibleItem, themeColors.text.secondary],
+    );
+
+    const renderContent = useMemo(() => {
+      if (collections.length > 0) {
+        return (
+          <FlatList
+            data={collections}
+            renderItem={renderCollection}
+            keyExtractor={(collection) => collection.collectionName}
+            showsVerticalScrollIndicator={false}
+            ListFooterComponent={DefaultListFooter}
+            refreshControl={
+              <RefreshControl
+                refreshing={isLoading}
+                tintColor={themeColors.secondary}
+                onRefresh={handleRefresh}
+              />
+            }
+          />
+        );
+      }
+
+      if (isLoading) {
+        return (
+          <View className="flex-1 pt-4">
+            <Spinner
+              testID="collectibles-grid-spinner"
+              size="large"
+              color={themeColors.secondary}
+            />
+          </View>
+        );
+      }
+
+      if (error) {
+        return (
+          <View className="flex-1 pt-4">
+            <Text md secondary>
+              {t("collectiblesGrid.error")}
+            </Text>
+          </View>
+        );
+      }
+
+      return (
+        <View className="flex-1 pt-4">
+          <Text md secondary>
+            {t("collectiblesGrid.empty")}
+          </Text>
+        </View>
+      );
+    }, [
+      collections,
+      isLoading,
+      error,
+      t,
+      themeColors.secondary,
+      renderCollection,
+      handleRefresh,
+    ]);
+
+    return <View className="flex-1">{renderContent}</View>;
+  },
+);
+
+CollectiblesGrid.displayName = "CollectiblesGrid";

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -16,7 +16,11 @@ import {
   RefreshControl,
 } from "react-native";
 
+/**
+ * Props for the CollectiblesGrid component
+ */
 interface CollectiblesGridProps {
+  /** Callback function triggered when a collectible item is pressed */
   onCollectiblePress?: (collectibleId: string) => void;
 }
 
@@ -29,8 +33,15 @@ interface CollectiblesGridProps {
  * - Displays collection names with item counts
  * - Shows collectible images in a horizontal scrollable grid
  * - Handles loading and empty states
+ * - Pull-to-refresh functionality
+ * - Responsive grid layout with proper spacing
+ * - Memoized rendering for performance optimization
+ *
+ * The component automatically fetches collectibles data on mount and provides
+ * a refresh mechanism for users to update the data manually.
  *
  * @param {CollectiblesGridProps} props - Component props
+ * @param {Function} [props.onCollectiblePress] - Callback function when a collectible is pressed
  * @returns {JSX.Element} The collectibles grid component
  */
 export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(

--- a/src/components/DefaultListFooter.tsx
+++ b/src/components/DefaultListFooter.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { View } from "react-native";
+
+/**
+ * DefaultListFooter Component
+ *
+ * A reusable footer component that provides consistent bottom spacing
+ * for FlatLists throughout the app.
+ *
+ * @returns {JSX.Element} A View with consistent height for list footers
+ */
+export const DefaultListFooter: React.FC = React.memo(() => (
+  <View className="h-10" />
+));
+
+DefaultListFooter.displayName = "DefaultListFooter";

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -1,14 +1,14 @@
 import { BalancesList } from "components/BalancesList";
 import { CollectiblesGrid } from "components/CollectiblesGrid";
+import ContextMenuButton, { MenuItem } from "components/ContextMenuButton";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { DEFAULT_PADDING, NETWORKS } from "config/constants";
-import { debug } from "helpers/debug";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useState, useCallback, useMemo } from "react";
-import { TouchableOpacity, View } from "react-native";
+import { Platform, TouchableOpacity, View } from "react-native";
 
 /**
  * Available tab types for the TokensCollectiblesTabs component
@@ -26,6 +26,8 @@ export enum TabType {
 interface Props {
   /** The default active tab when the component mounts */
   defaultTab?: TabType;
+  /** Whether to show the collectibles settings button */
+  showCollectiblesSettings?: boolean;
   /** Callback function triggered when tab changes */
   onTabChange?: (tab: TabType) => void;
   /** The public key of the wallet to display data for */
@@ -50,7 +52,7 @@ interface Props {
  * - Memoized content rendering for performance
  * - Dynamic tab styling based on active state
  * - Callback support for tab changes and item interactions
- * - Collectibles settings button (visible only when Collectibles tab is active)
+ * - Collectibles settings context menu with "Add manually" option
  * - Smart padding management for different content types
  *
  * @param {Props} props - Component props
@@ -59,6 +61,7 @@ interface Props {
 export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
   ({
     defaultTab = TabType.TOKENS,
+    showCollectiblesSettings = false,
     onTabChange,
     publicKey,
     network,
@@ -83,13 +86,21 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
     );
 
     /**
-     * Handles the press event for the collectibles settings button
-     * Currently logs debug information for development purposes
-     * TODO: Implement actual collectibles settings functionality
+     * Context menu actions for collectibles settings
      */
-    const handleCollectiblesSettingsPress = useCallback(() => {
-      debug("TokensCollectiblesTabs", "collectibles settings pressed");
-    }, []);
+    const collectiblesMenuActions: MenuItem[] = useMemo(
+      () => [
+        {
+          title: t("collectiblesGrid.addManually"),
+          systemIcon: Platform.select({
+            ios: "plus.rectangle.on.rectangle",
+            android: "add_box",
+          }),
+          disabled: true,
+        },
+      ],
+      [t],
+    );
 
     /**
      * Renders the tokens/balances list content
@@ -177,13 +188,17 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
           </TouchableOpacity>
 
           {/* Collectibles settings button - only visible when Collectibles tab is active */}
-          {activeTab === TabType.COLLECTIBLES && (
-            <TouchableOpacity
-              className="py-2 pl-4"
-              onPress={handleCollectiblesSettingsPress}
+          {activeTab === TabType.COLLECTIBLES && showCollectiblesSettings && (
+            <ContextMenuButton
+              contextMenuProps={{ actions: collectiblesMenuActions }}
+              side="bottom"
+              align="end"
+              sideOffset={8}
             >
-              <Icon.Sliders01 size={20} color={themeColors.text.secondary} />
-            </TouchableOpacity>
+              <View className="-mr-2">
+                <Icon.Sliders01 size={20} color={themeColors.text.secondary} />
+              </View>
+            </ContextMenuButton>
           )}
         </View>
 

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -26,6 +26,8 @@ export enum TabType {
 interface Props {
   /** The default active tab when the component mounts */
   defaultTab?: TabType;
+  /** Whether to hide the collectibles tab */
+  hideCollectibles?: boolean;
   /** Whether to show the collectibles settings button */
   showCollectiblesSettings?: boolean;
   /** Callback function triggered when tab changes */
@@ -61,6 +63,7 @@ interface Props {
 export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
   ({
     defaultTab = TabType.TOKENS,
+    hideCollectibles = false,
     showCollectiblesSettings = false,
     onTabChange,
     publicKey,
@@ -142,12 +145,18 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
      * Returns either the tokens content or collectibles content accordingly
      */
     const renderContent = useMemo(() => {
-      if (activeTab === TabType.TOKENS) {
+      // If collectibles are hidden, we should render tokens content only
+      if (hideCollectibles || activeTab === TabType.TOKENS) {
         return renderTokensContent;
       }
 
       return renderCollectiblesContent;
-    }, [activeTab, renderTokensContent, renderCollectiblesContent]);
+    }, [
+      hideCollectibles,
+      activeTab,
+      renderTokensContent,
+      renderCollectiblesContent,
+    ]);
 
     return (
       <View
@@ -171,21 +180,23 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
             </Text>
           </TouchableOpacity>
 
-          <TouchableOpacity
-            className="flex-1 py-2"
-            onPress={() => handleTabChange(TabType.COLLECTIBLES)}
-          >
-            <Text
-              medium
-              color={
-                activeTab === TabType.COLLECTIBLES
-                  ? themeColors.text.primary
-                  : themeColors.text.secondary
-              }
+          {!hideCollectibles && (
+            <TouchableOpacity
+              className="flex-1 py-2"
+              onPress={() => handleTabChange(TabType.COLLECTIBLES)}
             >
-              {t("collectiblesGrid.title")}
-            </Text>
-          </TouchableOpacity>
+              <Text
+                medium
+                color={
+                  activeTab === TabType.COLLECTIBLES
+                    ? themeColors.text.primary
+                    : themeColors.text.secondary
+                }
+              >
+                {t("collectiblesGrid.title")}
+              </Text>
+            </TouchableOpacity>
+          )}
 
           {/* Collectibles settings button - only visible when Collectibles tab is active */}
           {activeTab === TabType.COLLECTIBLES && showCollectiblesSettings && (

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -1,7 +1,8 @@
 import { BalancesList } from "components/BalancesList";
 import { CollectiblesGrid } from "components/CollectiblesGrid";
 import { Text } from "components/sds/Typography";
-import { NETWORKS } from "config/constants";
+import { DEFAULT_PADDING, NETWORKS } from "config/constants";
+import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useState, useCallback, useMemo } from "react";
@@ -85,7 +86,16 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
     );
 
     const renderCollectiblesContent = useMemo(
-      () => <CollectiblesGrid onCollectiblePress={onCollectiblePress} />,
+      () => (
+        // This is a workaround to avoid the default padding from being applied to the collectibles grid
+        // and the collectibles grid being cut off.
+        <View
+          className="flex-1"
+          style={{ marginHorizontal: -pxValue(DEFAULT_PADDING) }}
+        >
+          <CollectiblesGrid onCollectiblePress={onCollectiblePress} />
+        </View>
+      ),
       [onCollectiblePress],
     );
 
@@ -98,7 +108,10 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
     }, [activeTab, renderTokensContent, renderCollectiblesContent]);
 
     return (
-      <View className="flex-1">
+      <View
+        className="flex-1"
+        style={{ paddingHorizontal: pxValue(DEFAULT_PADDING) }}
+      >
         <View className="flex-row items-center gap-3 mb-4">
           <TouchableOpacity
             className="py-2"

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -7,17 +7,31 @@ import useColors from "hooks/useColors";
 import React, { useState, useCallback, useMemo } from "react";
 import { TouchableOpacity, View } from "react-native";
 
+/**
+ * Available tab types for the TokensCollectiblesTabs component
+ */
 export enum TabType {
+  /** Display tokens/balances list */
   TOKENS = "tokens",
+  /** Display collectibles grid */
   COLLECTIBLES = "collectibles",
 }
 
+/**
+ * Props for the TokensCollectiblesTabs component
+ */
 interface Props {
+  /** The default active tab when the component mounts */
   defaultTab?: TabType;
+  /** Callback function triggered when tab changes */
   onTabChange?: (tab: TabType) => void;
+  /** The public key of the wallet to display data for */
   publicKey: string;
+  /** The network to fetch data from */
   network: NETWORKS;
+  /** Callback function when a token is pressed */
   onTokenPress?: (tokenId: string) => void;
+  /** Callback function when a collectible is pressed */
   onCollectiblePress?: (collectibleId: string) => void;
 }
 
@@ -25,7 +39,14 @@ interface Props {
  * TokensCollectiblesTabs Component
  *
  * A reusable tab component for switching between Tokens and Collectibles views.
- * Used in HomeScreen and TransactionTokenScreen.
+ * Used in HomeScreen and TransactionTokenScreen to provide consistent navigation
+ * between different asset types.
+ *
+ * Features:
+ * - Tab switching between Tokens and Collectibles
+ * - Memoized content rendering for performance
+ * - Dynamic tab styling based on active state
+ * - Callback support for tab changes and item interactions
  *
  * @param {Props} props - Component props
  * @returns {JSX.Element} The tab component with content

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -3,7 +3,7 @@ import { Text } from "components/sds/Typography";
 import { NETWORKS } from "config/constants";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
-import React, { useState, memo, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { TouchableOpacity, View } from "react-native";
 
 export enum TabType {
@@ -11,7 +11,7 @@ export enum TabType {
   COLLECTIBLES = "collectibles",
 }
 
-interface TokensCollectiblesTabsProps {
+interface Props {
   defaultTab?: TabType;
   onTabChange?: (tab: TabType) => void;
   publicKey: string;
@@ -29,100 +29,99 @@ interface TokensCollectiblesTabsProps {
  * @param {TokensCollectiblesTabsProps} props - Component props
  * @returns {JSX.Element} The tab component with content
  */
-export const TokensCollectiblesTabs: React.FC<TokensCollectiblesTabsProps> =
-  memo(
-    ({
-      defaultTab = TabType.TOKENS,
-      onTabChange,
-      publicKey,
-      network,
-      onTokenPress,
-      onCollectiblePress,
-    }) => {
-      const { t } = useAppTranslation();
-      const { themeColors } = useColors();
+export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
+  ({
+    defaultTab = TabType.TOKENS,
+    onTabChange,
+    publicKey,
+    network,
+    onTokenPress,
+    onCollectiblePress,
+  }) => {
+    const { t } = useAppTranslation();
+    const { themeColors } = useColors();
 
-      const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
+    const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
 
-      const handleTabChange = useCallback(
-        (tab: TabType) => {
-          setActiveTab(tab);
-          onTabChange?.(tab);
-        },
-        [onTabChange],
-      );
+    const handleTabChange = useCallback(
+      (tab: TabType) => {
+        setActiveTab(tab);
+        onTabChange?.(tab);
+      },
+      [onTabChange],
+    );
 
-      const renderTokensContent = useMemo(
-        () => (
-          <BalancesList
-            publicKey={publicKey}
-            network={network}
-            onTokenPress={onTokenPress}
-          />
-        ),
-        [publicKey, network, onTokenPress],
-      );
+    const renderTokensContent = useMemo(
+      () => (
+        <BalancesList
+          publicKey={publicKey}
+          network={network}
+          onTokenPress={onTokenPress}
+        />
+      ),
+      [publicKey, network, onTokenPress],
+    );
 
-      const renderCollectiblesContent = useMemo(
-        () => (
-          // TODO: Implement CollectiblesGrid component
-          <View className="flex-1 items-center">
-            <Text md secondary onPress={() => onCollectiblePress?.("")}>
-              Collectibles coming soon
-            </Text>
-          </View>
-        ),
-        [onCollectiblePress],
-      );
-
-      const renderContent = useMemo(() => {
-        if (activeTab === TabType.TOKENS) {
-          return renderTokensContent;
-        }
-
-        return renderCollectiblesContent;
-      }, [activeTab, renderTokensContent, renderCollectiblesContent]);
-
-      return (
-        <View className="flex-1">
-          <View className="flex-row items-center mb-4">
-            <TouchableOpacity
-              className="p-2"
-              onPress={() => handleTabChange(TabType.TOKENS)}
-            >
-              <Text
-                medium
-                color={
-                  activeTab === TabType.TOKENS
-                    ? themeColors.text.primary
-                    : themeColors.text.secondary
-                }
-              >
-                {t("balancesList.title")}
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              className="p-2"
-              onPress={() => handleTabChange(TabType.COLLECTIBLES)}
-            >
-              <Text
-                medium
-                color={
-                  activeTab === TabType.COLLECTIBLES
-                    ? themeColors.text.primary
-                    : themeColors.text.secondary
-                }
-              >
-                {t("collectiblesGrid.title")}
-              </Text>
-            </TouchableOpacity>
-          </View>
-
-          {renderContent}
+    const renderCollectiblesContent = useMemo(
+      () => (
+        // TODO: Implement CollectiblesGrid component
+        <View className="flex-1 items-center">
+          <Text md secondary onPress={() => onCollectiblePress?.("")}>
+            Collectibles coming soon
+          </Text>
         </View>
-      );
-    },
-  );
+      ),
+      [onCollectiblePress],
+    );
+
+    const renderContent = useMemo(() => {
+      if (activeTab === TabType.TOKENS) {
+        return renderTokensContent;
+      }
+
+      return renderCollectiblesContent;
+    }, [activeTab, renderTokensContent, renderCollectiblesContent]);
+
+    return (
+      <View className="flex-1">
+        <View className="flex-row items-center mb-4">
+          <TouchableOpacity
+            className="p-2"
+            onPress={() => handleTabChange(TabType.TOKENS)}
+          >
+            <Text
+              medium
+              color={
+                activeTab === TabType.TOKENS
+                  ? themeColors.text.primary
+                  : themeColors.text.secondary
+              }
+            >
+              {t("balancesList.title")}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            className="p-2"
+            onPress={() => handleTabChange(TabType.COLLECTIBLES)}
+          >
+            <Text
+              medium
+              color={
+                activeTab === TabType.COLLECTIBLES
+                  ? themeColors.text.primary
+                  : themeColors.text.secondary
+              }
+            >
+              {t("collectiblesGrid.title")}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {renderContent}
+      </View>
+    );
+  },
+);
 
 TokensCollectiblesTabs.displayName = "TokensCollectiblesTabs";

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -3,7 +3,7 @@ import { Text } from "components/sds/Typography";
 import { NETWORKS } from "config/constants";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
-import React, { useState } from "react";
+import React, { useState, memo, useCallback, useMemo } from "react";
 import { TouchableOpacity, View } from "react-native";
 
 export enum TabType {
@@ -29,85 +29,100 @@ interface TokensCollectiblesTabsProps {
  * @param {TokensCollectiblesTabsProps} props - Component props
  * @returns {JSX.Element} The tab component with content
  */
-export const TokensCollectiblesTabs: React.FC<TokensCollectiblesTabsProps> = ({
-  defaultTab = TabType.TOKENS,
-  onTabChange,
-  publicKey,
-  network,
-  onTokenPress,
-  onCollectiblePress,
-}) => {
-  const { t } = useAppTranslation();
-  const { themeColors } = useColors();
+export const TokensCollectiblesTabs: React.FC<TokensCollectiblesTabsProps> =
+  memo(
+    ({
+      defaultTab = TabType.TOKENS,
+      onTabChange,
+      publicKey,
+      network,
+      onTokenPress,
+      onCollectiblePress,
+    }) => {
+      const { t } = useAppTranslation();
+      const { themeColors } = useColors();
 
-  const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
+      const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
 
-  const handleTabChange = (tab: TabType) => {
-    setActiveTab(tab);
-    onTabChange?.(tab);
-  };
+      const handleTabChange = useCallback(
+        (tab: TabType) => {
+          setActiveTab(tab);
+          onTabChange?.(tab);
+        },
+        [onTabChange],
+      );
 
-  const renderTokensContent = () => (
-    <BalancesList
-      publicKey={publicKey}
-      network={network}
-      onTokenPress={onTokenPress}
-    />
+      const renderTokensContent = useMemo(
+        () => (
+          <BalancesList
+            publicKey={publicKey}
+            network={network}
+            onTokenPress={onTokenPress}
+          />
+        ),
+        [publicKey, network, onTokenPress],
+      );
+
+      const renderCollectiblesContent = useMemo(
+        () => (
+          // TODO: Implement CollectiblesGrid component
+          <View className="flex-1 items-center">
+            <Text md secondary onPress={() => onCollectiblePress?.("")}>
+              Collectibles coming soon
+            </Text>
+          </View>
+        ),
+        [onCollectiblePress],
+      );
+
+      const renderContent = useMemo(() => {
+        if (activeTab === TabType.TOKENS) {
+          return renderTokensContent;
+        }
+
+        return renderCollectiblesContent;
+      }, [activeTab, renderTokensContent, renderCollectiblesContent]);
+
+      return (
+        <View className="flex-1">
+          <View className="flex-row items-center mb-4">
+            <TouchableOpacity
+              className="p-2"
+              onPress={() => handleTabChange(TabType.TOKENS)}
+            >
+              <Text
+                medium
+                color={
+                  activeTab === TabType.TOKENS
+                    ? themeColors.text.primary
+                    : themeColors.text.secondary
+                }
+              >
+                {t("balancesList.title")}
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              className="p-2"
+              onPress={() => handleTabChange(TabType.COLLECTIBLES)}
+            >
+              <Text
+                medium
+                color={
+                  activeTab === TabType.COLLECTIBLES
+                    ? themeColors.text.primary
+                    : themeColors.text.secondary
+                }
+              >
+                {t("collectiblesGrid.title")}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {renderContent}
+        </View>
+      );
+    },
   );
 
-  const renderCollectiblesContent = () => (
-    // TODO: Implement CollectiblesGrid component
-    <View className="flex-1 items-center">
-      <Text md secondary onPress={() => onCollectiblePress?.("")}>
-        Collectibles coming soon
-      </Text>
-    </View>
-  );
-  const renderContent = () => {
-    if (activeTab === TabType.TOKENS) {
-      return renderTokensContent();
-    }
-
-    return renderCollectiblesContent();
-  };
-
-  return (
-    <View className="flex-1">
-      <View className="flex-row items-center mb-4">
-        <TouchableOpacity
-          className="p-2"
-          onPress={() => handleTabChange(TabType.TOKENS)}
-        >
-          <Text
-            medium
-            color={
-              activeTab === TabType.TOKENS
-                ? themeColors.text.primary
-                : themeColors.text.secondary
-            }
-          >
-            {t("balancesList.title")}
-          </Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          className="p-2"
-          onPress={() => handleTabChange(TabType.COLLECTIBLES)}
-        >
-          <Text
-            medium
-            color={
-              activeTab === TabType.COLLECTIBLES
-                ? themeColors.text.primary
-                : themeColors.text.secondary
-            }
-          >
-            {t("collectiblesGrid.title")}
-          </Text>
-        </TouchableOpacity>
-      </View>
-
-      {renderContent()}
-    </View>
-  );
-};
+TokensCollectiblesTabs.displayName = "TokensCollectiblesTabs";

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -1,4 +1,5 @@
 import { BalancesList } from "components/BalancesList";
+import { CollectiblesGrid } from "components/CollectiblesGrid";
 import { Text } from "components/sds/Typography";
 import { NETWORKS } from "config/constants";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -26,7 +27,7 @@ interface Props {
  * A reusable tab component for switching between Tokens and Collectibles views.
  * Used in HomeScreen and TransactionTokenScreen.
  *
- * @param {TokensCollectiblesTabsProps} props - Component props
+ * @param {Props} props - Component props
  * @returns {JSX.Element} The tab component with content
  */
 export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
@@ -63,14 +64,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
     );
 
     const renderCollectiblesContent = useMemo(
-      () => (
-        // TODO: Implement CollectiblesGrid component
-        <View className="flex-1 items-center">
-          <Text md secondary onPress={() => onCollectiblePress?.("")}>
-            Collectibles coming soon
-          </Text>
-        </View>
-      ),
+      () => <CollectiblesGrid onCollectiblePress={onCollectiblePress} />,
       [onCollectiblePress],
     );
 
@@ -84,9 +78,9 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
 
     return (
       <View className="flex-1">
-        <View className="flex-row items-center mb-4">
+        <View className="flex-row items-center gap-3 mb-4">
           <TouchableOpacity
-            className="p-2"
+            className="py-2"
             onPress={() => handleTabChange(TabType.TOKENS)}
           >
             <Text
@@ -102,7 +96,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
           </TouchableOpacity>
 
           <TouchableOpacity
-            className="p-2"
+            className="py-2"
             onPress={() => handleTabChange(TabType.COLLECTIBLES)}
           >
             <Text

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -1,0 +1,113 @@
+import { BalancesList } from "components/BalancesList";
+import { Text } from "components/sds/Typography";
+import { NETWORKS } from "config/constants";
+import useAppTranslation from "hooks/useAppTranslation";
+import useColors from "hooks/useColors";
+import React, { useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+
+export enum TabType {
+  TOKENS = "tokens",
+  COLLECTIBLES = "collectibles",
+}
+
+interface TokensCollectiblesTabsProps {
+  defaultTab?: TabType;
+  onTabChange?: (tab: TabType) => void;
+  publicKey: string;
+  network: NETWORKS;
+  onTokenPress?: (tokenId: string) => void;
+  onCollectiblePress?: (collectibleId: string) => void;
+}
+
+/**
+ * TokensCollectiblesTabs Component
+ *
+ * A reusable tab component for switching between Tokens and Collectibles views.
+ * Used in HomeScreen and TransactionTokenScreen.
+ *
+ * @param {TokensCollectiblesTabsProps} props - Component props
+ * @returns {JSX.Element} The tab component with content
+ */
+export const TokensCollectiblesTabs: React.FC<TokensCollectiblesTabsProps> = ({
+  defaultTab = TabType.TOKENS,
+  onTabChange,
+  publicKey,
+  network,
+  onTokenPress,
+  onCollectiblePress,
+}) => {
+  const { t } = useAppTranslation();
+  const { themeColors } = useColors();
+
+  const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
+
+  const handleTabChange = (tab: TabType) => {
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
+
+  const renderTokensContent = () => (
+    <BalancesList
+      publicKey={publicKey}
+      network={network}
+      onTokenPress={onTokenPress}
+    />
+  );
+
+  const renderCollectiblesContent = () => (
+    // TODO: Implement CollectiblesGrid component
+    <View className="flex-1 items-center">
+      <Text md secondary onPress={() => onCollectiblePress?.("")}>
+        Collectibles coming soon
+      </Text>
+    </View>
+  );
+  const renderContent = () => {
+    if (activeTab === TabType.TOKENS) {
+      return renderTokensContent();
+    }
+
+    return renderCollectiblesContent();
+  };
+
+  return (
+    <View className="flex-1">
+      <View className="flex-row items-center mb-4">
+        <TouchableOpacity
+          className="p-2"
+          onPress={() => handleTabChange(TabType.TOKENS)}
+        >
+          <Text
+            medium
+            color={
+              activeTab === TabType.TOKENS
+                ? themeColors.text.primary
+                : themeColors.text.secondary
+            }
+          >
+            {t("balancesList.title")}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="p-2"
+          onPress={() => handleTabChange(TabType.COLLECTIBLES)}
+        >
+          <Text
+            medium
+            color={
+              activeTab === TabType.COLLECTIBLES
+                ? themeColors.text.primary
+                : themeColors.text.secondary
+            }
+          >
+            {t("collectiblesGrid.title")}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {renderContent()}
+    </View>
+  );
+};

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -1,7 +1,9 @@
 import { BalancesList } from "components/BalancesList";
 import { CollectiblesGrid } from "components/CollectiblesGrid";
+import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { DEFAULT_PADDING, NETWORKS } from "config/constants";
+import { debug } from "helpers/debug";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
@@ -48,6 +50,8 @@ interface Props {
  * - Memoized content rendering for performance
  * - Dynamic tab styling based on active state
  * - Callback support for tab changes and item interactions
+ * - Collectibles settings button (visible only when Collectibles tab is active)
+ * - Smart padding management for different content types
  *
  * @param {Props} props - Component props
  * @returns {JSX.Element} The tab component with content
@@ -66,6 +70,10 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
 
     const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
 
+    /**
+     * Handles tab switching and triggers the optional onTabChange callback
+     * @param {TabType} tab - The tab type to switch to
+     */
     const handleTabChange = useCallback(
       (tab: TabType) => {
         setActiveTab(tab);
@@ -74,6 +82,19 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
       [onTabChange],
     );
 
+    /**
+     * Handles the press event for the collectibles settings button
+     * Currently logs debug information for development purposes
+     * TODO: Implement actual collectibles settings functionality
+     */
+    const handleCollectiblesSettingsPress = useCallback(() => {
+      debug("TokensCollectiblesTabs", "collectibles settings pressed");
+    }, []);
+
+    /**
+     * Renders the tokens/balances list content
+     * Displays the BalancesList component with the provided props
+     */
     const renderTokensContent = useMemo(
       () => (
         <BalancesList
@@ -85,10 +106,16 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
       [publicKey, network, onTokenPress],
     );
 
+    /**
+     * Renders the collectibles content with custom padding management
+     *
+     * Note: This component uses a padding workaround to ensure the collectibles grid
+     * extends to the full screen width while maintaining proper spacing for other content.
+     * The negative horizontal margin counteracts the parent container's padding,
+     * allowing the CollectiblesGrid to render edge-to-edge as intended.
+     */
     const renderCollectiblesContent = useMemo(
       () => (
-        // This is a workaround to avoid the default padding from being applied to the collectibles grid
-        // and the collectibles grid being cut off.
         <View
           className="flex-1"
           style={{ marginHorizontal: -pxValue(DEFAULT_PADDING) }}
@@ -99,6 +126,10 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
       [onCollectiblePress],
     );
 
+    /**
+     * Determines which content to render based on the currently active tab
+     * Returns either the tokens content or collectibles content accordingly
+     */
     const renderContent = useMemo(() => {
       if (activeTab === TabType.TOKENS) {
         return renderTokensContent;
@@ -130,7 +161,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
           </TouchableOpacity>
 
           <TouchableOpacity
-            className="py-2"
+            className="flex-1 py-2"
             onPress={() => handleTabChange(TabType.COLLECTIBLES)}
           >
             <Text
@@ -144,6 +175,16 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
               {t("collectiblesGrid.title")}
             </Text>
           </TouchableOpacity>
+
+          {/* Collectibles settings button - only visible when Collectibles tab is active */}
+          {activeTab === TabType.COLLECTIBLES && (
+            <TouchableOpacity
+              className="py-2 pl-4"
+              onPress={handleCollectiblesSettingsPress}
+            >
+              <Icon.Sliders01 size={20} color={themeColors.text.secondary} />
+            </TouchableOpacity>
+          )}
         </View>
 
         {renderContent}

--- a/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
+++ b/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
@@ -1,3 +1,4 @@
+import { DefaultListFooter } from "components/DefaultListFooter";
 import { CustomHeaderButton } from "components/layout/CustomHeaderButton";
 import { TabPreview } from "components/screens/DiscoveryScreen/components";
 import Icon from "components/sds/Icon";
@@ -78,6 +79,7 @@ const TabOverview: React.FC<TabOverviewProps> = React.memo(
             justifyContent: "space-between",
             marginBottom: pxValue(14),
           }}
+          ListFooterComponent={DefaultListFooter}
           contentContainerStyle={{ padding: pxValue(DEFAULT_PADDING) }}
           keyExtractor={(tab) => tab.id}
           renderItem={({ item: tab }) => (

--- a/src/components/screens/HistoryScreen/HistoryList.tsx
+++ b/src/components/screens/HistoryScreen/HistoryList.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import BottomSheet from "components/BottomSheet";
+import { DefaultListFooter } from "components/DefaultListFooter";
 import Spinner from "components/Spinner";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { TransactionDetails } from "components/screens/HistoryScreen";
@@ -180,7 +181,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1 }}
         ListHeaderComponent={ListHeaderComponent}
-        ListFooterComponent={<View className="h-10" />}
+        ListFooterComponent={DefaultListFooter}
         className={className}
         ListEmptyComponent={
           <View className="flex-1 items-center justify-center px-2 gap-4">

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -31,10 +31,8 @@ import { useHomeHeaders } from "hooks/useHomeHeaders";
 import { useTotalBalance } from "hooks/useTotalBalance";
 import { useWelcomeBanner } from "hooks/useWelcomeBanner";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
-import { Dimensions, TouchableOpacity, View } from "react-native";
+import { TouchableOpacity, View } from "react-native";
 import { analytics } from "services/analytics";
-
-const { width } = Dimensions.get("window");
 
 /**
  * Top section of the home screen containing account info and actions
@@ -141,7 +139,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   };
 
   return (
-    <BaseLayout insets={{ bottom: false, top: false }}>
+    <BaseLayout
+      insets={{ bottom: false, top: false, left: false, right: false }}
+    >
       <WelcomeBannerBottomSheet
         modalRef={welcomeBannerBottomSheetModalRef}
         onAddXLM={navigateToBuyXLM}
@@ -203,10 +203,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         </View>
       </View>
 
-      <View
-        className="border-b mb-4 -ml-7 border-border-primary"
-        style={{ width }}
-      />
+      <View className="w-full border-b mb-4 border-border-primary" />
 
       <TokensCollectiblesTabs
         publicKey={account?.publicKey ?? ""}

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
-import { BalancesList } from "components/BalancesList";
 import { IconButton } from "components/IconButton";
+import { TokensCollectiblesTabs } from "components/TokensCollectiblesTabs";
 import { AnalyticsDebugBottomSheet } from "components/analytics/AnalyticsDebugBottomSheet";
 import { AnalyticsDebugTrigger } from "components/analytics/AnalyticsDebugTrigger";
 import { BaseLayout } from "components/layout/BaseLayout";
@@ -204,15 +204,11 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       </View>
 
       <View
-        className="border-b mb-6 -ml-7 border-border-primary"
+        className="border-b mb-4 -ml-7 border-border-primary"
         style={{ width }}
       />
 
-      <View className="flex-row items-center mb-6">
-        <Text medium>{t("balancesList.title")}</Text>
-      </View>
-
-      <BalancesList
+      <TokensCollectiblesTabs
         publicKey={account?.publicKey ?? ""}
         network={network}
         onTokenPress={handleTokenPress}

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -206,6 +206,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       <View className="w-full border-b mb-4 border-border-primary" />
 
       <TokensCollectiblesTabs
+        showCollectiblesSettings
         publicKey={account?.publicKey ?? ""}
         network={network}
         onTokenPress={handleTokenPress}

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -208,6 +208,10 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         style={{ width }}
       />
 
+      <View className="flex-row items-center mb-6">
+        <Text medium>{t("balancesList.title")}</Text>
+      </View>
+
       <BalancesList
         publicKey={account?.publicKey ?? ""}
         network={network}

--- a/src/components/screens/ImportSecretKeyScreen.tsx
+++ b/src/components/screens/ImportSecretKeyScreen.tsx
@@ -11,6 +11,7 @@ import {
   ROOT_NAVIGATOR_ROUTES,
 } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
+import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useState, useEffect } from "react";
@@ -110,7 +111,11 @@ const ImportSecretKeyScreen: React.FC<ImportSecretKeyScreenProps> = ({
               }
             />
             {validationError && (
-              <Text sm color={themeColors.status.error} className="mt-1">
+              <Text
+                sm
+                color={themeColors.status.error}
+                style={{ marginTop: pxValue(4) }}
+              >
                 {t("importSecretKeyScreen.invalidSecretKey")}
               </Text>
             )}

--- a/src/components/screens/ImportSecretKeyScreen.tsx
+++ b/src/components/screens/ImportSecretKeyScreen.tsx
@@ -148,7 +148,9 @@ const ImportSecretKeyScreen: React.FC<ImportSecretKeyScreenProps> = ({
               }
             />
             <View className="mt-2">
-              <Text md>{t("importSecretKeyScreen.passwordNote")}</Text>
+              <Text md secondary>
+                {t("importSecretKeyScreen.passwordNote")}
+              </Text>
             </View>
           </View>
 
@@ -168,9 +170,7 @@ const ImportSecretKeyScreen: React.FC<ImportSecretKeyScreenProps> = ({
               </View>
             </Pressable>
             <View className="flex-1 ml-2 pt-5">
-              <Text sm className="leading-5 text-white">
-                {t("importSecretKeyScreen.responsibilityNote")}
-              </Text>
+              <Text sm>{t("importSecretKeyScreen.responsibilityNote")}</Text>
             </View>
           </View>
         </View>

--- a/src/components/screens/ScanQRCodeScreen/ScanQRCodeScreen.tsx
+++ b/src/components/screens/ScanQRCodeScreen/ScanQRCodeScreen.tsx
@@ -122,6 +122,7 @@ const ScanQRCodeScreen: React.FC<ScanQRCodeScreenProps> = ({ navigation }) => {
         )}
         headerRight={() => (
           <CustomHeaderButton
+            position="right"
             icon={Icon.QrCode01}
             onPress={handleHeaderRight}
           />

--- a/src/components/screens/SendScreen/components/RecentContactsList.tsx
+++ b/src/components/screens/SendScreen/components/RecentContactsList.tsx
@@ -1,3 +1,4 @@
+import { DefaultListFooter } from "components/DefaultListFooter";
 import { ContactRow } from "components/screens/SendScreen/components";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
@@ -64,6 +65,7 @@ export const RecentContactsList: React.FC<RecentContactsListProps> = ({
         <FlatList
           data={transactions}
           ListHeaderComponent={ListHeader}
+          ListFooterComponent={DefaultListFooter}
           renderItem={({ item }) => (
             <ContactRow
               address={item.address}

--- a/src/components/screens/SendScreen/components/SearchSuggestionsList.tsx
+++ b/src/components/screens/SendScreen/components/SearchSuggestionsList.tsx
@@ -1,3 +1,4 @@
+import { DefaultListFooter } from "components/DefaultListFooter";
 import { ContactRow } from "components/screens/SendScreen/components";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
@@ -56,6 +57,7 @@ export const SearchSuggestionsList: React.FC<SearchSuggestionsListProps> = ({
           />
         )}
         keyExtractor={(item) => item.id}
+        ListFooterComponent={DefaultListFooter}
       />
     </View>
   );

--- a/src/components/screens/SendScreen/components/SendReviewBottomSheet.tsx
+++ b/src/components/screens/SendScreen/components/SendReviewBottomSheet.tsx
@@ -60,7 +60,7 @@ const SendReviewBottomSheet: React.FC<SendReviewBottomSheetProps> = ({
 
     if (error) {
       return (
-        <Text md medium className="text-red-600">
+        <Text md medium color={themeColors.status.error}>
           {t("common.error", { errorMessage: error })}
         </Text>
       );

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -3,9 +3,11 @@ import { TokensCollectiblesTabs } from "components/TokensCollectiblesTabs";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { ContactRow } from "components/screens/SendScreen/components";
 import { Button } from "components/sds/Button";
+import { DEFAULT_PADDING } from "config/constants";
 import { SEND_PAYMENT_ROUTES, SendPaymentStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
+import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
 import React from "react";
@@ -33,9 +35,14 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
   };
 
   return (
-    <BaseLayout insets={{ top: false, bottom: false }}>
+    <BaseLayout
+      insets={{ top: false, bottom: false, left: false, right: false }}
+    >
       <View className="flex-1">
-        <View className="rounded-[12px] py-[12px] px-[16px] bg-background-secondary">
+        <View
+          className="rounded-[12px] py-[12px] px-[16px] bg-background-secondary"
+          style={{ marginHorizontal: pxValue(DEFAULT_PADDING) }}
+        >
           <ContactRow
             address={recipientAddress}
             rightElement={

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -1,9 +1,8 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { BalancesList } from "components/BalancesList";
+import { TokensCollectiblesTabs } from "components/TokensCollectiblesTabs";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { ContactRow } from "components/screens/SendScreen/components";
 import { Button } from "components/sds/Button";
-import { Text } from "components/sds/Typography";
 import { SEND_PAYMENT_ROUTES, SendPaymentStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
@@ -46,12 +45,8 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
             }
           />
         </View>
-        <View className="flex-1 mt-[24px]">
-          <View className="flex-row items-center mb-6">
-            <Text medium>{t("balancesList.title")}</Text>
-          </View>
-
-          <BalancesList
+        <View className="flex-1 mt-[16px]">
+          <TokensCollectiblesTabs
             publicKey={publicKey ?? ""}
             network={network}
             onTokenPress={handleTokenPress}

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -33,7 +33,7 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
   };
 
   return (
-    <BaseLayout insets={{ top: false }}>
+    <BaseLayout insets={{ top: false, bottom: false }}>
       <View className="flex-1">
         <View className="rounded-[12px] py-[12px] px-[16px] bg-background-secondary">
           <ContactRow

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -54,6 +54,7 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
         </View>
         <View className="flex-1 mt-[16px]">
           <TokensCollectiblesTabs
+            hideCollectibles
             publicKey={publicKey ?? ""}
             network={network}
             onTokenPress={handleTokenPress}

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -49,7 +49,6 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
           <BalancesList
             publicKey={publicKey ?? ""}
             network={network}
-            showTitleIcon
             onTokenPress={handleTokenPress}
           />
         </View>

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -3,6 +3,7 @@ import { BalancesList } from "components/BalancesList";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { ContactRow } from "components/screens/SendScreen/components";
 import { Button } from "components/sds/Button";
+import { Text } from "components/sds/Typography";
 import { SEND_PAYMENT_ROUTES, SendPaymentStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
@@ -45,7 +46,11 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
             }
           />
         </View>
-        <View className="flex-1 mt-[32px]">
+        <View className="flex-1 mt-[24px]">
+          <View className="flex-row items-center mb-6">
+            <Text medium>{t("balancesList.title")}</Text>
+          </View>
+
           <BalancesList
             publicKey={publicKey ?? ""}
             network={network}

--- a/src/components/screens/SettingsScreen/PreferencesScreen/PermissionModal.tsx
+++ b/src/components/screens/SettingsScreen/PreferencesScreen/PermissionModal.tsx
@@ -2,6 +2,7 @@ import Modal from "components/Modal";
 import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
+import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useCallback } from "react";
@@ -56,15 +57,27 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
             {renderActionIcon()}
           </View>
 
-          <Text primary lg medium className="text-center mb-2">
+          <Text
+            primary
+            lg
+            medium
+            textAlign="center"
+            style={{ marginBottom: pxValue(8) }}
+          >
             {t(`preferences.permissionModal.${action}.title`)}
           </Text>
 
-          <Text secondary md regular className="text-center mb-4">
+          <Text
+            secondary
+            md
+            regular
+            textAlign="center"
+            style={{ marginBottom: pxValue(16) }}
+          >
             {t(`preferences.permissionModal.${action}.description`)}
           </Text>
 
-          <Text secondary sm regular className="text-center">
+          <Text secondary sm regular textAlign="center">
             {t(`preferences.permissionModal.${action}.instruction`)}
           </Text>
 

--- a/src/components/screens/SwapScreen/SwapScreen.tsx
+++ b/src/components/screens/SwapScreen/SwapScreen.tsx
@@ -6,7 +6,6 @@ import { SWAP_ROUTES, SwapStackParamList } from "config/routes";
 import { useSwapStore } from "ducks/swap";
 import { useSwapSettingsStore } from "ducks/swapSettings";
 import { useTransactionBuilderStore } from "ducks/transactionBuilder";
-import useAppTranslation from "hooks/useAppTranslation";
 import React, { useEffect } from "react";
 
 type SwapScreenProps = NativeStackScreenProps<
@@ -15,7 +14,6 @@ type SwapScreenProps = NativeStackScreenProps<
 >;
 
 const SwapScreen: React.FC<SwapScreenProps> = ({ navigation }) => {
-  const { t } = useAppTranslation();
   const { resetSwap } = useSwapStore();
   const { resetToDefaults } = useSwapSettingsStore();
   const { resetTransaction } = useTransactionBuilderStore();
@@ -36,10 +34,7 @@ const SwapScreen: React.FC<SwapScreenProps> = ({ navigation }) => {
 
   return (
     <BaseLayout insets={{ top: false, bottom: false }}>
-      <TokenSelectionContent
-        onTokenPress={handleTokenPress}
-        customTitle={t("swapScreen.swapScreenTokenListTitle")}
-      />
+      <TokenSelectionContent onTokenPress={handleTokenPress} />
     </BaseLayout>
   );
 };

--- a/src/components/screens/SwapScreen/components/SelectTokenBottomSheet.tsx
+++ b/src/components/screens/SwapScreen/components/SelectTokenBottomSheet.tsx
@@ -47,7 +47,6 @@ const SelectTokenBottomSheet: React.FC<SelectTokenBottomSheetProps> = ({
       <View className="flex-1">
         <TokenSelectionContent
           onTokenPress={onTokenSelect}
-          showTitleIcon={false}
           customTitle={customTitle}
           renderRightContent={renderTokenContextMenu}
         />

--- a/src/components/screens/SwapScreen/components/SelectTokenBottomSheet.tsx
+++ b/src/components/screens/SwapScreen/components/SelectTokenBottomSheet.tsx
@@ -4,27 +4,23 @@ import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { NETWORKS } from "config/constants";
 import { PricedBalance } from "config/types";
-import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React from "react";
 import { TouchableOpacity, View } from "react-native";
 
 interface SelectTokenBottomSheetProps {
   onTokenSelect: (tokenId: string, tokenSymbol: string) => void;
-  customTitle?: string;
-  title?: string;
+  title: string;
   onClose?: () => void;
   network: NETWORKS;
 }
 
 const SelectTokenBottomSheet: React.FC<SelectTokenBottomSheetProps> = ({
   onTokenSelect,
-  customTitle,
   title,
   onClose,
   network,
 }) => {
-  const { t } = useAppTranslation();
   const { themeColors } = useColors();
 
   const renderTokenContextMenu = (balance: PricedBalance) => (
@@ -40,14 +36,13 @@ const SelectTokenBottomSheet: React.FC<SelectTokenBottomSheetProps> = ({
           </TouchableOpacity>
         )}
         <Text md medium semiBold>
-          {title || t("swapScreen.swapTo")}
+          {title}
         </Text>
       </View>
 
       <View className="flex-1">
         <TokenSelectionContent
           onTokenPress={onTokenSelect}
-          customTitle={customTitle}
           renderRightContent={renderTokenContextMenu}
         />
       </View>

--- a/src/components/screens/SwapScreen/components/TokenSelectionContent.tsx
+++ b/src/components/screens/SwapScreen/components/TokenSelectionContent.tsx
@@ -15,14 +15,12 @@ import { View } from "react-native";
 
 interface TokenSelectionContentProps {
   onTokenPress: (tokenId: string, tokenSymbol: string) => void;
-  showTitleIcon?: boolean;
   customTitle?: string;
   renderRightContent?: (balance: PricedBalance) => ReactNode;
 }
 
 const TokenSelectionContent: React.FC<TokenSelectionContentProps> = ({
   onTokenPress,
-  showTitleIcon = false,
   customTitle,
   renderRightContent,
 }) => {
@@ -86,9 +84,8 @@ const TokenSelectionContent: React.FC<TokenSelectionContentProps> = ({
       <BalancesList
         publicKey={publicKey}
         network={network}
-        searchTerm={filteringTerm}
         onTokenPress={handleTokenPress}
-        showTitleIcon={showTitleIcon}
+        searchTerm={filteringTerm}
         customTitle={customTitle}
         disableNavigation
         renderRightContent={renderRightContent}

--- a/src/components/screens/SwapScreen/components/TokenSelectionContent.tsx
+++ b/src/components/screens/SwapScreen/components/TokenSelectionContent.tsx
@@ -1,6 +1,7 @@
 import { BalancesList } from "components/BalancesList";
 import Icon from "components/sds/Icon";
 import { Input } from "components/sds/Input";
+import { Text } from "components/sds/Typography";
 import { DEFAULT_DEBOUNCE_DELAY, NATIVE_TOKEN_CODE } from "config/constants";
 import { PricedBalance } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
@@ -15,13 +16,11 @@ import { View } from "react-native";
 
 interface TokenSelectionContentProps {
   onTokenPress: (tokenId: string, tokenSymbol: string) => void;
-  customTitle?: string;
   renderRightContent?: (balance: PricedBalance) => ReactNode;
 }
 
 const TokenSelectionContent: React.FC<TokenSelectionContentProps> = ({
   onTokenPress,
-  customTitle,
   renderRightContent,
 }) => {
   const { account } = useGetActiveAccount();
@@ -81,12 +80,17 @@ const TokenSelectionContent: React.FC<TokenSelectionContentProps> = ({
           value={searchTerm}
         />
       </View>
+
+      <View className="flex-row items-center mb-6">
+        <Text medium secondary>
+          {t("swapScreen.swapScreenTokenListTitle")}
+        </Text>
+      </View>
       <BalancesList
         publicKey={publicKey}
         network={network}
         onTokenPress={handleTokenPress}
         searchTerm={filteringTerm}
-        customTitle={customTitle}
         disableNavigation
         renderRightContent={renderRightContent}
       />

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -471,7 +471,6 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
         customContent={
           <SelectTokenBottomSheet
             onTokenSelect={handleDestinationTokenSelect}
-            customTitle={t("swapScreen.swapScreenTokenListTitle")}
             title={t("swapScreen.swapTo")}
             onClose={() => selectTokenBottomSheetModalRef.current?.dismiss()}
             network={network}

--- a/src/components/sds/Avatar/index.tsx
+++ b/src/components/sds/Avatar/index.tsx
@@ -205,16 +205,6 @@ export const Avatar: React.FC<AvatarProps> = ({
   isSelected = false,
 }) => {
   const { themeColors } = useColors();
-  const getTextSizeClass = () => {
-    const classes: Record<AvatarSize, string> = {
-      sm: "text-xs",
-      md: "text-base",
-      lg: "text-lg",
-      xl: "text-xl",
-    };
-
-    return classes[size];
-  };
 
   // Get initials from username
   const getInitials = (name: string): string => {
@@ -303,7 +293,7 @@ export const Avatar: React.FC<AvatarProps> = ({
       isSelected={isSelected}
       hasBackground={hasBackground}
     >
-      <Text className={`font-bold text-text-secondary ${getTextSizeClass()}`}>
+      <Text bold secondary size={size}>
         {initials}
       </Text>
     </AvatarWrapper>

--- a/src/components/sds/Typography/index.tsx
+++ b/src/components/sds/Typography/index.tsx
@@ -278,7 +278,6 @@ export interface TextProps extends TypographyBaseProps {
   style?: StyleProp<TextStyle>;
   numberOfLines?: number;
   onPress?: () => void;
-  className?: string;
   textAlign?: "left" | "center" | "right";
 }
 
@@ -355,7 +354,6 @@ export const Text: React.FC<TextProps> = ({
   isVerticallyCentered = false,
   url,
   onPress,
-  className,
   textAlign,
   ...props
 }) => {
@@ -379,7 +377,6 @@ export const Text: React.FC<TextProps> = ({
       {...(url && { onPress: () => handleOnPressUrl() })}
       {...(!url && onPress && { onPress: () => onPress() })}
       {...props}
-      className={className}
     >
       {children}
     </StyledText>

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -127,7 +127,8 @@ const dummyCollectibles: Collectible[] = [
     collectionName: "Soroban Domains",
     tokenId: "102510",
     name: "charles.xlm",
-    image: "https://sorobandomains.org/img/logo.png",
+    image:
+      "https://nftcalendar.io/storage/uploads/events/2025/7/Hdqv6YNVErVCmYlwobFVYfS5BiH19ferUgQova7Z.webp",
     description: "Charles' Soroban username",
     externalUrl: "https://app.sorobandomains.org/domains/charles.xlm",
     traits: [
@@ -142,7 +143,8 @@ const dummyCollectibles: Collectible[] = [
     collectionName: "Soroban Domains",
     tokenId: "102589",
     name: "cassio.xlm",
-    image: "https://sorobandomains.org/img/logo.png",
+    image:
+      "https://nftcalendar.io/storage/uploads/events/2025/7/MkaASwOL8VA3I5B2iIfCcNGT29vGBp4YZIJgmjzq.jpg",
     description: "Cassio's Soroban username",
     externalUrl: "https://app.sorobandomains.org/domains/cassio.xlm",
     traits: [

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -1,33 +1,64 @@
 import { create } from "zustand";
 
+/**
+ * Represents a trait/attribute of a collectible NFT
+ */
 export interface CollectibleTrait {
+  /** The name of the trait (e.g., "Color", "Rarity") */
   name: string;
+  /** The value of the trait (e.g., "Blue", "Legendary") */
   value: string | number;
 }
 
+/**
+ * Represents a single collectible NFT item
+ */
 export interface Collectible {
+  /** Unique identifier for the collection this collectible belongs to */
   collectionAddress: string;
+  /** Human-readable name of the collection */
   collectionName: string;
+  /** Unique identifier for this specific collectible within the collection */
   tokenId: string;
+  /** Human-readable name of the collectible */
   name: string;
+  /** URL to the collectible's image */
   image: string;
+  /** Detailed description of the collectible */
   description: string;
+  /** External URL for more information about the collectible */
   externalUrl: string;
+  /** Array of traits/attributes that define this collectible */
   traits: CollectibleTrait[];
 }
 
+/**
+ * Represents a collection of collectibles grouped by collection address
+ */
 export interface Collection {
+  /** Unique identifier for the collection */
   collectionAddress: string;
+  /** Human-readable name of the collection */
   collectionName: string;
+  /** Array of collectibles belonging to this collection */
   items: Collectible[];
+  /** Total count of collectibles in this collection */
   count: number;
 }
 
+/**
+ * State interface for the collectibles Zustand store
+ */
 interface CollectiblesState {
+  /** Array of all collectibles */
   collectibles: Collectible[];
+  /** Loading state indicator */
   isLoading: boolean;
+  /** Error message if fetch fails */
   error: string | null;
+  /** Function to fetch collectibles from API */
   fetchCollectibles: () => Promise<void>;
+  /** Function to clear any error state */
   clearError: () => void;
 }
 
@@ -143,11 +174,28 @@ const dummyCollectibles: Collectible[] = [
   },
 ];
 
+/**
+ * Zustand store for managing collectibles state
+ *
+ * Provides state management for:
+ * - Collectibles data
+ * - Loading states
+ * - Error handling
+ * - Data fetching operations
+ */
 export const useCollectiblesStore = create<CollectiblesState>((set) => ({
   collectibles: [],
   isLoading: false,
   error: null,
 
+  /**
+   * Fetches collectibles from the API
+   *
+   * Currently uses dummy data for development/testing.
+   * TODO: Replace with actual API call to fetch real collectibles data.
+   *
+   * @returns {Promise<void>} Promise that resolves when fetch completes
+   */
   fetchCollectibles: async () => {
     set({ isLoading: true, error: null });
 
@@ -173,6 +221,9 @@ export const useCollectiblesStore = create<CollectiblesState>((set) => ({
     }
   },
 
+  /**
+   * Clears any error state from the store
+   */
   clearError: () => {
     set({ error: null });
   },

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -1,0 +1,179 @@
+import { create } from "zustand";
+
+export interface CollectibleTrait {
+  name: string;
+  value: string | number;
+}
+
+export interface Collectible {
+  collectionAddress: string;
+  collectionName: string;
+  tokenId: string;
+  name: string;
+  image: string;
+  description: string;
+  externalUrl: string;
+  traits: CollectibleTrait[];
+}
+
+export interface Collection {
+  collectionAddress: string;
+  collectionName: string;
+  items: Collectible[];
+  count: number;
+}
+
+interface CollectiblesState {
+  collectibles: Collectible[];
+  isLoading: boolean;
+  error: string | null;
+  fetchCollectibles: () => Promise<void>;
+  clearError: () => void;
+}
+
+// Dummy data to test the collectibles UI
+const dummyCollectibles: Collectible[] = [
+  // Stellar Frogs Collection
+  {
+    collectionAddress: "GGGStellarFrogsCollection",
+    collectionName: "Stellar Frogs",
+    tokenId: "1",
+    name: "welcomingfrog.xlm",
+    image:
+      "https://nftcalendar.io/storage/uploads/events/2023/5/NeToOQbYtaJILHMnkigEAsA6ckKYe2GAA4ppAOSp.jpg",
+    description:
+      "A 3D blue and purple frog with a smooth, shiny texture, standing upright with arms outstretched in a friendly, welcoming gesture. The frog is set against a dark, gradient background.",
+    externalUrl: "https://nftcalendar.io/event/hairy-frog/",
+    traits: [
+      { name: "Color", value: "Blue/Purple" },
+      { name: "Texture", value: "Smooth" },
+      { name: "Pose", value: "Outstretched Arms" },
+      { name: "Mood", value: "Welcoming" },
+      { name: "Background", value: "Dark Gradient" },
+    ],
+  },
+  {
+    collectionAddress: "GGGStellarFrogsCollection",
+    collectionName: "Stellar Frogs",
+    tokenId: "2",
+    name: "pepethebot.xlm",
+    image:
+      "https://nftcalendar.io/storage/uploads/2024/06/02/pepe-the-bot_ml4cWknXFrF3K3U1.jpeg",
+    description:
+      "A vibrant green frog with a wide smile, large expressive eyes, and a humanoid posture, set against a dark background. The frog's appearance is reminiscent of the popular Pepe meme.",
+    externalUrl: "https://nftcalendar.io/event/pepe-the-bot/",
+    traits: [
+      { name: "Color", value: "Bright Green" },
+      { name: "Expression", value: "Smiling" },
+      { name: "Eyes", value: "Large" },
+      { name: "Background", value: "Dark" },
+      { name: "Theme", value: "Meme" },
+      { name: "Rarity", value: "Epic" },
+    ],
+  },
+  {
+    collectionAddress: "GGGStellarFrogsCollection",
+    collectionName: "Stellar Frogs",
+    tokenId: "3",
+    name: "princepepe.xlm",
+    image:
+      "https://nftcalendar.io/storage/uploads/events/2023/8/5kFeYwNfhpUST3TsSoLxm7FaGY1ljwLRgfZ5gQnV.jpg",
+    description:
+      "A green frog with a golden crown, red lips, and a blue background, evoking a royal and whimsical appearance.",
+    externalUrl: "https://nftcalendar.io/event/prince-pepe/",
+    traits: [
+      { name: "Color", value: "Green" },
+      { name: "Accessory", value: "Golden Crown" },
+      { name: "Mouth", value: "Red Lips" },
+      { name: "Background", value: "Blue" },
+      { name: "Theme", value: "Royal" },
+      { name: "Rarity", value: "Legendary" },
+    ],
+  },
+  // Soroban Domains Collection
+  {
+    collectionAddress: "GGGSorobanDomainsCollection",
+    collectionName: "Soroban Domains",
+    tokenId: "102510",
+    name: "charles.xlm",
+    image: "https://sorobandomains.org/img/logo.png",
+    description: "Charles' Soroban username",
+    externalUrl: "https://app.sorobandomains.org/domains/charles.xlm",
+    traits: [
+      { name: "Name", value: "charles" },
+      { name: "Length", value: 7 },
+      { name: "Character", value: "Alphanumeric" },
+      { name: "Type", value: "Domain" },
+    ],
+  },
+  {
+    collectionAddress: "GGGSorobanDomainsCollection",
+    collectionName: "Soroban Domains",
+    tokenId: "102589",
+    name: "cassio.xlm",
+    image: "https://sorobandomains.org/img/logo.png",
+    description: "Cassio's Soroban username",
+    externalUrl: "https://app.sorobandomains.org/domains/cassio.xlm",
+    traits: [
+      { name: "Name", value: "cassio" },
+      { name: "Length", value: 6 },
+      { name: "Character", value: "Alphanumeric" },
+      { name: "Type", value: "Domain" },
+    ],
+  },
+  // Future Monkeys Collection
+  {
+    collectionAddress: "GGGFutureMonkeysCollection",
+    collectionName: "Future Monkeys",
+    tokenId: "111",
+    name: "blueauramonkey.xlm",
+    image:
+      "https://nftcalendar.io/storage/uploads/events/2025/3/oUfeUrSj3KcVnjColyfnS5ICYuqzDbiuqQP4qLIz.png",
+    description:
+      "A 3D-rendered blue and purple monkey with a glossy, reflective coat, sitting upright and facing forward. The monkey has large, expressive eyes and is surrounded by a glowing purple aura. The background is a soft, dark gradient that accentuates the vibrant colors of the monkey.",
+    externalUrl: "https://nftcalendar.io/event/future-monkeys/",
+    traits: [
+      { name: "Species", value: "Monkey" },
+      { name: "Color", value: "Blue and Purple" },
+      { name: "Coat", value: "Glossy" },
+      { name: "Aura", value: "Glowing Purple" },
+      { name: "Eyes", value: "Large" },
+      { name: "Background", value: "Soft Dark Gradient" },
+    ],
+  },
+];
+
+export const useCollectiblesStore = create<CollectiblesState>((set) => ({
+  collectibles: [],
+  isLoading: false,
+  error: null,
+
+  fetchCollectibles: async () => {
+    set({ isLoading: true, error: null });
+
+    try {
+      // Simulate API call delay
+      // eslint-disable-next-line no-promise-executor-return
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // For now, return dummy data
+      // TODO: Replace with actual API call
+      set({
+        collectibles: dummyCollectibles,
+        isLoading: false,
+      });
+    } catch (error) {
+      set({
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch collectibles",
+        isLoading: false,
+      });
+    }
+  },
+
+  clearError: () => {
+    set({ error: null });
+  },
+}));

--- a/src/hooks/useCollectibles.ts
+++ b/src/hooks/useCollectibles.ts
@@ -1,11 +1,38 @@
 import { Collection, useCollectiblesStore } from "ducks/collectibles";
 import { useMemo } from "react";
 
+/**
+ * Custom hook for managing and processing collectibles data
+ *
+ * This hook provides:
+ * - Access to collectibles state from the store
+ * - Grouped collections by collection address
+ * - Utility functions for finding specific collections and collectibles
+ * - Memoized data processing for performance optimization
+ *
+ * @returns {Object} Object containing collectibles data, state, and utility functions
+ * @returns {Collectible[]} returns.collectibles - Array of all collectibles
+ * @returns {Collection[]} returns.collections - Collections grouped by address
+ * @returns {boolean} returns.isLoading - Loading state indicator
+ * @returns {string|null} returns.error - Error message if any
+ * @returns {Function} returns.getCollectionByCollectionAddress - Function to find collection by address
+ * @returns {Function} returns.getCollectibleByTokenId - Function to find collectible by token ID
+ * @returns {Function} returns.fetchCollectibles - Function to fetch collectibles data
+ * @returns {Function} returns.clearError - Function to clear error state
+ */
 export const useCollectibles = () => {
   const { collectibles, isLoading, error, fetchCollectibles, clearError } =
     useCollectiblesStore();
 
-  // Group collections by collection address
+  /**
+   * Groups collectibles by collection address into Collection objects
+   *
+   * Each collection contains:
+   * - collectionAddress: The unique identifier for the collection
+   * - collectionName: Human-readable name of the collection
+   * - items: Array of collectibles belonging to this collection
+   * - count: Total number of collectibles in the collection
+   */
   const groupedCollections = useMemo(() => {
     const grouped = collectibles.reduce<Record<string, Collection>>(
       (collections, collectible) => {
@@ -33,7 +60,12 @@ export const useCollectibles = () => {
     return Object.values(grouped);
   }, [collectibles]);
 
-  // Get collection by collection address
+  /**
+   * Utility function to find a collection by its collection address
+   *
+   * @param {string} collectionAddress - The collection address to search for
+   * @returns {Collection|undefined} The found collection or undefined if not found
+   */
   const getCollectionByCollectionAddress = useMemo(
     () => (collectionAddress: string) =>
       groupedCollections.find(
@@ -42,7 +74,12 @@ export const useCollectibles = () => {
     [groupedCollections],
   );
 
-  // Get a specific collectible by token ID
+  /**
+   * Utility function to find a specific collectible by its token ID
+   *
+   * @param {string} tokenId - The token ID to search for
+   * @returns {Collectible|undefined} The found collectible or undefined if not found
+   */
   const getCollectibleByTokenId = useMemo(
     () => (tokenId: string) =>
       collectibles.find((collectible) => collectible.tokenId === tokenId),

--- a/src/hooks/useCollectibles.ts
+++ b/src/hooks/useCollectibles.ts
@@ -1,0 +1,69 @@
+import { Collection, useCollectiblesStore } from "ducks/collectibles";
+import { useMemo } from "react";
+
+export const useCollectibles = () => {
+  const { collectibles, isLoading, error, fetchCollectibles, clearError } =
+    useCollectiblesStore();
+
+  // Group collections by collection address
+  const groupedCollections = useMemo(() => {
+    const grouped = collectibles.reduce<Record<string, Collection>>(
+      (collections, collectible) => {
+        const address = collectible.collectionAddress;
+
+        /* eslint-disable no-param-reassign */
+        if (!collections[address]) {
+          collections[address] = {
+            collectionAddress: collectible.collectionAddress,
+            collectionName: collectible.collectionName,
+            items: [],
+            count: 0,
+          };
+        }
+
+        collections[address].items.push(collectible);
+        collections[address].count += 1;
+        /* eslint-enable no-param-reassign */
+
+        return collections;
+      },
+      {},
+    );
+
+    return Object.values(grouped);
+  }, [collectibles]);
+
+  // Get collection by collection address
+  const getCollectionByCollectionAddress = useMemo(
+    () => (collectionAddress: string) =>
+      groupedCollections.find(
+        (collection) => collection.collectionAddress === collectionAddress,
+      ),
+    [groupedCollections],
+  );
+
+  // Get a specific collectible by token ID
+  const getCollectibleByTokenId = useMemo(
+    () => (tokenId: string) =>
+      collectibles.find((collectible) => collectible.tokenId === tokenId),
+    [collectibles],
+  );
+
+  return {
+    // Data
+    collectibles,
+    collections: groupedCollections,
+
+    // State
+    isLoading,
+    error,
+
+    // Utility functions
+    getCollectionByCollectionAddress,
+    getCollectibleByTokenId,
+
+    // Actions
+    fetchCollectibles,
+    clearError,
+  };
+};

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -315,6 +315,9 @@
       "fundAccountButton": "Add XLM"
     }
   },
+  "collectiblesGrid": {
+    "title": "Collectibles"
+  },
   "friendbotButton": {
     "title": "Fund with Friendbot"
   },

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -318,7 +318,8 @@
   "collectiblesGrid": {
     "title": "Collectibles",
     "error": "Error loading collectibles",
-    "empty": "No collectibles found"
+    "empty": "No collectibles found",
+    "addManually": "Add manually"
   },
   "friendbotButton": {
     "title": "Fund with Friendbot"

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -323,7 +323,7 @@
   "collectiblesGrid": {
     "title": "Collectibles",
     "error": "Error loading collectibles",
-    "empty": "No collectibles found",
+    "empty": "No collectibles yet",
     "addManually": "Add manually"
   },
   "friendbotButton": {

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -316,7 +316,9 @@
     }
   },
   "collectiblesGrid": {
-    "title": "Collectibles"
+    "title": "Collectibles",
+    "error": "Error loading collectibles",
+    "empty": "No collectibles found"
   },
   "friendbotButton": {
     "title": "Fund with Friendbot"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -295,7 +295,8 @@
   "collectiblesGrid": {
     "title": "Colecionáveis",
     "error": "Erro ao carregar colecionáveis",
-    "empty": "Nenhum colecionável encontrado"
+    "empty": "Nenhum colecionável encontrado",
+    "addManually": "Adicionar manualmente"
   },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -292,6 +292,9 @@
       "fundAccountButton": "Adicionar XLM"
     }
   },
+  "collectiblesGrid": {
+    "title": "Colecionáveis"
+  },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"
   },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -293,7 +293,9 @@
     }
   },
   "collectiblesGrid": {
-    "title": "Colecionáveis"
+    "title": "Colecionáveis",
+    "error": "Erro ao carregar colecionáveis",
+    "empty": "Nenhum colecionável encontrado"
   },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -300,7 +300,7 @@
   "collectiblesGrid": {
     "title": "Colecionáveis",
     "error": "Erro ao carregar colecionáveis",
-    "empty": "Nenhum colecionável encontrado",
+    "empty": "Nenhum colecionável ainda",
     "addManually": "Adicionar manualmente"
   },
   "friendbotButton": {


### PR DESCRIPTION
Closes #238 

This PR adds the Collectibles UI for the Home and Send grids.

It is displaying dummy data at the moment, we will connect it to our backend in a separate PR.

<img width="350" height="1084" alt="Screenshot 2025-08-14 at 18 42 31" src="https://github.com/user-attachments/assets/c0adcc80-37b5-4808-aa83-84b68085d93d" />

<img width="350" height="1084" alt="Screenshot 2025-08-14 at 18 42 39" src="https://github.com/user-attachments/assets/80027fb0-63e9-4813-b36e-6571f737e3d5" />

<img width="350" height="957" alt="Screenshot 2025-08-14 at 18 45 10" src="https://github.com/user-attachments/assets/47d75059-43c6-44e7-8411-5a838ccbe2d5" />

<img width="350" height="957" alt="Screenshot 2025-08-14 at 18 45 28" src="https://github.com/user-attachments/assets/3acf3db2-7a01-4d21-9538-2d84793d0a78" />

https://github.com/user-attachments/assets/1c9fdb9e-90d3-4c87-9335-8c9c6e2b9c67


https://github.com/user-attachments/assets/4d04a23b-3504-4e29-9143-19f9df3c21ca
