### PR TITLE
[Blockaid] Search Asset Flow

### DIFF
--- a/src/components/screens/AddTokenScreen/TokenItem.tsx
+++ b/src/components/screens/AddTokenScreen/TokenItem.tsx
@@ -1,6 +1,7 @@
 import ManageTokenRightContent from "components/ManageTokenRightContent";
 import { TokenIcon } from "components/TokenIcon";
 import AddTokenRightContent from "components/screens/AddTokenScreen/AddTokenRightContent";
+import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import {
   TokenTypeWithCustomToken,
@@ -23,42 +24,61 @@ const TokenItem: React.FC<TokenItemProps> = ({
   handleRemoveToken,
   isRemovingToken,
   isScanningToken,
-}) => (
-  <View className="mb-4 flex-row justify-between items-center flex-1">
-    <View className="flex-row items-center flex-1">
-      <TokenIcon
-        token={{
-          type: token.tokenType as TokenTypeWithCustomToken,
-          code: token.tokenCode,
-          issuer: {
-            key: token.issuer,
-          },
-        }}
-      />
-      <View className="ml-4 flex-1 mr-2">
-        <Text md primary medium numberOfLines={1}>
-          {token.tokenCode}
-        </Text>
-        <Text sm secondary medium numberOfLines={1}>
-          {token.domain || "-"}
-        </Text>
+}) => {
+  // Use security information from the token itself
+  const { isSuspicious, isMalicious } = {
+    isSuspicious: token.isSuspicious || token.isMalicious,
+    isMalicious: token.isMalicious,
+  };
+
+  return (
+    <View className="mb-4 flex-row justify-between items-center flex-1">
+      <View className="flex-row items-center flex-1">
+        <View className="relative z-0">
+          <TokenIcon
+            token={{
+              type: token.tokenType as TokenTypeWithCustomToken,
+              code: token.tokenCode,
+              issuer: {
+                key: token.issuer,
+              },
+            }}
+          />
+          {isSuspicious && (
+            <View className="absolute bottom-0 right-0 w-4 h-4 items-center justify-center z-10">
+              <Icon.AlertCircle
+                size={8}
+                themeColor={isMalicious ? "red" : "amber"}
+                withBackground
+              />
+            </View>
+          )}
+        </View>
+        <View className="ml-4 flex-1 mr-2">
+          <Text md primary medium numberOfLines={1}>
+            {token.tokenCode}
+          </Text>
+          <Text sm secondary medium numberOfLines={1}>
+            {token.domain || "-"}
+          </Text>
+        </View>
       </View>
+      {token.hasTrustline ? (
+        <ManageTokenRightContent
+          token={{
+            isNative: token.isNative,
+            id: `${token.tokenCode}:${token.issuer}`,
+          }}
+          handleRemoveToken={handleRemoveToken}
+          isRemovingToken={isRemovingToken}
+        />
+      ) : (
+        <AddTokenRightContent
+          handleAddToken={handleAddToken}
+          isScanningToken={isScanningToken}
+        />
+      )}
     </View>
-    {token.hasTrustline ? (
-      <ManageTokenRightContent
-        token={{
-          isNative: token.isNative,
-          id: `${token.tokenCode}:${token.issuer}`,
-        }}
-        handleRemoveToken={handleRemoveToken}
-        isRemovingToken={isRemovingToken}
-      />
-    ) : (
-      <AddTokenRightContent
-        handleAddToken={handleAddToken}
-        isScanningToken={isScanningToken}
-      />
-    )}
-  </View>
-);
+  );
+};
 export default TokenItem;

--- a/src/config/analyticsConfig.ts
+++ b/src/config/analyticsConfig.ts
@@ -128,6 +128,7 @@ export enum AnalyticsEvent {
 
   // Blockaid Events
   BLOCKAID_TOKEN_SCAN = "blockaid: scanned token",
+  BLOCKAID_BULK_TOKEN_SCAN = "blockaid: bulk scanned tokens",
   BLOCKAID_SITE_SCAN = "blockaid: scanned domain",
   BLOCKAID_TRANSACTION_SCAN = "blockaid: scanned transaction",
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -296,6 +296,9 @@ export type FormattedSearchTokenRecord = {
   tokenType?: TokenTypeWithCustomToken;
   name?: string;
   decimals?: number;
+  isSuspicious?: boolean;
+  isMalicious?: boolean;
+  securityLevel?: string;
 };
 
 /**

--- a/src/hooks/blockaid/useBlockaidToken.ts
+++ b/src/hooks/blockaid/useBlockaidToken.ts
@@ -1,13 +1,16 @@
 import Blockaid from "@blockaid/client";
 import { useAuthenticationStore } from "ducks/auth";
 import { useCallback } from "react";
-import { scanToken } from "services/blockaid/api";
+import { scanBulkTokens, scanToken } from "services/blockaid/api";
 
 interface UseBlockaidTokenResponse {
   scanToken: (
     tokenCode: string,
     tokenIssuer?: string,
   ) => Promise<Blockaid.TokenScanResponse>;
+  scanBulkTokens: (
+    addressList: string[],
+  ) => Promise<Blockaid.TokenBulkScanResponse>;
 }
 
 export const useBlockaidToken = (): UseBlockaidTokenResponse => {
@@ -27,5 +30,19 @@ export const useBlockaidToken = (): UseBlockaidTokenResponse => {
     [network],
   );
 
-  return { scanToken: scanTokenFunction };
+  const scanBulkTokensFunction = useCallback(
+    async (addressList: string[]): Promise<Blockaid.TokenBulkScanResponse> => {
+      if (!addressList.length) {
+        throw new Error("No token codes provided for scanning");
+      }
+
+      return scanBulkTokens({ addressList, network });
+    },
+    [network],
+  );
+
+  return {
+    scanToken: scanTokenFunction,
+    scanBulkTokens: scanBulkTokensFunction,
+  };
 };

--- a/src/services/blockaid/constants.ts
+++ b/src/services/blockaid/constants.ts
@@ -1,5 +1,6 @@
 export const BLOCKAID_ENDPOINTS = {
   SCAN_TOKEN: "/scan-asset",
+  SCAN_BULK_TOKENS: "/scan-asset-bulk",
   SCAN_SITE: "/scan-dapp",
   SCAN_TRANSACTION: "/scan-tx",
 } as const;
@@ -13,6 +14,7 @@ export const BLOCKAID_RESULT_TYPES = {
 
 export const BLOCKAID_ERROR_MESSAGES = {
   TOKEN_SCAN_FAILED: "Failed to scan token",
+  BULK_TOKEN_SCAN_FAILED: "Failed to bulk scan tokens",
   SITE_SCAN_FAILED: "Failed to scan site",
   TRANSACTION_SCAN_FAILED: "Failed to scan transaction",
   NETWORK_NOT_SUPPORTED: "Scanning is not supported on this network",

--- a/src/services/blockaid/types.ts
+++ b/src/services/blockaid/types.ts
@@ -24,6 +24,11 @@ export interface ScanTokenParams {
   network: NETWORKS;
 }
 
+export interface ScanBulkTokensParams {
+  addressList: string[];
+  network: NETWORKS;
+}
+
 export interface ScanSiteParams {
   url: string;
   network: NETWORKS;


### PR DESCRIPTION
Added blockaid scan token to the Add token screen

- Scan tokens when user search for a new token
- Order tokens before showing using the following order
  1. Bening
  2. Suspicious
  3. Malicious

## iOS 
https://github.com/user-attachments/assets/c3092655-8a61-44d2-8221-cce9fcb57554

## Android 🤖
[android_token_search.webm](https://github.com/user-attachments/assets/aba82656-fc59-46a8-926c-70efe8838caf)


closes #210 