### PR TITLE
[Collectibles] Collectible Details right header

### DIFF
--- a/__tests__/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.test.tsx
+++ b/__tests__/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.test.tsx
@@ -52,16 +52,67 @@ jest.mock("hooks/useColors", () => ({
   }),
 }));
 
+// Mock the useRightHeaderMenu hook
+jest.mock("hooks/useRightHeader", () => ({
+  useRightHeaderMenu: jest.fn(),
+}));
+
+// Mock the useAuthenticationStore hook
+jest.mock("ducks/auth", () => ({
+  useAuthenticationStore: () => ({
+    network: "testnet",
+  }),
+}));
+
+// Mock the useCollectiblesStore hook
+jest.mock("ducks/collectibles", () => ({
+  useCollectiblesStore: () => ({
+    fetchCollectibles: jest.fn(),
+  }),
+}));
+
+// Mock the getStellarExpertUrl helper
+jest.mock("helpers/stellarExpert", () => ({
+  getStellarExpertUrl: jest.fn(() => "https://testnet.stellar.expert"),
+}));
+
+// Mock the logger
+jest.mock("config/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Create a mock navigation object
+const mockNavigationObject = {
+  setOptions: jest.fn(),
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+  push: jest.fn(),
+  pop: jest.fn(),
+  reset: jest.fn(),
+  dispatch: jest.fn(),
+  canGoBack: jest.fn(),
+  isFocused: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+};
+
+// Mock the useNavigation hook
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => mockNavigationObject,
+}));
+
 describe("CollectibleDetailsScreen", () => {
   const mockRoute = {
     params: {
       collectionAddress: "test-collection",
       tokenId: "123",
     },
-  };
-
-  const mockNavigation = {
-    setOptions: jest.fn(),
   };
 
   beforeEach(() => {
@@ -72,7 +123,7 @@ describe("CollectibleDetailsScreen", () => {
     const { getByText } = renderWithProviders(
       <CollectibleDetailsScreen
         route={mockRoute as any}
-        navigation={mockNavigation as any}
+        navigation={{} as any}
       />,
     );
 
@@ -98,7 +149,7 @@ describe("CollectibleDetailsScreen", () => {
     const { getByText } = renderWithProviders(
       <CollectibleDetailsScreen
         route={mockRoute as any}
-        navigation={mockNavigation as any}
+        navigation={{} as any}
       />,
     );
 
@@ -112,11 +163,11 @@ describe("CollectibleDetailsScreen", () => {
     renderWithProviders(
       <CollectibleDetailsScreen
         route={mockRoute as any}
-        navigation={mockNavigation as any}
+        navigation={{} as any}
       />,
     );
 
-    expect(mockNavigation.setOptions).toHaveBeenCalledWith({
+    expect(mockNavigationObject.setOptions).toHaveBeenCalledWith({
       headerTitle: "Test NFT",
     });
   });

--- a/__tests__/hooks/useCollectibleDetailsHeader.test.tsx
+++ b/__tests__/hooks/useCollectibleDetailsHeader.test.tsx
@@ -1,0 +1,151 @@
+import { renderHook } from "@testing-library/react-native";
+import { useCollectibleDetailsHeader } from "hooks/useCollectibleDetailsHeader";
+import { Platform } from "react-native";
+
+// Create mock for navigation
+const mockSetOptions = jest.fn();
+
+// Mock all dependencies
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    setOptions: mockSetOptions,
+  }),
+}));
+
+jest.mock("hooks/useAppTranslation", () => ({
+  __esModule: true,
+  default: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("ducks/auth", () => ({
+  useAuthenticationStore: () => ({
+    network: "testnet",
+  }),
+}));
+
+jest.mock("ducks/collectibles", () => ({
+  useCollectiblesStore: () => ({
+    fetchCollectibles: jest.fn(),
+  }),
+}));
+
+jest.mock("helpers/stellarExpert", () => ({
+  getStellarExpertUrl: jest.fn(() => "https://testnet.stellar.expert"),
+}));
+
+jest.mock("hooks/useRightHeader", () => ({
+  useRightHeaderMenu: jest.fn(),
+}));
+
+jest.mock("config/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("components/sds/Icon", () => ({
+  DotsHorizontal: "DotsHorizontal",
+}));
+
+jest.mock("react-native/Libraries/Linking/Linking", () => ({
+  openURL: jest.fn(),
+}));
+
+describe("useCollectibleDetailsHeader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Platform, "select").mockReturnValue({
+      refreshMetadata: "arrow.clockwise",
+      viewOnStellarExpert: "link",
+    });
+  });
+
+  afterEach(() => {
+    (Platform.select as jest.Mock).mockRestore?.();
+  });
+
+  const defaultParams = {
+    collectionAddress: "test-collection-address",
+    collectibleName: "Test NFT",
+  };
+
+  it("should return handler functions", () => {
+    const { result } = renderHook(() =>
+      useCollectibleDetailsHeader(defaultParams),
+    );
+
+    expect(result.current).toEqual({
+      handleRefreshMetadata: expect.any(Function),
+      handleViewOnStellarExpert: expect.any(Function),
+    });
+  });
+
+  it("should set navigation title", () => {
+    renderHook(() => useCollectibleDetailsHeader(defaultParams));
+
+    expect(mockSetOptions).toHaveBeenCalledWith({
+      headerTitle: "Test NFT",
+    });
+  });
+
+  it("should call useRightHeaderMenu", () => {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    const { useRightHeaderMenu } = require("hooks/useRightHeader");
+
+    renderHook(() => useCollectibleDetailsHeader(defaultParams));
+
+    expect(useRightHeaderMenu).toHaveBeenCalled();
+  });
+
+  it("should set fallback title when collectible name is not provided", () => {
+    renderHook(() =>
+      useCollectibleDetailsHeader({
+        collectionAddress: "test-collection",
+        collectibleName: undefined,
+      }),
+    );
+
+    expect(mockSetOptions).toHaveBeenCalledWith({
+      headerTitle: "collectibleDetails.title",
+    });
+  });
+
+  it("should handle refresh metadata", async () => {
+    const { result } = renderHook(() =>
+      useCollectibleDetailsHeader(defaultParams),
+    );
+
+    // Test that the function exists and is callable
+    await expect(
+      result.current.handleRefreshMetadata(),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should handle view on stellar expert", async () => {
+    const { result } = renderHook(() =>
+      useCollectibleDetailsHeader(defaultParams),
+    );
+
+    // Test that the function exists and is callable
+    await expect(
+      result.current.handleViewOnStellarExpert(),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should call Platform.select for icon configuration", () => {
+    renderHook(() => useCollectibleDetailsHeader(defaultParams));
+
+    expect(Platform.select).toHaveBeenCalledWith({
+      ios: {
+        refreshMetadata: "arrow.clockwise",
+        viewOnStellarExpert: "link",
+      },
+      android: {
+        refreshMetadata: "refresh",
+        viewOnStellarExpert: "link",
+      },
+    });
+  });
+});

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -12,7 +12,13 @@ import { useCollectibleDetailsHeader } from "hooks/useCollectibleDetailsHeader";
 import { useCollectibles } from "hooks/useCollectibles";
 import useColors from "hooks/useColors";
 import React, { useMemo, useCallback } from "react";
-import { Image, Linking, ScrollView, View } from "react-native";
+import {
+  Image,
+  Linking,
+  ScrollView,
+  View,
+} from "react-native";
+import Spinner from "components/Spinner";
 
 type CollectibleDetailsScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -34,6 +40,7 @@ type CollectibleDetailsScreenProps = NativeStackScreenProps<
  * - Right header context menu with collectible actions (handled by useCollectibleDetailsHeader)
  * - Responsive layout with proper spacing and typography
  * - Error handling for missing collectibles
+ * - Loading state with centered spinner
  *
  * @param {CollectibleDetailsScreenProps} props - Component props
  * @param {Object} props.route - Navigation route object containing collectible parameters
@@ -62,7 +69,8 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
     const { collectionAddress, tokenId } = route.params;
     const { t } = useAppTranslation();
     const { themeColors } = useColors();
-    const { getCollectible } = useCollectibles();
+    const { getCollectible, isLoading: isCollectiblesLoading } =
+      useCollectibles();
 
     const basicInfoTitleColor = themeColors.text.secondary;
 
@@ -149,6 +157,20 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
         );
       }
     }, []);
+
+    // Show loading spinner when collectibles are being fetched
+    if (isCollectiblesLoading) {
+      return (
+        <BaseLayout insets={{ top: false }}>
+          <View className="flex-1 items-center justify-center p-4">
+            <Spinner
+              size="large"
+              color={themeColors.secondary}
+            />
+          </View>
+        </BaseLayout>
+      );
+    }
 
     // If collectible is not found, show error state
     if (!collectible) {

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -8,9 +8,10 @@ import { logger } from "config/logger";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
+import { useCollectibleDetailsHeader } from "hooks/useCollectibleDetailsHeader";
 import { useCollectibles } from "hooks/useCollectibles";
 import useColors from "hooks/useColors";
-import React, { useMemo, useLayoutEffect, useCallback } from "react";
+import React, { useMemo, useCallback } from "react";
 import { Image, Linking, ScrollView, View } from "react-native";
 
 type CollectibleDetailsScreenProps = NativeStackScreenProps<
@@ -30,6 +31,7 @@ type CollectibleDetailsScreenProps = NativeStackScreenProps<
  * - Detailed description section
  * - Collectible traits/attributes displayed in a 2-column grid layout
  * - Conditional "View in Browser" button for external URLs
+ * - Right header context menu with collectible actions (handled by useCollectibleDetailsHeader)
  * - Responsive layout with proper spacing and typography
  * - Error handling for missing collectibles
  *
@@ -56,7 +58,7 @@ type CollectibleDetailsScreenProps = NativeStackScreenProps<
  * ```
  */
 export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
-  React.memo(({ route, navigation }) => {
+  React.memo(({ route }) => {
     const { collectionAddress, tokenId } = route.params;
     const { t } = useAppTranslation();
     const { themeColors } = useColors();
@@ -72,6 +74,16 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
       () => getCollectible({ collectionAddress, tokenId }),
       [getCollectible, collectionAddress, tokenId],
     );
+
+    /**
+     * Sets up the header configuration including title and context menu.
+     * This hook handles all header-related logic.
+     */
+    useCollectibleDetailsHeader({
+      collectionAddress,
+      tokenId,
+      collectibleName: collectible?.name,
+    });
 
     /**
      * Prepares the list items for displaying basic collectible information.
@@ -119,16 +131,6 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
         collectible?.tokenId,
       ],
     );
-
-    /**
-     * Sets the navigation header title to the collectible name.
-     * Falls back to a default title if the collectible name is not available.
-     */
-    useLayoutEffect(() => {
-      navigation.setOptions({
-        headerTitle: collectible?.name || t("collectibleDetails.title"),
-      });
-    }, [navigation, collectible?.name, t]);
 
     /**
      * Handles opening the collectible's external URL in the device's default browser.

--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -1,5 +1,6 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { List } from "components/List";
+import Spinner from "components/Spinner";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
@@ -12,13 +13,7 @@ import { useCollectibleDetailsHeader } from "hooks/useCollectibleDetailsHeader";
 import { useCollectibles } from "hooks/useCollectibles";
 import useColors from "hooks/useColors";
 import React, { useMemo, useCallback } from "react";
-import {
-  Image,
-  Linking,
-  ScrollView,
-  View,
-} from "react-native";
-import Spinner from "components/Spinner";
+import { Image, Linking, ScrollView, View } from "react-native";
 
 type CollectibleDetailsScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -89,7 +84,6 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
      */
     useCollectibleDetailsHeader({
       collectionAddress,
-      tokenId,
       collectibleName: collectible?.name,
     });
 
@@ -163,10 +157,7 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
       return (
         <BaseLayout insets={{ top: false }}>
           <View className="flex-1 items-center justify-center p-4">
-            <Spinner
-              size="large"
-              color={themeColors.secondary}
-            />
+            <Spinner size="large" color={themeColors.secondary} />
           </View>
         </BaseLayout>
       );

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -66,7 +66,7 @@ interface CollectiblesState {
 const dummyCollectibles: Collectible[] = [
   // Stellar Frogs Collection
   {
-    collectionAddress: "GGGStellarFrogsCollection",
+    collectionAddress: "CCCStellarFrogsCollection",
     collectionName: "Stellar Frogs",
     tokenId: "1",
     name: "welcomingfrog.xlm",
@@ -84,7 +84,7 @@ const dummyCollectibles: Collectible[] = [
     ],
   },
   {
-    collectionAddress: "GGGStellarFrogsCollection",
+    collectionAddress: "CCCStellarFrogsCollection",
     collectionName: "Stellar Frogs",
     tokenId: "2",
     name: "pepethebot.xlm",
@@ -103,7 +103,7 @@ const dummyCollectibles: Collectible[] = [
     ],
   },
   {
-    collectionAddress: "GGGStellarFrogsCollection",
+    collectionAddress: "CCCStellarFrogsCollection",
     collectionName: "Stellar Frogs",
     tokenId: "3",
     name: "princepepe.xlm",
@@ -123,7 +123,7 @@ const dummyCollectibles: Collectible[] = [
   },
   // Soroban Domains Collection
   {
-    collectionAddress: "GGGSorobanDomainsCollection",
+    collectionAddress: "CCCSorobanDomainsCollection",
     collectionName: "Soroban Domains",
     tokenId: "102510",
     name: "charles.xlm",
@@ -138,7 +138,7 @@ const dummyCollectibles: Collectible[] = [
     ],
   },
   {
-    collectionAddress: "GGGSorobanDomainsCollection",
+    collectionAddress: "CCCSorobanDomainsCollection",
     collectionName: "Soroban Domains",
     tokenId: "102589",
     name: "cassio.xlm",
@@ -155,7 +155,7 @@ const dummyCollectibles: Collectible[] = [
   },
   // Future Monkeys Collection
   {
-    collectionAddress: "GGGFutureMonkeysCollection",
+    collectionAddress: "CCCFutureMonkeysCollection",
     collectionName: "Future Monkeys",
     tokenId: "111",
     name: "blueauramonkey.xlm",

--- a/src/hooks/useCollectibleDetailsHeader.ts
+++ b/src/hooks/useCollectibleDetailsHeader.ts
@@ -2,6 +2,7 @@ import { useNavigation } from "@react-navigation/native";
 import Icon from "components/sds/Icon";
 import { logger } from "config/logger";
 import { useAuthenticationStore } from "ducks/auth";
+import { useCollectiblesStore } from "ducks/collectibles";
 import { getStellarExpertUrl } from "helpers/stellarExpert";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useRightHeaderMenu } from "hooks/useRightHeader";
@@ -42,6 +43,7 @@ export const useCollectibleDetailsHeader = ({
   const navigation = useNavigation();
   const { t } = useAppTranslation();
   const { network } = useAuthenticationStore();
+  const { fetchCollectibles } = useCollectiblesStore();
 
   /**
    * Sets the navigation header title to the collectible name.
@@ -55,20 +57,11 @@ export const useCollectibleDetailsHeader = ({
 
   /**
    * Handles refreshing metadata for the collectible.
-   * Currently a placeholder for future implementation.
+   * Calls fetchCollectibles to refresh collectible data from the API.
    */
   const handleRefreshMetadata = useCallback(async () => {
     try {
-      // TODO: Implement metadata refresh logic
-      // This could involve re-fetching from the blockchain or API
-      logger.info(
-        "useCollectibleDetailsHeader",
-        "Refreshing metadata for collectible",
-        {
-          collectionAddress,
-          tokenId,
-        },
-      );
+      await fetchCollectibles();
     } catch (error) {
       logger.error(
         "useCollectibleDetailsHeader",
@@ -76,7 +69,7 @@ export const useCollectibleDetailsHeader = ({
         error,
       );
     }
-  }, [collectionAddress, tokenId]);
+  }, [fetchCollectibles]);
 
   /**
    * Handles saving the collectible image to the device's photo library.
@@ -128,7 +121,6 @@ export const useCollectibleDetailsHeader = ({
   const handleReportAsSpam = useCallback(async () => {
     try {
       // TODO: Implement spam reporting logic
-      // This could involve opening a form or sending data to a moderation service
       logger.info(
         "useCollectibleDetailsHeader",
         "Reporting collectible as spam",
@@ -160,7 +152,7 @@ export const useCollectibleDetailsHeader = ({
         },
         android: {
           refreshMetadata: "refresh", // Refresh icon (Material)
-          saveToPhotos: "download",   // Download icon (Material)
+          saveToPhotos: "download", // Download icon (Material)
           viewOnStellarExpert: "link", // Link icon (Material)
           reportAsSpam: "outlined_flag", // Flag icon (Material)
         },

--- a/src/hooks/useCollectibleDetailsHeader.ts
+++ b/src/hooks/useCollectibleDetailsHeader.ts
@@ -1,0 +1,222 @@
+import { useNavigation } from "@react-navigation/native";
+import Icon from "components/sds/Icon";
+import { logger } from "config/logger";
+import { useAuthenticationStore } from "ducks/auth";
+import { getStellarExpertUrl } from "helpers/stellarExpert";
+import useAppTranslation from "hooks/useAppTranslation";
+import { useRightHeaderMenu } from "hooks/useRightHeader";
+import { useLayoutEffect, useMemo, useCallback } from "react";
+import { Linking, Platform } from "react-native";
+
+/**
+ * Custom hook for managing the CollectibleDetailsScreen header configuration.
+ *
+ * This hook handles:
+ * - Setting the header title to the collectible name
+ * - Setting up the right header context menu with collectible actions
+ * - All menu action handlers (refresh metadata, save to photos, view on stellar.expert, report as spam)
+ *
+ * @param {Object} params - Hook parameters
+ * @param {string} params.collectionAddress - The collection address of the collectible
+ * @param {string} params.tokenId - The unique token ID of the collectible
+ * @param {string} params.collectibleName - The name of the collectible for the header title
+ *
+ * @example
+ * ```tsx
+ * const { handleViewInBrowser } = useCollectibleDetailsHeader({
+ *   collectionAddress: "collection123",
+ *   tokenId: "token456",
+ *   collectibleName: "My NFT"
+ * });
+ * ```
+ */
+export const useCollectibleDetailsHeader = ({
+  collectionAddress,
+  tokenId,
+  collectibleName,
+}: {
+  collectionAddress: string;
+  tokenId: string;
+  collectibleName?: string;
+}) => {
+  const navigation = useNavigation();
+  const { t } = useAppTranslation();
+  const { network } = useAuthenticationStore();
+
+  /**
+   * Sets the navigation header title to the collectible name.
+   * Falls back to a default title if the collectible name is not available.
+   */
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: collectibleName || t("collectibleDetails.title"),
+    });
+  }, [navigation, collectibleName, t]);
+
+  /**
+   * Handles refreshing metadata for the collectible.
+   * Currently a placeholder for future implementation.
+   */
+  const handleRefreshMetadata = useCallback(async () => {
+    try {
+      // TODO: Implement metadata refresh logic
+      // This could involve re-fetching from the blockchain or API
+      logger.info(
+        "useCollectibleDetailsHeader",
+        "Refreshing metadata for collectible",
+        {
+          collectionAddress,
+          tokenId,
+        },
+      );
+    } catch (error) {
+      logger.error(
+        "useCollectibleDetailsHeader",
+        "Failed to refresh metadata:",
+        error,
+      );
+    }
+  }, [collectionAddress, tokenId]);
+
+  /**
+   * Handles saving the collectible image to the device's photo library.
+   * Currently a placeholder for future implementation.
+   */
+  const handleSaveToPhotos = useCallback(async () => {
+    try {
+      // TODO: Implement save to photos functionality
+      // This would require additional permissions and native modules
+      logger.info(
+        "useCollectibleDetailsHeader",
+        "Saving collectible image to photos",
+        {
+          collectionAddress,
+          tokenId,
+        },
+      );
+    } catch (error) {
+      logger.error(
+        "useCollectibleDetailsHeader",
+        "Failed to save to photos:",
+        error,
+      );
+    }
+  }, [collectionAddress, tokenId]);
+
+  /**
+   * Handles opening the collectible on stellar.expert explorer.
+   * Constructs the appropriate URL based on the current network.
+   */
+  const handleViewOnStellarExpert = useCallback(async () => {
+    try {
+      const stellarExpertUrl = getStellarExpertUrl(network);
+      const collectibleUrl = `${stellarExpertUrl}/contract/${collectionAddress}`;
+      await Linking.openURL(collectibleUrl);
+    } catch (error) {
+      logger.error(
+        "useCollectibleDetailsHeader",
+        "Failed to open stellar.expert:",
+        error,
+      );
+    }
+  }, [network, collectionAddress]);
+
+  /**
+   * Handles reporting the collectible as spam.
+   * Currently a placeholder for future implementation.
+   */
+  const handleReportAsSpam = useCallback(async () => {
+    try {
+      // TODO: Implement spam reporting logic
+      // This could involve opening a form or sending data to a moderation service
+      logger.info(
+        "useCollectibleDetailsHeader",
+        "Reporting collectible as spam",
+        {
+          collectionAddress,
+          tokenId,
+        },
+      );
+    } catch (error) {
+      logger.error(
+        "useCollectibleDetailsHeader",
+        "Failed to report as spam:",
+        error,
+      );
+    }
+  }, [collectionAddress, tokenId]);
+
+  /**
+   * Platform-specific system icons for the context menu actions.
+   */
+  const systemIcons = useMemo(
+    () =>
+      Platform.select({
+        ios: {
+          refreshMetadata: "arrow.clockwise", // Circular arrow for refresh
+          saveToPhotos: "square.and.arrow.down", // Download/save icon
+          viewOnStellarExpert: "link", // Link/chain icon
+          reportAsSpam: "flag", // Flag icon for reporting as spam
+        },
+        android: {
+          refreshMetadata: "refresh", // Refresh icon (Material)
+          saveToPhotos: "download",   // Download icon (Material)
+          viewOnStellarExpert: "link", // Link icon (Material)
+          reportAsSpam: "outlined_flag", // Flag icon (Material)
+        },
+      }),
+    [],
+  );
+
+  /**
+   * Context menu actions configuration with platform-specific icons.
+   * Memoized to prevent unnecessary re-creation on re-renders.
+   */
+  const contextMenuActions = useMemo(
+    () => [
+      {
+        title: t("collectibleDetails.refreshMetadata"),
+        systemIcon: systemIcons?.refreshMetadata,
+        onPress: handleRefreshMetadata,
+      },
+      {
+        title: t("collectibleDetails.saveToPhotos"),
+        systemIcon: systemIcons?.saveToPhotos,
+        onPress: handleSaveToPhotos,
+      },
+      {
+        title: t("collectibleDetails.viewOnStellarExpert"),
+        systemIcon: systemIcons?.viewOnStellarExpert,
+        onPress: handleViewOnStellarExpert,
+      },
+      {
+        title: t("collectibleDetails.reportAsSpam"),
+        systemIcon: systemIcons?.reportAsSpam,
+        onPress: handleReportAsSpam,
+        destructive: true,
+      },
+    ],
+    [
+      t,
+      systemIcons,
+      handleRefreshMetadata,
+      handleSaveToPhotos,
+      handleViewOnStellarExpert,
+      handleReportAsSpam,
+    ],
+  );
+
+  // Set up the right header menu
+  useRightHeaderMenu({
+    actions: contextMenuActions,
+    icon: Icon.DotsHorizontal,
+  });
+
+  // Return any handlers that might be needed by the component
+  return {
+    handleRefreshMetadata,
+    handleSaveToPhotos,
+    handleViewOnStellarExpert,
+    handleReportAsSpam,
+  };
+};

--- a/src/hooks/useCollectibleDetailsHeader.ts
+++ b/src/hooks/useCollectibleDetailsHeader.ts
@@ -15,29 +15,25 @@ import { Linking, Platform } from "react-native";
  * This hook handles:
  * - Setting the header title to the collectible name
  * - Setting up the right header context menu with collectible actions
- * - All menu action handlers (refresh metadata, save to photos, view on stellar.expert, report as spam)
+ * - All menu action handlers (refresh metadata, view on stellar.expert, etc.)
  *
  * @param {Object} params - Hook parameters
  * @param {string} params.collectionAddress - The collection address of the collectible
- * @param {string} params.tokenId - The unique token ID of the collectible
  * @param {string} params.collectibleName - The name of the collectible for the header title
  *
  * @example
  * ```tsx
  * const { handleViewInBrowser } = useCollectibleDetailsHeader({
  *   collectionAddress: "collection123",
- *   tokenId: "token456",
  *   collectibleName: "My NFT"
  * });
  * ```
  */
 export const useCollectibleDetailsHeader = ({
   collectionAddress,
-  tokenId,
   collectibleName,
 }: {
   collectionAddress: string;
-  tokenId: string;
   collectibleName?: string;
 }) => {
   const navigation = useNavigation();
@@ -72,31 +68,6 @@ export const useCollectibleDetailsHeader = ({
   }, [fetchCollectibles]);
 
   /**
-   * Handles saving the collectible image to the device's photo library.
-   * Currently a placeholder for future implementation.
-   */
-  const handleSaveToPhotos = useCallback(async () => {
-    try {
-      // TODO: Implement save to photos functionality
-      // This would require additional permissions and native modules
-      logger.info(
-        "useCollectibleDetailsHeader",
-        "Saving collectible image to photos",
-        {
-          collectionAddress,
-          tokenId,
-        },
-      );
-    } catch (error) {
-      logger.error(
-        "useCollectibleDetailsHeader",
-        "Failed to save to photos:",
-        error,
-      );
-    }
-  }, [collectionAddress, tokenId]);
-
-  /**
    * Handles opening the collectible on stellar.expert explorer.
    * Constructs the appropriate URL based on the current network.
    */
@@ -115,30 +86,6 @@ export const useCollectibleDetailsHeader = ({
   }, [network, collectionAddress]);
 
   /**
-   * Handles reporting the collectible as spam.
-   * Currently a placeholder for future implementation.
-   */
-  const handleReportAsSpam = useCallback(async () => {
-    try {
-      // TODO: Implement spam reporting logic
-      logger.info(
-        "useCollectibleDetailsHeader",
-        "Reporting collectible as spam",
-        {
-          collectionAddress,
-          tokenId,
-        },
-      );
-    } catch (error) {
-      logger.error(
-        "useCollectibleDetailsHeader",
-        "Failed to report as spam:",
-        error,
-      );
-    }
-  }, [collectionAddress, tokenId]);
-
-  /**
    * Platform-specific system icons for the context menu actions.
    */
   const systemIcons = useMemo(
@@ -146,15 +93,11 @@ export const useCollectibleDetailsHeader = ({
       Platform.select({
         ios: {
           refreshMetadata: "arrow.clockwise", // Circular arrow for refresh
-          saveToPhotos: "square.and.arrow.down", // Download/save icon
           viewOnStellarExpert: "link", // Link/chain icon
-          reportAsSpam: "flag", // Flag icon for reporting as spam
         },
         android: {
           refreshMetadata: "refresh", // Refresh icon (Material)
-          saveToPhotos: "download", // Download icon (Material)
           viewOnStellarExpert: "link", // Link icon (Material)
-          reportAsSpam: "outlined_flag", // Flag icon (Material)
         },
       }),
     [],
@@ -172,30 +115,12 @@ export const useCollectibleDetailsHeader = ({
         onPress: handleRefreshMetadata,
       },
       {
-        title: t("collectibleDetails.saveToPhotos"),
-        systemIcon: systemIcons?.saveToPhotos,
-        onPress: handleSaveToPhotos,
-      },
-      {
         title: t("collectibleDetails.viewOnStellarExpert"),
         systemIcon: systemIcons?.viewOnStellarExpert,
         onPress: handleViewOnStellarExpert,
       },
-      {
-        title: t("collectibleDetails.reportAsSpam"),
-        systemIcon: systemIcons?.reportAsSpam,
-        onPress: handleReportAsSpam,
-        destructive: true,
-      },
     ],
-    [
-      t,
-      systemIcons,
-      handleRefreshMetadata,
-      handleSaveToPhotos,
-      handleViewOnStellarExpert,
-      handleReportAsSpam,
-    ],
+    [t, systemIcons, handleRefreshMetadata, handleViewOnStellarExpert],
   );
 
   // Set up the right header menu
@@ -207,8 +132,6 @@ export const useCollectibleDetailsHeader = ({
   // Return any handlers that might be needed by the component
   return {
     handleRefreshMetadata,
-    handleSaveToPhotos,
     handleViewOnStellarExpert,
-    handleReportAsSpam,
   };
 };

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -338,9 +338,7 @@
     "traits": "Collectible Traits",
     "view": "View",
     "refreshMetadata": "Refresh metadata",
-    "saveToPhotos": "Save to photos",
-    "viewOnStellarExpert": "View on stellar.expert",
-    "reportAsSpam": "Report as spam"
+    "viewOnStellarExpert": "View on stellar.expert"
   },
   "friendbotButton": {
     "title": "Fund with Friendbot"

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -337,7 +337,10 @@
     "description": "Description",
     "traits": "Collectible Traits",
     "view": "View",
-    "send": "Send"
+    "refreshMetadata": "Refresh metadata",
+    "saveToPhotos": "Save to photos",
+    "viewOnStellarExpert": "View on stellar.expert",
+    "reportAsSpam": "Report as spam"
   },
   "friendbotButton": {
     "title": "Fund with Friendbot"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -315,9 +315,7 @@
     "traits": "Características do Colecionável",
     "view": "Visualizar",
     "refreshMetadata": "Atualizar metadados",
-    "saveToPhotos": "Salvar nas fotos",
-    "viewOnStellarExpert": "Ver no stellar.expert",
-    "reportAsSpam": "Reportar como spam"
+    "viewOnStellarExpert": "Ver no stellar.expert"
   },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -314,7 +314,10 @@
     "description": "Descrição",
     "traits": "Características do Colecionável",
     "view": "Visualizar",
-    "send": "Enviar"
+    "refreshMetadata": "Atualizar metadados",
+    "saveToPhotos": "Salvar nas fotos",
+    "viewOnStellarExpert": "Ver no stellar.expert",
+    "reportAsSpam": "Reportar como spam"
   },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"


### PR DESCRIPTION
This PR adds the right header menu for the Collectible Details screen with the `Refresh metadata` and `View on stellar.expert` options.

[Figma designs](https://www.figma.com/design/KwkHXQxbNmDllwermJtnRu/Freighter-Mobile?node-id=5931-148526&t=lQSXDbVXhVRsOqqq-1).

Notes on other options:
- `Save to photos`: should be implemented in a [separate task](https://github.com/orgs/stellar/projects/58/views/1?pane=issue&itemId=122673879&issue=stellar%7Cfreighter-mobile%7C243) next Sprint
- `Hide collectible`: [not in scope](https://docs.google.com/spreadsheets/d/1Zp_LOti0KcVzcagqG4MUMq8wFC7Ekx7efoIIRTKUMrw/edit?gid=1680436234#gid=1680436234) for V1
- `Report as spam`: [not in scope](https://stellarfoundation.slack.com/archives/C03347FNAHK/p1755698365668489) for V1


## iOS



## Android
