### PR TITLE
add deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/stellar/freighter-mobile)
+
 ## Quick Start Dev Environment Setup
 
 This guide will help you set up your development environment for Freighter


### PR DESCRIPTION
Adds the deepwiki badge for this repository. See the wiki [here](https://deepwiki.com/stellar/freighter-mobile).