### PR TITLE
[Collectibles] Add Collectible UI + allow screen button taps when keyboard is visible

### DIFF
--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -149,13 +149,14 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
             ios: "plus.rectangle.on.rectangle",
             android: "add_box",
           }),
-          disabled: true,
+          onPress: () =>
+            navigation.navigate(ROOT_NAVIGATOR_ROUTES.ADD_COLLECTIBLE_SCREEN),
         },
       ];
 
       // Reverse the array for iOS to match Android behavior
       return isIOS ? actions.reverse() : actions;
-    }, [t]);
+    }, [t, navigation]);
 
     /**
      * Renders the tokens/balances list content

--- a/src/components/layout/ScrollableKeyboardView.tsx
+++ b/src/components/layout/ScrollableKeyboardView.tsx
@@ -30,7 +30,7 @@ const StyledKeyboardAvoidingView = styled(KeyboardAvoidingView).attrs(
 const StyledScrollView = styled(ScrollView).attrs(
   (props: ScrollViewProps) =>
     ({
-      keyboardShouldPersistTaps: "never",
+      keyboardShouldPersistTaps: "handled",
       showsVerticalScrollIndicator: false,
       alwaysBounceVertical: false,
       contentContainerStyle: {

--- a/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
+++ b/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
@@ -37,21 +37,20 @@ export const AddCollectibleScreen: React.FC<AddCollectibleScreenProps> = ({
     (address: string) => {
       if (!address.trim()) {
         setCollectionAddressError("");
-        return false;
+        return;
       }
 
       if (address.includes(" ")) {
         setCollectionAddressError(t("addCollectibleScreen.addressNoSpaces"));
-        return false;
+        return;
       }
 
       if (!isContractId(address.trim())) {
         setCollectionAddressError(t("addCollectibleScreen.invalidAddress"));
-        return false;
+        return;
       }
 
       setCollectionAddressError("");
-      return true;
     },
     [t],
   );
@@ -60,16 +59,15 @@ export const AddCollectibleScreen: React.FC<AddCollectibleScreenProps> = ({
     (id: string) => {
       if (!id.trim()) {
         setTokenIdError("");
-        return false;
+        return;
       }
 
       if (id.includes(" ")) {
         setTokenIdError(t("addCollectibleScreen.tokenIdNoSpaces"));
-        return false;
+        return;
       }
 
       setTokenIdError("");
-      return true;
     },
     [t],
   );

--- a/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
+++ b/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
@@ -1,0 +1,191 @@
+import { BaseLayout } from "components/layout/BaseLayout";
+import { Button } from "components/sds/Button";
+import Icon from "components/sds/Icon";
+import { Input } from "components/sds/Input";
+import { Text } from "components/sds/Typography";
+import { isContractId } from "helpers/soroban";
+import useAppTranslation from "hooks/useAppTranslation";
+import { useClipboard } from "hooks/useClipboard";
+import useColors from "hooks/useColors";
+import React, { useState, useCallback, useRef } from "react";
+import { View, TextInput, Alert } from "react-native";
+
+export const AddCollectibleScreen: React.FC = () => {
+  const { t } = useAppTranslation();
+  const { getClipboardText } = useClipboard();
+  const { themeColors } = useColors();
+
+  const [collectionAddress, setCollectionAddress] = useState("");
+  const [tokenId, setTokenId] = useState("");
+  const [collectionAddressError, setCollectionAddressError] = useState("");
+  const [tokenIdError, setTokenIdError] = useState("");
+
+  const collectionAddressRef = useRef<TextInput>(null);
+  const tokenIdRef = useRef<TextInput>(null);
+
+  const validateCollectionAddress = useCallback(
+    (address: string) => {
+      if (!address.trim()) {
+        setCollectionAddressError("");
+        return false;
+      }
+
+      if (!isContractId(address.trim())) {
+        setCollectionAddressError(t("addCollectibleScreen.invalidAddress"));
+        return false;
+      }
+
+      setCollectionAddressError("");
+      return true;
+    },
+    [t],
+  );
+
+  const validateTokenId = useCallback(
+    (id: string) => {
+      if (!id.trim()) {
+        setTokenIdError("");
+        return false;
+      }
+
+      // Check if input contains spaces
+      if (id.includes(" ")) {
+        setTokenIdError(t("addCollectibleScreen.tokenIdNoSpaces"));
+        return false;
+      }
+
+      setTokenIdError("");
+      return true;
+    },
+    [t],
+  );
+
+  const handleCollectionAddressChange = useCallback(
+    (text: string) => {
+      setCollectionAddress(text);
+      validateCollectionAddress(text);
+    },
+    [validateCollectionAddress],
+  );
+
+  const handleTokenIdChange = useCallback(
+    (text: string) => {
+      setTokenId(text);
+      validateTokenId(text);
+    },
+    [validateTokenId],
+  );
+
+  const handlePasteCollectionAddress = useCallback(() => {
+    getClipboardText()
+      .then((text) => {
+        if (text) {
+          setCollectionAddress(text);
+          validateCollectionAddress(text);
+        }
+      })
+      .catch(() => {
+        // Failed to get clipboard content
+        // TODO: log error
+      });
+  }, [validateCollectionAddress, getClipboardText]);
+
+  const handlePasteTokenId = useCallback(() => {
+    getClipboardText()
+      .then((text) => {
+        if (text) {
+          setTokenId(text);
+          validateTokenId(text);
+        }
+      })
+      .catch(() => {
+        // Failed to get clipboard content
+        // TODO: log error
+      });
+  }, [validateTokenId, getClipboardText]);
+
+  const isFormValid =
+    collectionAddress.trim() &&
+    tokenId.trim() &&
+    !collectionAddressError &&
+    !tokenIdError;
+
+  const handleButtonPress = useCallback(() => {
+    if (isFormValid) {
+      // TODO: fake a "add collectible" loading state
+      // TODO: fake a "add collectible" success state
+      // TODO: fake a "add collectible" error state
+      // TODO: Implement add collectible logic
+      Alert.alert(t("common.done"), t("addCollectibleScreen.toastSuccess"));
+      return;
+    }
+
+    // Focus next available input field
+    if (!collectionAddress.trim() || collectionAddressError) {
+      collectionAddressRef.current?.focus();
+    } else if (!tokenId.trim() || tokenIdError) {
+      tokenIdRef.current?.focus();
+    }
+  }, [
+    isFormValid,
+    collectionAddress,
+    tokenId,
+    collectionAddressError,
+    tokenIdError,
+    t,
+  ]);
+
+  const buttonTitle = isFormValid
+    ? t("addCollectibleScreen.addToWallet")
+    : t("addCollectibleScreen.enterDetails");
+
+  return (
+    <BaseLayout useKeyboardAvoidingView insets={{ top: false }}>
+      <View className="mb-6">
+        <Input
+          ref={collectionAddressRef}
+          placeholder={t("addCollectibleScreen.collectionAddress")}
+          value={collectionAddress}
+          onChangeText={handleCollectionAddressChange}
+          error={collectionAddressError}
+          endButton={{
+            content: (
+              <Icon.Clipboard size={20} color={themeColors.text.secondary} />
+            ),
+            onPress: handlePasteCollectionAddress,
+          }}
+        />
+      </View>
+
+      <View className="mb-6">
+        <Input
+          ref={tokenIdRef}
+          placeholder={t("addCollectibleScreen.tokenId")}
+          value={tokenId}
+          onChangeText={handleTokenIdChange}
+          error={tokenIdError}
+          endButton={{
+            content: (
+              <Icon.Clipboard size={20} color={themeColors.text.secondary} />
+            ),
+            onPress: handlePasteTokenId,
+          }}
+        />
+      </View>
+
+      <View className="mb-8">
+        <Text sm secondary>
+          {t("addCollectibleScreen.description")}
+        </Text>
+      </View>
+
+      <View className="mt-auto">
+        <Button xl tertiary onPress={handleButtonPress} isFullWidth>
+          {buttonTitle}
+        </Button>
+      </View>
+    </BaseLayout>
+  );
+};
+
+export default AddCollectibleScreen;

--- a/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
+++ b/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
@@ -3,6 +3,7 @@ import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Input } from "components/sds/Input";
 import { Text } from "components/sds/Typography";
+import { logger } from "config/logger";
 import { isContractId } from "helpers/soroban";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useClipboard } from "hooks/useClipboard";
@@ -30,6 +31,11 @@ export const AddCollectibleScreen: React.FC = () => {
         return false;
       }
 
+      if (address.includes(" ")) {
+        setCollectionAddressError(t("addCollectibleScreen.addressNoSpaces"));
+        return false;
+      }
+
       if (!isContractId(address.trim())) {
         setCollectionAddressError(t("addCollectibleScreen.invalidAddress"));
         return false;
@@ -48,7 +54,6 @@ export const AddCollectibleScreen: React.FC = () => {
         return false;
       }
 
-      // Check if input contains spaces
       if (id.includes(" ")) {
         setTokenIdError(t("addCollectibleScreen.tokenIdNoSpaces"));
         return false;
@@ -84,9 +89,12 @@ export const AddCollectibleScreen: React.FC = () => {
           validateCollectionAddress(text);
         }
       })
-      .catch(() => {
-        // Failed to get clipboard content
-        // TODO: log error
+      .catch((error) => {
+        logger.error(
+          "handlePasteCollectionAddress",
+          "Failed to get clipboard content",
+          error,
+        );
       });
   }, [validateCollectionAddress, getClipboardText]);
 
@@ -98,9 +106,12 @@ export const AddCollectibleScreen: React.FC = () => {
           validateTokenId(text);
         }
       })
-      .catch(() => {
-        // Failed to get clipboard content
-        // TODO: log error
+      .catch((error) => {
+        logger.error(
+          "handlePasteTokenId",
+          "Failed to get clipboard content",
+          error,
+        );
       });
   }, [validateTokenId, getClipboardText]);
 
@@ -112,10 +123,6 @@ export const AddCollectibleScreen: React.FC = () => {
 
   const handleButtonPress = useCallback(() => {
     if (isFormValid) {
-      // TODO: fake a "add collectible" loading state
-      // TODO: fake a "add collectible" success state
-      // TODO: fake a "add collectible" error state
-      // TODO: Implement add collectible logic
       Alert.alert(t("common.done"), t("addCollectibleScreen.toastSuccess"));
       return;
     }
@@ -141,7 +148,7 @@ export const AddCollectibleScreen: React.FC = () => {
 
   return (
     <BaseLayout useKeyboardAvoidingView insets={{ top: false }}>
-      <View className="mb-6">
+      <View className="mb-3">
         <Input
           ref={collectionAddressRef}
           placeholder={t("addCollectibleScreen.collectionAddress")}
@@ -150,7 +157,7 @@ export const AddCollectibleScreen: React.FC = () => {
           error={collectionAddressError}
           endButton={{
             content: (
-              <Icon.Clipboard size={20} color={themeColors.text.secondary} />
+              <Icon.Clipboard size={18} color={themeColors.text.secondary} />
             ),
             onPress: handlePasteCollectionAddress,
           }}
@@ -166,7 +173,7 @@ export const AddCollectibleScreen: React.FC = () => {
           error={tokenIdError}
           endButton={{
             content: (
-              <Icon.Clipboard size={20} color={themeColors.text.secondary} />
+              <Icon.Clipboard size={18} color={themeColors.text.secondary} />
             ),
             onPress: handlePasteTokenId,
           }}

--- a/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
+++ b/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
@@ -123,7 +123,7 @@ export const AddCollectibleScreen: React.FC = () => {
 
   const handleButtonPress = useCallback(() => {
     if (isFormValid) {
-      Alert.alert(t("common.done"), t("addCollectibleScreen.toastSuccess"));
+      Alert.alert("Confirmation Test", "Collectible added");
       return;
     }
 
@@ -139,7 +139,6 @@ export const AddCollectibleScreen: React.FC = () => {
     tokenId,
     collectionAddressError,
     tokenIdError,
-    t,
   ]);
 
   const buttonTitle = isFormValid

--- a/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
+++ b/src/components/screens/AddCollectibleScreen/AddCollectibleScreen.tsx
@@ -1,17 +1,26 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { BaseLayout } from "components/layout/BaseLayout";
 import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Input } from "components/sds/Input";
 import { Text } from "components/sds/Typography";
 import { logger } from "config/logger";
+import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { isContractId } from "helpers/soroban";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useClipboard } from "hooks/useClipboard";
 import useColors from "hooks/useColors";
 import React, { useState, useCallback, useRef } from "react";
-import { View, TextInput, Alert } from "react-native";
+import { View, TextInput } from "react-native";
 
-export const AddCollectibleScreen: React.FC = () => {
+type AddCollectibleScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  typeof ROOT_NAVIGATOR_ROUTES.ADD_COLLECTIBLE_SCREEN
+>;
+
+export const AddCollectibleScreen: React.FC<AddCollectibleScreenProps> = ({
+  navigation,
+}) => {
   const { t } = useAppTranslation();
   const { getClipboardText } = useClipboard();
   const { themeColors } = useColors();
@@ -123,7 +132,7 @@ export const AddCollectibleScreen: React.FC = () => {
 
   const handleButtonPress = useCallback(() => {
     if (isFormValid) {
-      Alert.alert("Confirmation Test", "Collectible added");
+      navigation.goBack();
       return;
     }
 
@@ -139,6 +148,7 @@ export const AddCollectibleScreen: React.FC = () => {
     tokenId,
     collectionAddressError,
     tokenIdError,
+    navigation,
   ]);
 
   const buttonTitle = isFormValid

--- a/src/components/screens/AddCollectibleScreen/index.ts
+++ b/src/components/screens/AddCollectibleScreen/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./AddCollectibleScreen";
+export { AddCollectibleScreen } from "./AddCollectibleScreen";

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -42,6 +42,7 @@ export const ROOT_NAVIGATOR_ROUTES = {
   CONNECTED_APPS_SCREEN: "ConnectedAppsScreen",
   TOKEN_DETAILS_SCREEN: "TokenDetailsScreen",
   COLLECTIBLE_DETAILS_SCREEN: "CollectibleDetailsScreen",
+  ADD_COLLECTIBLE_SCREEN: "AddCollectibleScreen",
 } as const;
 
 export const AUTH_STACK_ROUTES = {
@@ -152,6 +153,7 @@ export type RootStackParamList = {
     collectionAddress: string;
     tokenId: string;
   };
+  [ROOT_NAVIGATOR_ROUTES.ADD_COLLECTIBLE_SCREEN]: undefined;
 };
 
 export type AuthStackParamList = {

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -346,6 +346,7 @@
     "addToWallet": "Add to wallet",
     "enterDetails": "Enter details",
     "invalidAddress": "Invalid address",
+    "addressNoSpaces": "Address cannot contain spaces",
     "invalidTokenId": "Invalid token ID",
     "tokenIdNoSpaces": "Token ID cannot contain spaces",
     "description": "If a collectible is missing from your wallet, you can manually add it here.",

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -350,9 +350,7 @@
     "addressNoSpaces": "Address cannot contain spaces",
     "invalidTokenId": "Invalid token ID",
     "tokenIdNoSpaces": "Token ID cannot contain spaces",
-    "description": "If a collectible is missing from your wallet, you can manually add it here.",
-    "toastSuccess": "Collectible successfully added to wallet",
-    "toastError": "Error adding collectible"
+    "description": "If a collectible is missing from your wallet, you can manually add it here."
   },
   "friendbotButton": {
     "title": "Fund with Friendbot"

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -339,6 +339,19 @@
     "view": "View",
     "send": "Send"
   },
+  "addCollectibleScreen": {
+    "title": "Add Collectible",
+    "collectionAddress": "Collection address",
+    "tokenId": "Token ID",
+    "addToWallet": "Add to wallet",
+    "enterDetails": "Enter details",
+    "invalidAddress": "Invalid address",
+    "invalidTokenId": "Invalid token ID",
+    "tokenIdNoSpaces": "Token ID cannot contain spaces",
+    "description": "If a collectible is missing from your wallet, you can manually add it here.",
+    "toastSuccess": "Collectible successfully added to wallet",
+    "toastError": "Error adding collectible"
+  },
   "friendbotButton": {
     "title": "Fund with Friendbot"
   },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -323,6 +323,7 @@
     "addToWallet": "Adicionar à carteira",
     "enterDetails": "Inserir detalhes",
     "invalidAddress": "Endereço inválido",
+    "addressNoSpaces": "Endereço não pode conter espaços",
     "invalidTokenId": "ID do token inválido",
     "tokenIdNoSpaces": "O ID do token não pode conter espaços",
     "description": "Se um colecionável estiver ausente da sua carteira, você pode adicioná-lo manualmente aqui.",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -327,9 +327,7 @@
     "addressNoSpaces": "Endereço não pode conter espaços",
     "invalidTokenId": "ID do token inválido",
     "tokenIdNoSpaces": "O ID do token não pode conter espaços",
-    "description": "Se um colecionável estiver ausente da sua carteira, você pode adicioná-lo manualmente aqui.",
-    "toastSuccess": "Colecionável adicionado com sucesso à carteira",
-    "toastError": "Erro ao adicionar colecionável"
+    "description": "Se um colecionável estiver ausente da sua carteira, você pode adicioná-lo manualmente aqui."
   },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -316,6 +316,19 @@
     "view": "Visualizar",
     "send": "Enviar"
   },
+  "addCollectibleScreen": {
+    "title": "Adicionar Colecionável",
+    "collectionAddress": "Endereço da coleção",
+    "tokenId": "ID do Token",
+    "addToWallet": "Adicionar à carteira",
+    "enterDetails": "Inserir detalhes",
+    "invalidAddress": "Endereço inválido",
+    "invalidTokenId": "ID do token inválido",
+    "tokenIdNoSpaces": "O ID do token não pode conter espaços",
+    "description": "Se um colecionável estiver ausente da sua carteira, você pode adicioná-lo manualmente aqui.",
+    "toastSuccess": "Colecionável adicionado com sucesso à carteira",
+    "toastError": "Erro ao adicionar colecionável"
+  },
   "friendbotButton": {
     "title": "Adicionar saldo com Friendbot"
   },

--- a/src/navigators/RootNavigator.tsx
+++ b/src/navigators/RootNavigator.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { CustomHeaderButton } from "components/layout/CustomHeaderButton";
 import CustomNavigationHeader from "components/layout/CustomNavigationHeader";
 import AccountQRCodeScreen from "components/screens/AccountQRCodeScreen";
+import AddCollectibleScreen from "components/screens/AddCollectibleScreen";
 import CollectibleDetailsScreen from "components/screens/CollectibleDetailsScreen";
 import ConnectedAppsScreen from "components/screens/ConnectedAppsScreen";
 import { LoadingScreen } from "components/screens/LoadingScreen";
@@ -155,6 +156,16 @@ export const RootNavigator = () => {
             name={ROOT_NAVIGATOR_ROUTES.COLLECTIBLE_DETAILS_SCREEN}
             component={CollectibleDetailsScreen}
             options={{
+              headerShown: true,
+              header: (props) => <CustomNavigationHeader {...props} />,
+              headerLeft: () => <CustomHeaderButton icon={Icon.X} />,
+            }}
+          />
+          <RootStack.Screen
+            name={ROOT_NAVIGATOR_ROUTES.ADD_COLLECTIBLE_SCREEN}
+            component={AddCollectibleScreen}
+            options={{
+              headerTitle: t("addCollectibleScreen.title"),
               headerShown: true,
               header: (props) => <CustomNavigationHeader {...props} />,
               headerLeft: () => <CustomHeaderButton icon={Icon.X} />,


### PR DESCRIPTION
Closes #240 

This PR adds the UI for the [Add Collectible screen](https://www.figma.com/design/KwkHXQxbNmDllwermJtnRu/Freighter-Mobile?node-id=5923-142677&t=7DnZZRX7cEk5jBjr-1).

The logic for actually adding and storing a collectible will be implemented as a [separate task](https://github.com/orgs/stellar/projects/58/views/2?pane=issue&itemId=122673132&issue=stellar%7Cfreighter-mobile%7C241).

This PR also makes a change so that users are able to `tap on screen buttons while the keyboard is visible` without having to dismiss the keyboard first.

### Add Collectible UI


### Tapping buttons on the background while keyboard is visible

