### PR TITLE
Enable Freighter mobile detection on Webviews

### DIFF
--- a/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
+++ b/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
@@ -195,6 +195,14 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
                       javaScriptEnabled
                       domStorageEnabled
                       startInLoadingState
+                      injectedJavaScript={`
+                        window.stellar = {
+                          provider: 'freighter',
+                          platform: 'mobile',
+                          version: '0.9.23'
+                        };
+                        true;
+                      `}
                       ref={(ref) => {
                         webViewRefs.current[tab.id] = ref;
                         if (isActive) {

--- a/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
+++ b/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
@@ -195,13 +195,12 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
                       javaScriptEnabled
                       domStorageEnabled
                       startInLoadingState
-                      injectedJavaScript={`
+                      injectedJavaScriptBeforeContentLoaded={`
                         window.stellar = {
                           provider: 'freighter',
                           platform: 'mobile',
                           version: '0.9.23'
                         };
-                        true;
                       `}
                       ref={(ref) => {
                         webViewRefs.current[tab.id] = ref;

--- a/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
+++ b/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
@@ -1,6 +1,6 @@
 import Spinner from "components/Spinner";
 import { DiscoveryHomepage } from "components/screens/DiscoveryScreen/components";
-import { BROWSER_CONSTANTS } from "config/constants";
+import { APP_VERSION, BROWSER_CONSTANTS } from "config/constants";
 import { logger } from "config/logger";
 import { useBrowserTabsStore } from "ducks/browserTabs";
 import { isHomepageUrl } from "helpers/browser";
@@ -189,8 +189,7 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
                     }}
                   >
                     <WebView
-                      // The "iOS" user agent seems to work better for WalletConnect in all cases
-                      userAgent={BROWSER_CONSTANTS.IOS_USER_AGENT}
+                      userAgent={BROWSER_CONSTANTS.DISCOVERY_USER_AGENT}
                       allowsLinkPreview={false}
                       javaScriptEnabled
                       domStorageEnabled
@@ -199,7 +198,7 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
                         window.stellar = {
                           provider: 'freighter',
                           platform: 'mobile',
-                          version: '0.9.23'
+                          version: '${APP_VERSION}'
                         };
                       `}
                       ref={(ref) => {

--- a/src/components/screens/SettingsScreen/AboutScreen/AboutScreen.tsx
+++ b/src/components/screens/SettingsScreen/AboutScreen/AboutScreen.tsx
@@ -11,7 +11,7 @@ import {
   STELLAR_FOUNDATION_PRIVACY_URL,
 } from "config/constants";
 import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
-import { getAppVersion } from "helpers/version";
+import { getAppVersionAndBuildNumber } from "helpers/version";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React from "react";
@@ -25,7 +25,7 @@ type AboutScreenProps = NativeStackScreenProps<
 const AboutScreen: React.FC<AboutScreenProps> = () => {
   const { t } = useAppTranslation();
   const { themeColors } = useColors();
-  const appVersion = getAppVersion();
+  const appVersion = getAppVersionAndBuildNumber();
   const currentYear = new Date().getFullYear();
 
   const linksListItems = [

--- a/src/components/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen/SettingsScreen.tsx
@@ -6,7 +6,7 @@ import Icon from "components/sds/Icon";
 import { FREIGHTER_BASE_URL } from "config/constants";
 import { SETTINGS_ROUTES, SettingsStackParamList } from "config/routes";
 import { useAuthenticationStore } from "ducks/auth";
-import { getAppVersion } from "helpers/version";
+import { getAppVersionAndBuildNumber } from "helpers/version";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React from "react";
@@ -20,7 +20,7 @@ type SettingsScreenProps = NativeStackScreenProps<
 const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation }) => {
   const { logout } = useAuthenticationStore();
   const { t } = useAppTranslation();
-  const appVersion = getAppVersion();
+  const appVersion = getAppVersionAndBuildNumber();
   const { themeColors } = useColors();
 
   const handleLogout = () => {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -266,7 +266,7 @@ export const BROWSER_CONSTANTS = {
   TAB_PREVIEW_TILE_SIZE: "w-[48%] h-64",
   // dApps work differently depending on the user agent, let's use the below for consistent behavior
   IOS_USER_AGENT:
-    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1 FreighterMobile/0.9.23",
   ANDROID_USER_AGENT:
-    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.6533.103 Mobile Safari/537.36",
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.6533.103 Mobile Safari/537.36 FreighterMobile/0.9.23",
 } as const;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Networks } from "@stellar/stellar-sdk";
 import BigNumber from "bignumber.js";
+import { getAppVersion } from "helpers/version";
 import { t } from "i18next";
+
+export const APP_VERSION = getAppVersion();
 
 export const DEFAULT_PADDING = 24;
 export const DEFAULT_ICON_SIZE = 24;
@@ -264,9 +267,7 @@ export const BROWSER_CONSTANTS = {
   TAB_PREVIEW_FAVICON_SIZE: 32,
   TAB_PREVIEW_CLOSE_ICON_SIZE: 12,
   TAB_PREVIEW_TILE_SIZE: "w-[48%] h-64",
+
   // dApps work differently depending on the user agent, let's use the below for consistent behavior
-  IOS_USER_AGENT:
-    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1 FreighterMobile/0.9.23",
-  ANDROID_USER_AGENT:
-    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.6533.103 Mobile Safari/537.36 FreighterMobile/0.9.23",
+  DISCOVERY_USER_AGENT: `Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1 FreighterMobile/${APP_VERSION}`,
 } as const;

--- a/src/helpers/version.ts
+++ b/src/helpers/version.ts
@@ -1,7 +1,9 @@
 import { getVersion, getBuildNumber } from "react-native-device-info";
 
-export const getAppVersion = (): string => {
-  const version = getVersion();
+export const getAppVersion = (): string => getVersion();
+
+export const getAppVersionAndBuildNumber = (): string => {
+  const version = getAppVersion();
   const buildNumber = getBuildNumber();
 
   return `v${version} (${buildNumber})`;


### PR DESCRIPTION
Closes #290 

This PR injects a `window.stellar` object on Discovery webviews with the below properties:
```
window.stellar = {
   provider: "freighter",
   platform: "mobile",
   version: "0.9.23" 
}
```

This PR also appends a Freighter mobile specific string to the `User-Agent` on Discovery webviews like the below:
`(... rest of the user agent string) FreighterMobile/0.9.23`

This will be specially useful for dApps using `Stellar Wallets kit` as it'll detect the browser is being opened from Freighter mobile thus `skipping directly to the Wallet Connect modal` highly reducing user confusion since before users were seeing both the mobile and extension buttons on the same modal as described on [the issue](https://github.com/stellar/freighter-mobile/issues/290).

### Connection step with latest Stellar Wallets kit version (only present on xBull Swap at the moment)

https://github.com/user-attachments/assets/13fc037e-e9e0-4548-bdec-a6f2849897fa

[android-xbull-wc.webm](https://github.com/user-attachments/assets/8471fba8-d913-4500-88a3-34d145ecaee3)


