### PR TITLE
[Collectibles] Collectible Details UI

### DIFF
--- a/__tests__/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.test.tsx
+++ b/__tests__/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent } from "@testing-library/react-native";
+import { CollectibleDetailsScreen } from "components/screens/CollectibleDetailsScreen";
+import { renderWithProviders } from "helpers/testUtils";
+import React from "react";
+import { Linking } from "react-native";
+
+// Mock the Linking module
+jest.mock("react-native/Libraries/Linking/Linking", () => ({
+  openURL: jest.fn(),
+}));
+
+// Mock the useCollectibles hook
+jest.mock("hooks/useCollectibles", () => ({
+  useCollectibles: () => ({
+    getCollectible: jest.fn(() => ({
+      collectionAddress: "test-collection",
+      collectionName: "Test Collection",
+      tokenId: "123",
+      name: "Test NFT",
+      image: "https://example.com/image.jpg",
+      description: "A test NFT description",
+      externalUrl: "https://example.com/nft",
+      traits: [
+        { name: "Color", value: "Blue" },
+        { name: "Rarity", value: "Common" },
+      ],
+    })),
+  }),
+}));
+
+// Mock the useAppTranslation hook
+jest.mock("hooks/useAppTranslation", () => ({
+  __esModule: true,
+  default: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock the useColors hook
+jest.mock("hooks/useColors", () => ({
+  __esModule: true,
+  default: () => ({
+    themeColors: {
+      base: ["#000000", "#ffffff"],
+    },
+  }),
+}));
+
+describe("CollectibleDetailsScreen", () => {
+  const mockRoute = {
+    params: {
+      collectionAddress: "test-collection",
+      tokenId: "123",
+    },
+  };
+
+  const mockNavigation = {
+    setOptions: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders collectible details correctly", () => {
+    const { getByText } = renderWithProviders(
+      <CollectibleDetailsScreen
+        route={mockRoute as any}
+        navigation={mockNavigation as any}
+      />,
+    );
+
+    // Check if the collectible name is displayed
+    expect(getByText("Test NFT")).toBeTruthy();
+
+    // Check if the description is displayed
+    expect(getByText("A test NFT description")).toBeTruthy();
+
+    // Check if traits are displayed
+    expect(getByText("Blue")).toBeTruthy();
+    expect(getByText("Common")).toBeTruthy();
+    expect(getByText("Color")).toBeTruthy();
+    expect(getByText("Rarity")).toBeTruthy();
+  });
+
+  it("opens external URL when view button is pressed", () => {
+    const mockOpenURL = Linking.openURL as jest.MockedFunction<
+      typeof Linking.openURL
+    >;
+    mockOpenURL.mockResolvedValue(undefined);
+
+    const { getByText } = renderWithProviders(
+      <CollectibleDetailsScreen
+        route={mockRoute as any}
+        navigation={mockNavigation as any}
+      />,
+    );
+
+    const viewButton = getByText("collectibleDetails.view");
+    fireEvent.press(viewButton);
+
+    expect(mockOpenURL).toHaveBeenCalledWith("https://example.com/nft");
+  });
+
+  it("sets navigation title to collectible name", () => {
+    renderWithProviders(
+      <CollectibleDetailsScreen
+        route={mockRoute as any}
+        navigation={mockNavigation as any}
+      />,
+    );
+
+    expect(mockNavigation.setOptions).toHaveBeenCalledWith({
+      headerTitle: "Test NFT",
+    });
+  });
+});

--- a/__tests__/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.test.tsx
+++ b/__tests__/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.test.tsx
@@ -42,6 +42,12 @@ jest.mock("hooks/useColors", () => ({
   default: () => ({
     themeColors: {
       base: ["#000000", "#ffffff"],
+      text: {
+        secondary: "#666666",
+      },
+      foreground: {
+        primary: "#000000",
+      },
     },
   }),
 }));

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -22,7 +22,13 @@ import {
  */
 interface CollectiblesGridProps {
   /** Callback function triggered when a collectible item is pressed */
-  onCollectiblePress?: (collectibleId: string) => void;
+  onCollectiblePress?: ({
+    collectionAddress,
+    tokenId,
+  }: {
+    collectionAddress: string;
+    tokenId: string;
+  }) => void;
 }
 
 /**
@@ -66,7 +72,12 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
         <TouchableOpacity
           className="w-[165px] h-[165px] rounded-2xl overflow-hidden items-center justify-center mr-6 bg-background-tertiary"
           delayPressIn={DEFAULT_PRESS_DELAY}
-          onPress={() => onCollectiblePress?.(item.tokenId)}
+          onPress={() =>
+            onCollectiblePress?.({
+              collectionAddress: item.collectionAddress,
+              tokenId: item.tokenId,
+            })
+          }
         >
           {/* Placeholder icon for when the image is not loaded */}
           <View className="absolute z-1">

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -48,7 +48,13 @@ interface Props {
   /** Callback function when a token is pressed */
   onTokenPress?: (tokenId: string) => void;
   /** Callback function when a collectible is pressed */
-  onCollectiblePress?: (collectibleId: string) => void;
+  onCollectiblePress?: ({
+    collectionAddress,
+    tokenId,
+  }: {
+    collectionAddress: string;
+    tokenId: string;
+  }) => void;
 }
 
 /**

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -1,0 +1,201 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { List } from "components/List";
+import { BaseLayout } from "components/layout/BaseLayout";
+import { Button } from "components/sds/Button";
+import Icon from "components/sds/Icon";
+import { Text } from "components/sds/Typography";
+import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
+import useAppTranslation from "hooks/useAppTranslation";
+import { useCollectibles } from "hooks/useCollectibles";
+import useColors from "hooks/useColors";
+import React, { useMemo, useLayoutEffect } from "react";
+import { Image, Linking, ScrollView, View } from "react-native";
+
+type CollectibleDetailsScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  typeof ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN
+>;
+
+/**
+ * CollectibleDetailsScreen Component
+ *
+ * Displays detailed information about a specific collectible NFT including:
+ * - Large collectible image
+ * - Basic information (Name, Collection, Token ID)
+ * - Description
+ * - Traits/attributes
+ * - Action buttons (View in browser, Send)
+ *
+ * @param {CollectibleDetailsScreenProps} props - Component props
+ * @returns {JSX.Element} The collectible details screen
+ */
+export const CollectibleDetailsScreen: React.FC<
+  CollectibleDetailsScreenProps
+> = ({ route, navigation }) => {
+  const { collectionAddress, tokenId } = route.params;
+  const { t } = useAppTranslation();
+  const { themeColors } = useColors();
+  const { getCollectible } = useCollectibles();
+
+  const basicInfoTitleColor = themeColors.text.secondary;
+
+  // Get the collectible data
+  const collectible = useMemo(
+    () => getCollectible({ collectionAddress, tokenId }),
+    [getCollectible, collectionAddress, tokenId],
+  );
+
+  // Set the header title to the collectible name
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: collectible?.name || t("collectibleDetails.title"),
+    });
+  }, [navigation, collectible?.name, t]);
+
+  // Handle opening the external URL
+  const handleViewInBrowser = async () => {
+    if (collectible?.externalUrl) {
+      try {
+        await Linking.openURL(collectible.externalUrl);
+      } catch (error) {
+        // Silently handle URL opening errors
+        // In a production app, you might want to show a toast notification
+      }
+    }
+  };
+
+  // If collectible is not found, show error state
+  if (!collectible) {
+    return (
+      <BaseLayout insets={{ top: false }}>
+        <View className="flex-1 items-center justify-center p-4">
+          <View className="mb-3">
+            <Text lg medium>
+              {t("collectibleDetails.notFound")}
+            </Text>
+          </View>
+        </View>
+      </BaseLayout>
+    );
+  }
+
+  // Prepare list items for basic information
+  const basicInfoItems = [
+    {
+      key: "name",
+      title: t("collectibleDetails.name"),
+      titleColor: basicInfoTitleColor,
+      trailingContent: (
+        <Text md medium>
+          {collectible.name}
+        </Text>
+      ),
+    },
+    {
+      key: "collection",
+      title: t("collectibleDetails.collection"),
+      titleColor: basicInfoTitleColor,
+      trailingContent: (
+        <Text md medium>
+          {collectible.collectionName}
+        </Text>
+      ),
+    },
+    {
+      key: "tokenId",
+      title: t("collectibleDetails.tokenId"),
+      titleColor: basicInfoTitleColor,
+      trailingContent: (
+        <Text md medium>
+          {collectible.tokenId}
+        </Text>
+      ),
+    },
+  ];
+
+  return (
+    <BaseLayout insets={{ top: false }}>
+      <ScrollView className="flex-1 mb-7" showsVerticalScrollIndicator={false}>
+        {/* Collectible Image */}
+        <View className="w-[354px] h-[354px] rounded-[32px] overflow-hidden items-center justify-center bg-background-tertiary mt-2 mb-6">
+          {/* Placeholder icon for when the image is not loaded */}
+          <View className="absolute z-1">
+            <Icon.Image01 size={90} color={themeColors.text.secondary} />
+          </View>
+
+          {/* NFT image */}
+          <View className="absolute z-10 w-full h-full">
+            <Image
+              source={{ uri: collectible.image }}
+              className="w-full h-full"
+              resizeMode="cover"
+            />
+          </View>
+        </View>
+
+        {/* Basic Information */}
+        <View className="mb-6">
+          <List items={basicInfoItems} variant="secondary" />
+        </View>
+
+        {/* Description */}
+        <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
+          <View className="mb-3">
+            <Text md medium secondary>
+              {t("collectibleDetails.description")}
+            </Text>
+          </View>
+          <Text md medium>
+            {collectible.description}
+          </Text>
+        </View>
+
+        {/* Collectible Traits */}
+        <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
+          <View className="mb-3">
+            <Text md medium secondary>
+              {t("collectibleDetails.traits")}
+            </Text>
+          </View>
+          <View className="flex-row flex-wrap justify-between">
+            {collectible.traits.map((trait) => (
+              <View
+                key={`${trait.name}-${trait.value}`}
+                className="bg-background-secondary rounded-2xl p-4 w-[48%] mb-3 items-center justify-center"
+              >
+                <Text sm medium textAlign="center">
+                  {trait.value}
+                </Text>
+                <View className="mt-1">
+                  <Text sm secondary textAlign="center">
+                    {trait.name}
+                  </Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {/* Bottom spacing for floating buttons */}
+        <View className="h-10" />
+      </ScrollView>
+
+      <Button
+        tertiary
+        xl
+        isFullWidth
+        icon={
+          <Icon.LinkExternal01
+            size={18}
+            color={themeColors.foreground.primary}
+          />
+        }
+        onPress={handleViewInBrowser}
+      >
+        {t("collectibleDetails.view")}
+      </Button>
+    </BaseLayout>
+  );
+};
+
+export default CollectibleDetailsScreen;

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -205,7 +205,7 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
           </View>
 
           {/* Collectible Traits */}
-          <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
+          <View className="mb-6 bg-background-tertiary rounded-2xl px-4 pt-4 pb-1">
             <View className="mb-3">
               <Text md medium secondary>
                 {t("collectibleDetails.traits")}

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -21,15 +21,39 @@ type CollectibleDetailsScreenProps = NativeStackScreenProps<
 /**
  * CollectibleDetailsScreen Component
  *
- * Displays detailed information about a specific collectible NFT including:
- * - Large collectible image
- * - Basic information (Name, Collection, Token ID)
- * - Description
- * - Traits/attributes
- * - Action buttons (View in browser, Send)
+ * A detailed view screen that displays comprehensive information about a specific NFT collectible.
+ * This screen is navigated to when users tap on a collectible item from the CollectiblesGrid.
+ *
+ * Features:
+ * - Large collectible image display (354x354) with fallback placeholder
+ * - Basic metadata information (Name, Collection, Token ID) in a structured list
+ * - Detailed description section
+ * - Collectible traits/attributes displayed in a 2-column grid layout
+ * - Conditional "View in Browser" button for external URLs
+ * - Responsive layout with proper spacing and typography
+ * - Error handling for missing collectibles
  *
  * @param {CollectibleDetailsScreenProps} props - Component props
- * @returns {JSX.Element} The collectible details screen
+ * @param {Object} props.route - Navigation route object containing collectible parameters
+ * @param {Object} props.route.params - Route parameters
+ * @param {string} props.route.params.collectionAddress - The collection address of the collectible
+ * @param {string} props.route.params.tokenId - The unique token ID of the collectible
+ * @param {Object} props.navigation - Navigation object for header configuration
+ *
+ * @returns {JSX.Element} The collectible details screen component
+ *
+ * @example
+ * ```tsx
+ * <CollectibleDetailsScreen
+ *   route={{
+ *     params: {
+ *       collectionAddress: "collection123",
+ *       tokenId: "token456"
+ *     }
+ *   }}
+ *   navigation={navigation}
+ * />
+ * ```
  */
 export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
   React.memo(({ route, navigation }) => {
@@ -40,13 +64,20 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
 
     const basicInfoTitleColor = themeColors.text.secondary;
 
-    // Get the collectible data
+    /**
+     * Retrieves the collectible data based on collection address and token ID.
+     * Memoized to prevent unnecessary re-fetching on re-renders.
+     */
     const collectible = useMemo(
       () => getCollectible({ collectionAddress, tokenId }),
       [getCollectible, collectionAddress, tokenId],
     );
 
-    // Prepare list items for basic information
+    /**
+     * Prepares the list items for displaying basic collectible information.
+     * Each item contains a title, title color, and trailing content (value).
+     * Memoized to prevent unnecessary recreation of the array on re-renders.
+     */
     const basicInfoItems = useMemo(
       () => [
         {
@@ -89,15 +120,22 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
       ],
     );
 
-    // TODO: add settings right header button
-    // Set the header title to the collectible name
+    /**
+     * Sets the navigation header title to the collectible name.
+     * Falls back to a default title if the collectible name is not available.
+     */
     useLayoutEffect(() => {
       navigation.setOptions({
         headerTitle: collectible?.name || t("collectibleDetails.title"),
       });
     }, [navigation, collectible?.name, t]);
 
-    // Handle opening the external URL
+    /**
+     * Handles opening the collectible's external URL in the device's default browser.
+     * Includes error logging for debugging purposes.
+     *
+     * @param {string} url - The external URL to open
+     */
     const handleViewInBrowser = useCallback(async (url: string) => {
       try {
         await Linking.openURL(url);

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -4,11 +4,13 @@ import { BaseLayout } from "components/layout/BaseLayout";
 import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
+import { logger } from "config/logger";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
+import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useCollectibles } from "hooks/useCollectibles";
 import useColors from "hooks/useColors";
-import React, { useMemo, useLayoutEffect } from "react";
+import React, { useMemo, useLayoutEffect, useCallback } from "react";
 import { Image, Linking, ScrollView, View } from "react-native";
 
 type CollectibleDetailsScreenProps = NativeStackScreenProps<
@@ -29,173 +31,194 @@ type CollectibleDetailsScreenProps = NativeStackScreenProps<
  * @param {CollectibleDetailsScreenProps} props - Component props
  * @returns {JSX.Element} The collectible details screen
  */
-export const CollectibleDetailsScreen: React.FC<
-  CollectibleDetailsScreenProps
-> = ({ route, navigation }) => {
-  const { collectionAddress, tokenId } = route.params;
-  const { t } = useAppTranslation();
-  const { themeColors } = useColors();
-  const { getCollectible } = useCollectibles();
+export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
+  React.memo(({ route, navigation }) => {
+    const { collectionAddress, tokenId } = route.params;
+    const { t } = useAppTranslation();
+    const { themeColors } = useColors();
+    const { getCollectible } = useCollectibles();
 
-  const basicInfoTitleColor = themeColors.text.secondary;
+    const basicInfoTitleColor = themeColors.text.secondary;
 
-  // Get the collectible data
-  const collectible = useMemo(
-    () => getCollectible({ collectionAddress, tokenId }),
-    [getCollectible, collectionAddress, tokenId],
-  );
+    // Get the collectible data
+    const collectible = useMemo(
+      () => getCollectible({ collectionAddress, tokenId }),
+      [getCollectible, collectionAddress, tokenId],
+    );
 
-  // Set the header title to the collectible name
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerTitle: collectible?.name || t("collectibleDetails.title"),
-    });
-  }, [navigation, collectible?.name, t]);
+    // Prepare list items for basic information
+    const basicInfoItems = useMemo(
+      () => [
+        {
+          key: "name",
+          title: t("collectibleDetails.name"),
+          titleColor: basicInfoTitleColor,
+          trailingContent: (
+            <Text md medium>
+              {collectible?.name}
+            </Text>
+          ),
+        },
+        {
+          key: "collection",
+          title: t("collectibleDetails.collection"),
+          titleColor: basicInfoTitleColor,
+          trailingContent: (
+            <Text md medium>
+              {collectible?.collectionName}
+            </Text>
+          ),
+        },
+        {
+          key: "tokenId",
+          title: t("collectibleDetails.tokenId"),
+          titleColor: basicInfoTitleColor,
+          trailingContent: (
+            <Text md medium>
+              {collectible?.tokenId}
+            </Text>
+          ),
+        },
+      ],
+      [
+        t,
+        basicInfoTitleColor,
+        collectible?.name,
+        collectible?.collectionName,
+        collectible?.tokenId,
+      ],
+    );
 
-  // Handle opening the external URL
-  const handleViewInBrowser = async () => {
-    if (collectible?.externalUrl) {
+    // TODO: add settings right header button
+    // Set the header title to the collectible name
+    useLayoutEffect(() => {
+      navigation.setOptions({
+        headerTitle: collectible?.name || t("collectibleDetails.title"),
+      });
+    }, [navigation, collectible?.name, t]);
+
+    // Handle opening the external URL
+    const handleViewInBrowser = useCallback(async (url: string) => {
       try {
-        await Linking.openURL(collectible.externalUrl);
+        await Linking.openURL(url);
       } catch (error) {
-        // Silently handle URL opening errors
-        // In a production app, you might want to show a toast notification
+        logger.error(
+          "CollectibleDetailsScreen",
+          "Failed to open externalUrl in browser:",
+          error,
+        );
       }
-    }
-  };
+    }, []);
 
-  // If collectible is not found, show error state
-  if (!collectible) {
+    // TODO: review this
+    // If collectible is not found, show error state
+    if (!collectible) {
+      return (
+        <BaseLayout insets={{ top: false }}>
+          <View className="flex-1 items-center justify-center p-4">
+            <View className="mb-3">
+              <Text lg medium>
+                {t("collectibleDetails.notFound")}
+              </Text>
+            </View>
+          </View>
+        </BaseLayout>
+      );
+    }
+
     return (
-      <BaseLayout insets={{ top: false }}>
-        <View className="flex-1 items-center justify-center p-4">
-          <View className="mb-3">
-            <Text lg medium>
-              {t("collectibleDetails.notFound")}
+      <BaseLayout
+        insets={{ top: false, bottom: Boolean(collectible?.externalUrl) }}
+      >
+        <ScrollView
+          className="flex-1"
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingBottom: pxValue(40) }}
+        >
+          {/* Collectible Image */}
+          <View className="w-[354px] h-[354px] rounded-[32px] overflow-hidden items-center justify-center bg-background-tertiary mt-2 mb-6">
+            {/* Placeholder icon for when the image is not loaded */}
+            <View className="absolute z-1">
+              <Icon.Image01 size={90} color={themeColors.text.secondary} />
+            </View>
+
+            {/* NFT image */}
+            <View className="absolute z-10 w-full h-full">
+              <Image
+                source={{ uri: collectible.image }}
+                className="w-full h-full"
+                resizeMode="cover"
+              />
+            </View>
+          </View>
+
+          {/* Basic Information */}
+          <View className="mb-6">
+            <List items={basicInfoItems} variant="secondary" />
+          </View>
+
+          {/* Description */}
+          <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
+            <View className="mb-3">
+              <Text md medium secondary>
+                {t("collectibleDetails.description")}
+              </Text>
+            </View>
+            <Text md medium>
+              {collectible.description}
             </Text>
           </View>
-        </View>
+
+          {/* Collectible Traits */}
+          <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
+            <View className="mb-3">
+              <Text md medium secondary>
+                {t("collectibleDetails.traits")}
+              </Text>
+            </View>
+            <View className="flex-row flex-wrap justify-between">
+              {collectible.traits.map((trait) => (
+                <View
+                  key={`${trait.name}-${trait.value}`}
+                  className="bg-background-secondary rounded-2xl p-4 w-[48%] mb-3 items-center justify-center"
+                >
+                  <Text sm medium textAlign="center">
+                    {trait.value}
+                  </Text>
+                  <View className="mt-1">
+                    <Text sm secondary textAlign="center">
+                      {trait.name}
+                    </Text>
+                  </View>
+                </View>
+              ))}
+            </View>
+          </View>
+        </ScrollView>
+
+        {/* View in browser button */}
+        {collectible?.externalUrl && (
+          <View className="mt-7">
+            <Button
+              tertiary
+              xl
+              isFullWidth
+              icon={
+                <Icon.LinkExternal01
+                  size={18}
+                  color={themeColors.foreground.primary}
+                />
+              }
+              onPress={() => handleViewInBrowser(collectible?.externalUrl)}
+            >
+              {t("collectibleDetails.view")}
+            </Button>
+          </View>
+        )}
       </BaseLayout>
     );
-  }
+  });
 
-  // Prepare list items for basic information
-  const basicInfoItems = [
-    {
-      key: "name",
-      title: t("collectibleDetails.name"),
-      titleColor: basicInfoTitleColor,
-      trailingContent: (
-        <Text md medium>
-          {collectible.name}
-        </Text>
-      ),
-    },
-    {
-      key: "collection",
-      title: t("collectibleDetails.collection"),
-      titleColor: basicInfoTitleColor,
-      trailingContent: (
-        <Text md medium>
-          {collectible.collectionName}
-        </Text>
-      ),
-    },
-    {
-      key: "tokenId",
-      title: t("collectibleDetails.tokenId"),
-      titleColor: basicInfoTitleColor,
-      trailingContent: (
-        <Text md medium>
-          {collectible.tokenId}
-        </Text>
-      ),
-    },
-  ];
-
-  return (
-    <BaseLayout insets={{ top: false }}>
-      <ScrollView className="flex-1 mb-7" showsVerticalScrollIndicator={false}>
-        {/* Collectible Image */}
-        <View className="w-[354px] h-[354px] rounded-[32px] overflow-hidden items-center justify-center bg-background-tertiary mt-2 mb-6">
-          {/* Placeholder icon for when the image is not loaded */}
-          <View className="absolute z-1">
-            <Icon.Image01 size={90} color={themeColors.text.secondary} />
-          </View>
-
-          {/* NFT image */}
-          <View className="absolute z-10 w-full h-full">
-            <Image
-              source={{ uri: collectible.image }}
-              className="w-full h-full"
-              resizeMode="cover"
-            />
-          </View>
-        </View>
-
-        {/* Basic Information */}
-        <View className="mb-6">
-          <List items={basicInfoItems} variant="secondary" />
-        </View>
-
-        {/* Description */}
-        <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
-          <View className="mb-3">
-            <Text md medium secondary>
-              {t("collectibleDetails.description")}
-            </Text>
-          </View>
-          <Text md medium>
-            {collectible.description}
-          </Text>
-        </View>
-
-        {/* Collectible Traits */}
-        <View className="mb-6 bg-background-tertiary rounded-2xl p-4">
-          <View className="mb-3">
-            <Text md medium secondary>
-              {t("collectibleDetails.traits")}
-            </Text>
-          </View>
-          <View className="flex-row flex-wrap justify-between">
-            {collectible.traits.map((trait) => (
-              <View
-                key={`${trait.name}-${trait.value}`}
-                className="bg-background-secondary rounded-2xl p-4 w-[48%] mb-3 items-center justify-center"
-              >
-                <Text sm medium textAlign="center">
-                  {trait.value}
-                </Text>
-                <View className="mt-1">
-                  <Text sm secondary textAlign="center">
-                    {trait.name}
-                  </Text>
-                </View>
-              </View>
-            ))}
-          </View>
-        </View>
-
-        {/* Bottom spacing for floating buttons */}
-        <View className="h-10" />
-      </ScrollView>
-
-      <Button
-        tertiary
-        xl
-        isFullWidth
-        icon={
-          <Icon.LinkExternal01
-            size={18}
-            color={themeColors.foreground.primary}
-          />
-        }
-        onPress={handleViewInBrowser}
-      >
-        {t("collectibleDetails.view")}
-      </Button>
-    </BaseLayout>
-  );
-};
+CollectibleDetailsScreen.displayName = "CollectibleDetailsScreen";
 
 export default CollectibleDetailsScreen;

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -110,17 +110,14 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
       }
     }, []);
 
-    // TODO: review this
     // If collectible is not found, show error state
     if (!collectible) {
       return (
         <BaseLayout insets={{ top: false }}>
           <View className="flex-1 items-center justify-center p-4">
-            <View className="mb-3">
-              <Text lg medium>
-                {t("collectibleDetails.notFound")}
-              </Text>
-            </View>
+            <Text lg medium secondary>
+              {t("collectibleDetails.notFound")}
+            </Text>
           </View>
         </BaseLayout>
       );

--- a/src/components/screens/CollectibleDetailsScreen/index.ts
+++ b/src/components/screens/CollectibleDetailsScreen/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CollectibleDetailsScreen";
+export { CollectibleDetailsScreen } from "./CollectibleDetailsScreen";

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -45,6 +45,7 @@ type HomeScreenProps = BottomTabScreenProps<
 /**
  * Home screen component displaying account information and balances
  */
+// TODO: memoize Home functions
 export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const { account } = useGetActiveAccount();
   const { network, getAllAccounts, allAccounts } = useAuthenticationStore();
@@ -124,6 +125,19 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
     navigation.navigate(ROOT_NAVIGATOR_ROUTES.TOKEN_DETAILS_SCREEN, {
       tokenId,
       tokenSymbol,
+    });
+  };
+
+  const handleCollectiblePress = ({
+    collectionAddress,
+    tokenId,
+  }: {
+    collectionAddress: string;
+    tokenId: string;
+  }) => {
+    navigation.navigate(ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN, {
+      collectionAddress,
+      tokenId,
     });
   };
 
@@ -212,6 +226,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         publicKey={account?.publicKey ?? ""}
         network={network}
         onTokenPress={handleTokenPress}
+        onCollectiblePress={handleCollectiblePress}
       />
 
       {/* Analytics Debug - Development Only */}

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -45,200 +45,219 @@ type HomeScreenProps = BottomTabScreenProps<
 /**
  * Home screen component displaying account information and balances
  */
-// TODO: memoize Home functions
-export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
-  const { account } = useGetActiveAccount();
-  const { network, getAllAccounts, allAccounts } = useAuthenticationStore();
-  const { themeColors } = useColors();
-  const manageAccountsBottomSheetRef = useRef<BottomSheetModal>(null);
-  const analyticsDebugBottomSheetRef = useRef<BottomSheetModal>(null);
+export const HomeScreen: React.FC<HomeScreenProps> = React.memo(
+  ({ navigation }) => {
+    const { account } = useGetActiveAccount();
+    const { network, getAllAccounts, allAccounts } = useAuthenticationStore();
+    const { themeColors } = useColors();
+    const manageAccountsBottomSheetRef = useRef<BottomSheetModal>(null);
+    const analyticsDebugBottomSheetRef = useRef<BottomSheetModal>(null);
 
-  const { t } = useAppTranslation();
-  const { copyToClipboard } = useClipboard();
+    const { t } = useAppTranslation();
+    const { copyToClipboard } = useClipboard();
 
-  const { formattedBalance, rawBalance } = useTotalBalance();
-  const {
-    balances,
-    isFunded,
-    isLoading: isLoadingBalances,
-  } = useBalancesStore();
-
-  const hasTokens = useMemo(() => Object.keys(balances).length > 0, [balances]);
-  const hasZeroBalance = useMemo(
-    () => rawBalance?.isLessThanOrEqualTo(0) ?? true,
-    [rawBalance],
-  );
-
-  // Set up navigation headers (hook handles navigation.setOptions internally)
-  useHomeHeaders({ navigation });
-
-  const { welcomeBannerBottomSheetModalRef, handleWelcomeBannerDismiss } =
-    useWelcomeBanner({
-      account,
+    const { formattedBalance, rawBalance } = useTotalBalance();
+    const {
+      balances,
       isFunded,
-      isLoadingBalances,
-    });
+      isLoading: isLoadingBalances,
+    } = useBalancesStore();
 
-  // NOTE: VIEW_HOME analytics event is already tracked by useNavigationAnalytics
-  // when the user navigates to this screen. No need for additional tracking here.
+    const hasTokens = useMemo(
+      () => Object.keys(balances).length > 0,
+      [balances],
+    );
+    const hasZeroBalance = useMemo(
+      () => rawBalance?.isLessThanOrEqualTo(0) ?? true,
+      [rawBalance],
+    );
 
-  useEffect(() => {
-    const fetchAccounts = async () => {
-      await getAllAccounts();
-    };
+    // Set up navigation headers (hook handles navigation.setOptions internally)
+    useHomeHeaders({ navigation });
 
-    fetchAccounts();
-  }, [getAllAccounts]);
+    const { welcomeBannerBottomSheetModalRef, handleWelcomeBannerDismiss } =
+      useWelcomeBanner({
+        account,
+        isFunded,
+        isLoadingBalances,
+      });
 
-  const navigateToBuyXLM = useCallback(() => {
-    // Navigation analytics already tracked by useNavigationAnalytics
-    navigation.navigate(ROOT_NAVIGATOR_ROUTES.BUY_XLM_STACK, {
-      screen: BUY_XLM_ROUTES.BUY_XLM_SCREEN,
-      params: { isUnfunded: !isFunded },
-    });
-  }, [navigation, isFunded]);
+    // NOTE: VIEW_HOME analytics event is already tracked by useNavigationAnalytics
+    // when the user navigates to this screen. No need for additional tracking here.
 
-  const handleCopyAddress = (publicKey?: string) => {
-    if (!publicKey) return;
+    useEffect(() => {
+      const fetchAccounts = async () => {
+        await getAllAccounts();
+      };
 
-    analytics.trackCopyPublicKey();
+      fetchAccounts();
+    }, [getAllAccounts]);
 
-    copyToClipboard(publicKey, {
-      notificationMessage: t("accountAddressCopied"),
-    });
-  };
+    const navigateToBuyXLM = useCallback(() => {
+      // Navigation analytics already tracked by useNavigationAnalytics
+      navigation.navigate(ROOT_NAVIGATOR_ROUTES.BUY_XLM_STACK, {
+        screen: BUY_XLM_ROUTES.BUY_XLM_SCREEN,
+        params: { isUnfunded: !isFunded },
+      });
+    }, [navigation, isFunded]);
 
-  const handleTokenPress = (tokenId: string) => {
-    let tokenSymbol: string;
+    const handleCopyAddress = useCallback(
+      (publicKey?: string) => {
+        if (!publicKey) return;
 
-    if (tokenId === "native") {
-      tokenSymbol = NATIVE_TOKEN_CODE;
-    } else if (isContractId(tokenId)) {
-      // For Soroban contracts, pass the contract ID as symbol initially
-      // The TokenDetailsScreen will handle fetching the actual symbol
-      tokenSymbol = tokenId;
-    } else {
-      // Classic asset format: CODE:ISSUER
-      [tokenSymbol] = tokenId.split(":");
-    }
+        analytics.trackCopyPublicKey();
 
-    navigation.navigate(ROOT_NAVIGATOR_ROUTES.TOKEN_DETAILS_SCREEN, {
-      tokenId,
-      tokenSymbol,
-    });
-  };
+        copyToClipboard(publicKey, {
+          notificationMessage: t("accountAddressCopied"),
+        });
+      },
+      [copyToClipboard, t],
+    );
 
-  const handleCollectiblePress = ({
-    collectionAddress,
-    tokenId,
-  }: {
-    collectionAddress: string;
-    tokenId: string;
-  }) => {
-    navigation.navigate(ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN, {
-      collectionAddress,
-      tokenId,
-    });
-  };
+    const handleTokenPress = useCallback(
+      (tokenId: string) => {
+        let tokenSymbol: string;
 
-  const handleSendPress = () => {
-    navigation.navigate(ROOT_NAVIGATOR_ROUTES.SEND_PAYMENT_STACK, {
-      screen: SEND_PAYMENT_ROUTES.SEND_SEARCH_CONTACTS_SCREEN,
-      params: { tokenId: undefined },
-    });
-  };
+        if (tokenId === "native") {
+          tokenSymbol = NATIVE_TOKEN_CODE;
+        } else if (isContractId(tokenId)) {
+          // For Soroban contracts, pass the contract ID as symbol initially
+          // The TokenDetailsScreen will handle fetching the actual symbol
+          tokenSymbol = tokenId;
+        } else {
+          // Classic asset format: CODE:ISSUER
+          [tokenSymbol] = tokenId.split(":");
+        }
 
-  const handleSwapPress = () => {
-    navigation.navigate(ROOT_NAVIGATOR_ROUTES.SWAP_STACK, {
-      screen: SWAP_ROUTES.SWAP_SCREEN,
-    });
-  };
+        navigation.navigate(ROOT_NAVIGATOR_ROUTES.TOKEN_DETAILS_SCREEN, {
+          tokenId,
+          tokenSymbol,
+        });
+      },
+      [navigation],
+    );
 
-  return (
-    <BaseLayout
-      insets={{ bottom: false, top: false, left: false, right: false }}
-    >
-      <WelcomeBannerBottomSheet
-        modalRef={welcomeBannerBottomSheetModalRef}
-        onAddXLM={navigateToBuyXLM}
-        onDismiss={() => {
-          handleWelcomeBannerDismiss();
-        }}
-      />
-      <ManageAccounts
-        navigation={navigation}
-        accounts={allAccounts}
-        activeAccount={account}
-        bottomSheetRef={manageAccountsBottomSheetRef}
-      />
+    const handleCollectiblePress = useCallback(
+      ({
+        collectionAddress,
+        tokenId,
+      }: {
+        collectionAddress: string;
+        tokenId: string;
+      }) => {
+        navigation.navigate(ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN, {
+          collectionAddress,
+          tokenId,
+        });
+      },
+      [navigation],
+    );
 
-      <View className="pt-8 w-full items-center">
-        <View className="flex-col gap-3 items-center">
-          <TouchableOpacity
-            onPress={() => {
-              manageAccountsBottomSheetRef.current?.present();
-            }}
-          >
-            <View className="flex-row items-center gap-2">
-              <Avatar size="sm" publicAddress={account?.publicKey ?? ""} />
-              <Text>{account?.accountName ?? t("home.title")}</Text>
-              <Icon.ChevronDown
-                size={16}
-                color={themeColors.foreground.primary}
-              />
-            </View>
-          </TouchableOpacity>
-          <Display lg medium>
-            {formattedBalance}
-          </Display>
+    const handleSendPress = useCallback(() => {
+      navigation.navigate(ROOT_NAVIGATOR_ROUTES.SEND_PAYMENT_STACK, {
+        screen: SEND_PAYMENT_ROUTES.SEND_SEARCH_CONTACTS_SCREEN,
+        params: { tokenId: undefined },
+      });
+    }, [navigation]);
+
+    const handleSwapPress = useCallback(() => {
+      navigation.navigate(ROOT_NAVIGATOR_ROUTES.SWAP_STACK, {
+        screen: SWAP_ROUTES.SWAP_SCREEN,
+      });
+    }, [navigation]);
+
+    const handleManageAccountsPress = useCallback(() => {
+      manageAccountsBottomSheetRef.current?.present();
+    }, []);
+
+    const handleAnalyticsDebugPress = useCallback(() => {
+      analyticsDebugBottomSheetRef.current?.present();
+    }, []);
+
+    const handleAnalyticsDebugDismiss = useCallback(() => {
+      analyticsDebugBottomSheetRef.current?.dismiss();
+    }, []);
+
+    return (
+      <BaseLayout
+        insets={{ bottom: false, top: false, left: false, right: false }}
+      >
+        <WelcomeBannerBottomSheet
+          modalRef={welcomeBannerBottomSheetModalRef}
+          onAddXLM={navigateToBuyXLM}
+          onDismiss={handleWelcomeBannerDismiss}
+        />
+        <ManageAccounts
+          navigation={navigation}
+          accounts={allAccounts}
+          activeAccount={account}
+          bottomSheetRef={manageAccountsBottomSheetRef}
+        />
+
+        <View className="pt-8 w-full items-center">
+          <View className="flex-col gap-3 items-center">
+            <TouchableOpacity onPress={handleManageAccountsPress}>
+              <View className="flex-row items-center gap-2">
+                <Avatar size="sm" publicAddress={account?.publicKey ?? ""} />
+                <Text>{account?.accountName ?? t("home.title")}</Text>
+                <Icon.ChevronDown
+                  size={16}
+                  color={themeColors.foreground.primary}
+                />
+              </View>
+            </TouchableOpacity>
+            <Display lg medium>
+              {formattedBalance}
+            </Display>
+          </View>
+
+          <View className="flex-row gap-6 items-center justify-center my-8">
+            <IconButton
+              Icon={Icon.Plus}
+              title={t("home.buy")}
+              onPress={navigateToBuyXLM}
+            />
+            <IconButton
+              Icon={Icon.ArrowUp}
+              title={t("home.send")}
+              disabled={hasZeroBalance}
+              onPress={handleSendPress}
+            />
+            <IconButton
+              Icon={Icon.RefreshCw02}
+              title={t("home.swap")}
+              disabled={hasZeroBalance}
+              onPress={handleSwapPress}
+            />
+            <IconButton
+              Icon={Icon.Copy01}
+              title={t("home.copy")}
+              onPress={() => handleCopyAddress(account?.publicKey)}
+            />
+          </View>
         </View>
 
-        <View className="flex-row gap-6 items-center justify-center my-8">
-          <IconButton
-            Icon={Icon.Plus}
-            title={t("home.buy")}
-            onPress={navigateToBuyXLM}
-          />
-          <IconButton
-            Icon={Icon.ArrowUp}
-            title={t("home.send")}
-            disabled={hasZeroBalance}
-            onPress={handleSendPress}
-          />
-          <IconButton
-            Icon={Icon.RefreshCw02}
-            title={t("home.swap")}
-            disabled={hasZeroBalance}
-            onPress={handleSwapPress}
-          />
-          <IconButton
-            Icon={Icon.Copy01}
-            title={t("home.copy")}
-            onPress={() => handleCopyAddress(account?.publicKey)}
-          />
-        </View>
-      </View>
+        <View className="w-full border-b mb-4 border-border-primary" />
 
-      <View className="w-full border-b mb-4 border-border-primary" />
+        <TokensCollectiblesTabs
+          showTokensSettings={hasTokens}
+          publicKey={account?.publicKey ?? ""}
+          network={network}
+          onTokenPress={handleTokenPress}
+          onCollectiblePress={handleCollectiblePress}
+        />
 
-      <TokensCollectiblesTabs
-        showTokensSettings={hasTokens}
-        publicKey={account?.publicKey ?? ""}
-        network={network}
-        onTokenPress={handleTokenPress}
-        onCollectiblePress={handleCollectiblePress}
-      />
+        {/* Analytics Debug - Development Only */}
+        <AnalyticsDebugBottomSheet
+          modalRef={analyticsDebugBottomSheetRef}
+          onDismiss={handleAnalyticsDebugDismiss}
+        />
+        <AnalyticsDebugTrigger onPress={handleAnalyticsDebugPress} />
+      </BaseLayout>
+    );
+  },
+);
 
-      {/* Analytics Debug - Development Only */}
-      <AnalyticsDebugBottomSheet
-        modalRef={analyticsDebugBottomSheetRef}
-        onDismiss={() => analyticsDebugBottomSheetRef.current?.dismiss()}
-      />
-      <AnalyticsDebugTrigger
-        onPress={() => analyticsDebugBottomSheetRef.current?.present()}
-      />
-    </BaseLayout>
-  );
-};
+HomeScreen.displayName = "HomeScreen";
 
 export default HomeScreen;

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -41,6 +41,7 @@ export const ROOT_NAVIGATOR_ROUTES = {
   SCAN_QR_CODE_SCREEN: "ScanQRCodeScreen",
   CONNECTED_APPS_SCREEN: "ConnectedAppsScreen",
   TOKEN_DETAILS_SCREEN: "TokenDetailsScreen",
+  COLLECTIBLE_DETAILS_SCREEN: "CollectibleDetailsScreen",
 } as const;
 
 export const AUTH_STACK_ROUTES = {
@@ -146,6 +147,10 @@ export type RootStackParamList = {
   [ROOT_NAVIGATOR_ROUTES.TOKEN_DETAILS_SCREEN]: {
     tokenId: string;
     tokenSymbol: string;
+  };
+  [ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN]: {
+    collectionAddress: string;
+    tokenId: string;
   };
 };
 

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -129,13 +129,12 @@ const dummyCollectibles: Collectible[] = [
     name: "charles.xlm",
     image:
       "https://nftcalendar.io/storage/uploads/events/2025/7/Hdqv6YNVErVCmYlwobFVYfS5BiH19ferUgQova7Z.webp",
-    description: "Charles' Soroban username",
+    description: "The protocol to register your Soroban username",
     externalUrl: "https://app.sorobandomains.org/domains/charles.xlm",
     traits: [
       { name: "Name", value: "charles" },
       { name: "Length", value: 7 },
       { name: "Character", value: "Alphanumeric" },
-      { name: "Type", value: "Domain" },
     ],
   },
   {
@@ -143,8 +142,8 @@ const dummyCollectibles: Collectible[] = [
     collectionName: "Soroban Domains",
     tokenId: "102589",
     name: "cassio.xlm",
-    image:
-      "https://nftcalendar.io/storage/uploads/events/2025/7/MkaASwOL8VA3I5B2iIfCcNGT29vGBp4YZIJgmjzq.jpg",
+    // image:
+    //   "https://nftcalendar.io/storage/uploads/events/2025/7/MkaASwOL8VA3I5B2iIfCcNGT29vGBp4YZIJgmjzq.jpg",
     description: "Cassio's Soroban username",
     externalUrl: "https://app.sorobandomains.org/domains/cassio.xlm",
     traits: [

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -142,8 +142,8 @@ const dummyCollectibles: Collectible[] = [
     collectionName: "Soroban Domains",
     tokenId: "102589",
     name: "cassio.xlm",
-    // image:
-    //   "https://nftcalendar.io/storage/uploads/events/2025/7/MkaASwOL8VA3I5B2iIfCcNGT29vGBp4YZIJgmjzq.jpg",
+    image:
+      "https://nftcalendar.io/storage/uploads/events/2025/7/MkaASwOL8VA3I5B2iIfCcNGT29vGBp4YZIJgmjzq.jpg",
     description: "Cassio's Soroban username",
     externalUrl: "https://app.sorobandomains.org/domains/cassio.xlm",
     traits: [

--- a/src/hooks/useCollectibles.ts
+++ b/src/hooks/useCollectibles.ts
@@ -16,7 +16,7 @@ import { useMemo } from "react";
  * @returns {boolean} returns.isLoading - Loading state indicator
  * @returns {string|null} returns.error - Error message if any
  * @returns {Function} returns.getCollectionByCollectionAddress - Function to find collection by address
- * @returns {Function} returns.getCollectibleByTokenId - Function to find collectible by token ID
+ * @returns {Function} returns.getCollectible - Function to find collectible by collection address and token ID
  * @returns {Function} returns.fetchCollectibles - Function to fetch collectibles data
  * @returns {Function} returns.clearError - Function to clear error state
  */
@@ -66,7 +66,7 @@ export const useCollectibles = () => {
    * @param {string} collectionAddress - The collection address to search for
    * @returns {Collection|undefined} The found collection or undefined if not found
    */
-  const getCollectionByCollectionAddress = useMemo(
+  const getCollection = useMemo(
     () => (collectionAddress: string) =>
       groupedCollections.find(
         (collection) => collection.collectionAddress === collectionAddress,
@@ -75,14 +75,27 @@ export const useCollectibles = () => {
   );
 
   /**
-   * Utility function to find a specific collectible by its token ID
+   * Utility function to find a specific collectible by its collection address and token ID
    *
-   * @param {string} tokenId - The token ID to search for
+   * @param {Object} params - The parameters object
+   * @param {string} params.collectionAddress - The collection address to search for
+   * @param {string} params.tokenId - The token ID to search for
    * @returns {Collectible|undefined} The found collectible or undefined if not found
    */
-  const getCollectibleByTokenId = useMemo(
-    () => (tokenId: string) =>
-      collectibles.find((collectible) => collectible.tokenId === tokenId),
+  const getCollectible = useMemo(
+    () =>
+      ({
+        collectionAddress,
+        tokenId,
+      }: {
+        collectionAddress: string;
+        tokenId: string;
+      }) =>
+        collectibles.find(
+          (collectible) =>
+            collectible.collectionAddress === collectionAddress &&
+            collectible.tokenId === tokenId,
+        ),
     [collectibles],
   );
 
@@ -96,8 +109,8 @@ export const useCollectibles = () => {
     error,
 
     // Utility functions
-    getCollectionByCollectionAddress,
-    getCollectibleByTokenId,
+    getCollection,
+    getCollectible,
 
     // Actions
     fetchCollectibles,

--- a/src/hooks/useWelcomeBanner.ts
+++ b/src/hooks/useWelcomeBanner.ts
@@ -3,7 +3,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { STORAGE_KEYS } from "config/constants";
 import { logger } from "config/logger";
 import { ActiveAccount } from "ducks/auth";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface UseWelcomeBannerProps {
   account: ActiveAccount | null;
@@ -13,7 +13,7 @@ interface UseWelcomeBannerProps {
 
 interface UseWelcomeBannerReturn {
   welcomeBannerBottomSheetModalRef: React.RefObject<BottomSheetModal | null>;
-  handleWelcomeBannerDismiss: () => Promise<void>;
+  handleWelcomeBannerDismiss: () => void;
 }
 
 const getWelcomeBannerShownKey = (publicKey: string) =>
@@ -29,17 +29,24 @@ export const useWelcomeBanner = ({
     boolean | undefined
   >(undefined);
 
+  // Memoize the storage key to avoid recreating it on every render
+  const welcomeBannerShownKey = useMemo(
+    () =>
+      account?.publicKey ? getWelcomeBannerShownKey(account.publicKey) : null,
+    [account?.publicKey],
+  );
+
   useEffect(() => {
     const checkWelcomeBannerStatus = async () => {
-      if (account?.publicKey) {
+      if (welcomeBannerShownKey) {
         const hasSeenWelcome = await AsyncStorage.getItem(
-          getWelcomeBannerShownKey(account.publicKey),
+          welcomeBannerShownKey,
         );
         setHasAccountSeenWelcome(hasSeenWelcome === "true");
       }
     };
     checkWelcomeBannerStatus();
-  }, [account?.publicKey]);
+  }, [welcomeBannerShownKey]);
 
   // Check if welcome modal should be shown for new accounts
   const checkWelcomeBannerStatus = useCallback(() => {
@@ -61,22 +68,25 @@ export const useWelcomeBanner = ({
     checkWelcomeBannerStatus();
   }, [checkWelcomeBannerStatus, isFunded, isLoadingBalances]);
 
-  const handleWelcomeBannerDismiss = async () => {
+  const handleWelcomeBannerDismiss = useCallback(async () => {
     try {
-      if (account?.publicKey) {
-        await AsyncStorage.setItem(
-          getWelcomeBannerShownKey(account.publicKey),
-          "true",
-        );
+      if (welcomeBannerShownKey) {
+        await AsyncStorage.setItem(welcomeBannerShownKey, "true");
       }
     } catch (error) {
       logger.error("Error saving welcome banner status:", String(error));
     }
     welcomeBannerBottomSheetModalRef.current?.dismiss();
-  };
+  }, [welcomeBannerShownKey]);
 
-  return {
-    welcomeBannerBottomSheetModalRef,
-    handleWelcomeBannerDismiss,
-  };
+  // Memoize the return object to prevent unnecessary re-renders
+  const returnValue = useMemo(
+    () => ({
+      welcomeBannerBottomSheetModalRef,
+      handleWelcomeBannerDismiss,
+    }),
+    [handleWelcomeBannerDismiss],
+  );
+
+  return returnValue;
 };

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -328,6 +328,17 @@
     "empty": "No collectibles yet",
     "menuAddManually": "Add manually"
   },
+  "collectibleDetails": {
+    "title": "Collectible Details",
+    "notFound": "Collectible not found",
+    "name": "Name",
+    "collection": "Collection",
+    "tokenId": "Token ID",
+    "description": "Description",
+    "traits": "Collectible Traits",
+    "view": "View",
+    "send": "Send"
+  },
   "friendbotButton": {
     "title": "Fund with Friendbot"
   },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -305,6 +305,17 @@
     "empty": "Nenhum colecionável ainda",
     "menuAddManually": "Adicionar manualmente"
   },
+  "collectibleDetails": {
+    "title": "Detalhes do Colecionável",
+    "notFound": "Colecionável não encontrado",
+    "name": "Nome",
+    "collection": "Coleção",
+    "tokenId": "ID do Token",
+    "description": "Descrição",
+    "traits": "Características do Colecionável",
+    "view": "Visualizar",
+    "send": "Enviar"
+  },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"
   },

--- a/src/navigators/RootNavigator.tsx
+++ b/src/navigators/RootNavigator.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { CustomHeaderButton } from "components/layout/CustomHeaderButton";
 import CustomNavigationHeader from "components/layout/CustomNavigationHeader";
 import AccountQRCodeScreen from "components/screens/AccountQRCodeScreen";
+import CollectibleDetailsScreen from "components/screens/CollectibleDetailsScreen";
 import ConnectedAppsScreen from "components/screens/ConnectedAppsScreen";
 import { LoadingScreen } from "components/screens/LoadingScreen";
 import { LockScreen } from "components/screens/LockScreen";
@@ -144,6 +145,15 @@ export const RootNavigator = () => {
           <RootStack.Screen
             name={ROOT_NAVIGATOR_ROUTES.TOKEN_DETAILS_SCREEN}
             component={TokenDetailsScreen}
+            options={{
+              headerShown: true,
+              header: (props) => <CustomNavigationHeader {...props} />,
+              headerLeft: () => <CustomHeaderButton icon={Icon.X} />,
+            }}
+          />
+          <RootStack.Screen
+            name={ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN}
+            component={CollectibleDetailsScreen}
             options={{
               headerShown: true,
               header: (props) => <CustomNavigationHeader {...props} />,


### PR DESCRIPTION
Closes #239  

This PR adds the UI for the [Collectible Details screen](https://www.figma.com/design/KwkHXQxbNmDllwermJtnRu/Freighter-Mobile?node-id=5931-148476&t=POOkOjOFFZ16NQhB-1).

It is displaying dummy data at the moment, we will connect it to our backend in a separate PR.

The [right header settings](https://www.figma.com/design/KwkHXQxbNmDllwermJtnRu/Freighter-Mobile?node-id=5931-148526&t=POOkOjOFFZ16NQhB-1) (below) will be pushed in a separate PR.
<img width="200" height="575" alt="Screenshot 2025-08-18 at 16 03 53" src="https://github.com/user-attachments/assets/8a9300d0-31f5-48e7-946e-082779a7a2b1" />

### Screen samples
<img width="400" height="1084" alt="Screenshot 2025-08-18 at 16 07 09" src="https://github.com/user-attachments/assets/d6750d3e-d64d-4527-8d98-21229ca38402" />
<img width="400" height="1084" alt="Screenshot 2025-08-18 at 16 19 17" src="https://github.com/user-attachments/assets/6aa42013-6437-4518-b53d-bc4afda8fa69" />
<img width="400" height="1084" alt="Screenshot 2025-08-18 at 16 20 36" src="https://github.com/user-attachments/assets/a29a4aff-cc09-48ea-872b-2196550bf9b2" />
<img width="400" height="1084" alt="Screenshot 2025-08-18 at 16 07 37" src="https://github.com/user-attachments/assets/ad5d6d64-b07f-4547-a410-6deec10f06fa" />

### Navigating between collectibles

https://github.com/user-attachments/assets/1d138168-a683-41fa-bca1-eccb337f996d
