### PR TITLE
[FEATURE] Verified token lists icons

### DIFF
--- a/__mocks__/api-service.ts
+++ b/__mocks__/api-service.ts
@@ -1,0 +1,30 @@
+import { AxiosInstance } from "axios";
+import { ApiResponse, RequestConfig } from "services/apiFactory";
+
+type GetFn = <T>(
+  url: string,
+  config?: RequestConfig,
+) => Promise<ApiResponse<T>>;
+type PostFn = <T, D = unknown>(
+  url: string,
+  data?: D,
+  config?: RequestConfig,
+) => Promise<ApiResponse<T>>;
+type PutFn = <T, D = unknown>(
+  url: string,
+  data?: D,
+  config?: RequestConfig,
+) => Promise<ApiResponse<T>>;
+type DeleteFn = <T>(
+  url: string,
+  config?: RequestConfig,
+) => Promise<ApiResponse<T>>;
+
+export const mockApiService = {
+  get: jest.fn() as jest.MockedFunction<GetFn>,
+  post: jest.fn() as jest.MockedFunction<PostFn>,
+  put: jest.fn() as jest.MockedFunction<PutFn>,
+  delete: jest.fn() as jest.MockedFunction<DeleteFn>,
+  setAuthToken: jest.fn(),
+  getInstance: () => ({ getUri: () => "mock://uri" }) as AxiosInstance,
+};

--- a/__mocks__/token-list-response.ts
+++ b/__mocks__/token-list-response.ts
@@ -1,0 +1,20 @@
+import { NETWORKS } from "config/constants";
+
+export const MOCK_TOKEN_LIST_RESPONSE = {
+  name: "Mock Tokens List",
+  description: "a mock list of verified tokens",
+  network: NETWORKS.TESTNET,
+  version: "1.0",
+  provider: "test-suite",
+  assets: [
+    {
+      code: "FTT",
+      issuer: "G..",
+      contract: "C..",
+      domain: "example.com",
+      icon: "example.com/image",
+      decimals: 7,
+      name: "Freighter Test Token",
+    },
+  ],
+};

--- a/__tests__/helpers/getIconUrl.test.ts
+++ b/__tests__/helpers/getIconUrl.test.ts
@@ -1,4 +1,4 @@
-import { NETWORKS, NETWORK_URLS } from "config/constants";
+import { NETWORKS } from "config/constants";
 import { getIconUrl } from "helpers/getIconUrl";
 import * as tokenListModule from "helpers/getIconUrlFromTokensLists";
 
@@ -10,7 +10,6 @@ describe("getIconUrl", () => {
   };
 
   const network = NETWORKS.PUBLIC;
-  const networkUrl = NETWORK_URLS.PUBLIC;
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -21,7 +20,7 @@ describe("getIconUrl", () => {
       .spyOn(tokenListModule, "getIconUrlFromTokensLists")
       .mockResolvedValue("https://token-list-icon.png");
 
-    const result = await getIconUrl({ asset, network, networkUrl });
+    const result = await getIconUrl({ asset, network });
 
     expect(result).toBe("https://token-list-icon.png");
     expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);

--- a/__tests__/helpers/getIconUrl.test.ts
+++ b/__tests__/helpers/getIconUrl.test.ts
@@ -1,5 +1,6 @@
 import { NETWORKS } from "config/constants";
 import { getIconUrl } from "helpers/getIconUrl";
+import * as issuerModule from "helpers/getIconUrlFromIssuer";
 import * as tokenListModule from "helpers/getIconUrlFromTokensLists";
 
 describe("getIconUrl", () => {
@@ -26,45 +27,43 @@ describe("getIconUrl", () => {
     expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
   });
 
-  // it("falls back to issuer TOML if token lists returns undefined", async () => {
-  //   jest
-  //     .spyOn(tokenListModule, "getIconUrlFromTokensLists")
-  //     .mockResolvedValue(undefined);
-  //   jest
-  //     .spyOn(issuerModule, "getIconUrlFromIssuer")
-  //     .mockResolvedValue("https://issuer-icon.png");
+  it("falls back to issuer TOML if token lists returns undefined", async () => {
+    jest
+      .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(issuerModule, "getIconUrlFromIssuer")
+      .mockResolvedValue("https://issuer-icon.png");
 
-  //   const result = await getIconUrl({ asset, network, networkUrl });
+    const result = await getIconUrl({ asset, network });
 
-  //   expect(result).toBe("https://issuer-icon.png");
-  //   expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
-  //   expect(issuerModule.getIconUrlFromIssuer).toHaveBeenCalledTimes(1);
-  // });
+    expect(result).toBe("https://issuer-icon.png");
+    expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
+    expect(issuerModule.getIconUrlFromIssuer).toHaveBeenCalledTimes(1);
+  });
 
-  // it("returns undefined if both token lists and issuer TOML fail", async () => {
-  //   jest
-  //     .spyOn(tokenListModule, "getIconUrlFromTokensLists")
-  //     .mockResolvedValue(undefined);
-  //   jest
-  //     .spyOn(issuerModule, "getIconUrlFromIssuer")
-  //     .mockResolvedValue("");
+  it("returns undefined if both token lists and issuer TOML fail", async () => {
+    jest
+      .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+      .mockResolvedValue(undefined);
+    jest.spyOn(issuerModule, "getIconUrlFromIssuer").mockResolvedValue("");
 
-  //   const result = await getIconUrl({ asset, network, networkUrl });
+    const result = await getIconUrl({ asset, network });
 
-  //   expect(result).toEqual("");
-  //   expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
-  //   expect(issuerModule.getIconUrlFromIssuer).toHaveBeenCalledTimes(1);
-  // });
+    expect(result).toEqual("");
+    expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
+    expect(issuerModule.getIconUrlFromIssuer).toHaveBeenCalledTimes(1);
+  });
 
-  // it("does not call issuer TOML if asset.issuer or asset.code is missing", async () => {
-  //   const assetMissing = { contractId: "C123" }; // no issuer/code
-  //   jest
-  //     .spyOn(tokenListModule, "getIconUrlFromTokensLists")
-  //     .mockResolvedValue(undefined);
+  it("does not call issuer TOML if asset.issuer or asset.code is missing", async () => {
+    const assetMissing = { contractId: "C123" }; // no issuer/code
+    jest
+      .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+      .mockResolvedValue(undefined);
 
-  //   const result = await getIconUrl({ asset: assetMissing, network, networkUrl });
+    const result = await getIconUrl({ asset: assetMissing, network });
 
-  //   expect(result).toEqual("");
-  //   expect(issuerModule.getIconUrlFromIssuer).not.toHaveBeenCalled();
-  // });
+    expect(result).toEqual("");
+    expect(issuerModule.getIconUrlFromIssuer).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/helpers/getIconUrl.test.ts
+++ b/__tests__/helpers/getIconUrl.test.ts
@@ -1,0 +1,71 @@
+import { NETWORKS, NETWORK_URLS } from "config/constants";
+import { getIconUrl } from "helpers/getIconUrl";
+import * as tokenListModule from "helpers/getIconUrlFromTokensLists";
+
+describe("getIconUrl", () => {
+  const asset = {
+    issuer: "GABC123ISSUER",
+    contractId: "C123CONTRACT",
+    code: "USDC",
+  };
+
+  const network = NETWORKS.PUBLIC;
+  const networkUrl = NETWORK_URLS.PUBLIC;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns icon from token lists if available", async () => {
+    jest
+      .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+      .mockResolvedValue("https://token-list-icon.png");
+
+    const result = await getIconUrl({ asset, network, networkUrl });
+
+    expect(result).toBe("https://token-list-icon.png");
+    expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
+  });
+
+  // it("falls back to issuer TOML if token lists returns undefined", async () => {
+  //   jest
+  //     .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+  //     .mockResolvedValue(undefined);
+  //   jest
+  //     .spyOn(issuerModule, "getIconUrlFromIssuer")
+  //     .mockResolvedValue("https://issuer-icon.png");
+
+  //   const result = await getIconUrl({ asset, network, networkUrl });
+
+  //   expect(result).toBe("https://issuer-icon.png");
+  //   expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
+  //   expect(issuerModule.getIconUrlFromIssuer).toHaveBeenCalledTimes(1);
+  // });
+
+  // it("returns undefined if both token lists and issuer TOML fail", async () => {
+  //   jest
+  //     .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+  //     .mockResolvedValue(undefined);
+  //   jest
+  //     .spyOn(issuerModule, "getIconUrlFromIssuer")
+  //     .mockResolvedValue("");
+
+  //   const result = await getIconUrl({ asset, network, networkUrl });
+
+  //   expect(result).toEqual("");
+  //   expect(tokenListModule.getIconUrlFromTokensLists).toHaveBeenCalledTimes(1);
+  //   expect(issuerModule.getIconUrlFromIssuer).toHaveBeenCalledTimes(1);
+  // });
+
+  // it("does not call issuer TOML if asset.issuer or asset.code is missing", async () => {
+  //   const assetMissing = { contractId: "C123" }; // no issuer/code
+  //   jest
+  //     .spyOn(tokenListModule, "getIconUrlFromTokensLists")
+  //     .mockResolvedValue(undefined);
+
+  //   const result = await getIconUrl({ asset: assetMissing, network, networkUrl });
+
+  //   expect(result).toEqual("");
+  //   expect(issuerModule.getIconUrlFromIssuer).not.toHaveBeenCalled();
+  // });
+});

--- a/__tests__/helpers/getIconUrlFromTokensLists.test.ts
+++ b/__tests__/helpers/getIconUrlFromTokensLists.test.ts
@@ -1,0 +1,71 @@
+import { NETWORKS } from "config/constants";
+import { getIconUrlFromTokensLists } from "helpers/getIconUrlFromTokensLists";
+import {
+  fetchVerifiedTokens,
+  TOKEN_LISTS_API_SERVICES,
+} from "services/verified-token-lists";
+
+jest.mock("services/verified-token-lists", () => ({
+  fetchVerifiedTokens: jest.fn(),
+  TOKEN_LISTS_API_SERVICES: {},
+}));
+
+describe("getIconUrlFromTokensLists", () => {
+  const mockTokens = [
+    { contract: "ABC123", issuer: "issuer1", icon: "icon-url-1" },
+    { contract: "DEF456", issuer: "issuer2", icon: "icon-url-2" },
+    { contract: "GHI789", issuer: "issuer3" },
+  ];
+
+  beforeEach(() => {
+    (fetchVerifiedTokens as jest.Mock).mockResolvedValue(mockTokens);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the icon when contractId matches", async () => {
+    const icon = await getIconUrlFromTokensLists({
+      asset: { contractId: "abc123" },
+      network: NETWORKS.PUBLIC,
+    });
+    expect(icon).toBe("icon-url-1");
+    expect(fetchVerifiedTokens).toHaveBeenCalledWith({
+      tokenListsApiServices: TOKEN_LISTS_API_SERVICES,
+      network: NETWORKS.PUBLIC,
+    });
+  });
+
+  it("returns the icon when issuer matches", async () => {
+    const icon = await getIconUrlFromTokensLists({
+      asset: { issuer: "ISSUER2" }, // case-insensitive
+      network: NETWORKS.PUBLIC,
+    });
+    expect(icon).toBe("icon-url-2");
+  });
+
+  it("returns undefined when no match is found", async () => {
+    const icon = await getIconUrlFromTokensLists({
+      asset: { contractId: "notfound" },
+      network: NETWORKS.PUBLIC,
+    });
+    expect(icon).toBeUndefined();
+  });
+
+  it("returns undefined when token has no icon", async () => {
+    const icon = await getIconUrlFromTokensLists({
+      asset: { contractId: "GHI789" },
+      network: NETWORKS.PUBLIC,
+    });
+    expect(icon).toBeUndefined();
+  });
+
+  it("handles asset with no contractId or issuer gracefully", async () => {
+    const icon = await getIconUrlFromTokensLists({
+      asset: {},
+      network: NETWORKS.PUBLIC,
+    });
+    expect(icon).toBeUndefined();
+  });
+});

--- a/__tests__/services/verified-token-lists.test.ts
+++ b/__tests__/services/verified-token-lists.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @fnando/consistent-import/consistent-import */
+import { NETWORKS } from "config/constants";
+import { logger } from "config/logger";
+import { fetchVerifiedTokens } from "services/verified-token-lists";
+
+import { mockApiService } from "../../__mocks__/api-service";
+import { MOCK_TOKEN_LIST_RESPONSE } from "../../__mocks__/token-list-response";
+
+describe("Verified Token Lists", () => {
+  it("returns a list off verified assets", async () => {
+    (mockApiService.get as jest.Mock).mockResolvedValue({
+      data: MOCK_TOKEN_LIST_RESPONSE,
+      status: 200,
+      statusText: "OK",
+    });
+
+    const verifiedTokens = await fetchVerifiedTokens({
+      tokenListsApiServices: { [NETWORKS.TESTNET]: [mockApiService] },
+      network: NETWORKS.TESTNET,
+    });
+
+    expect(verifiedTokens).toEqual(MOCK_TOKEN_LIST_RESPONSE.assets);
+  });
+
+  it("logs an error when fetching a list fails", async () => {
+    const error = new Error("Network error");
+    (mockApiService.get as jest.Mock).mockRejectedValue(error);
+
+    const loggerSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+
+    const verifiedAssets = await fetchVerifiedTokens({
+      tokenListsApiServices: { [NETWORKS.TESTNET]: [mockApiService] },
+      network: NETWORKS.TESTNET,
+    });
+
+    expect(verifiedAssets).toEqual([]);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      "fetchVerifiedTokens",
+      expect.stringContaining("Error retrieving verified tokens"),
+      error,
+    );
+
+    loggerSpy.mockRestore();
+  });
+});

--- a/src/components/screens/HistoryScreen/mappers/index.tsx
+++ b/src/components/screens/HistoryScreen/mappers/index.tsx
@@ -99,7 +99,7 @@ export const mapHistoryItemData = async ({
       stellarExpertUrl,
       date,
       fee,
-      networkUrl: networkDetails.networkUrl,
+      network: networkDetails.network,
       themeColors,
     });
   }

--- a/src/components/screens/HistoryScreen/mappers/swap.tsx
+++ b/src/components/screens/HistoryScreen/mappers/swap.tsx
@@ -13,10 +13,10 @@ import {
 import Icon from "components/sds/Icon";
 import { Token } from "components/sds/Token";
 import { Text } from "components/sds/Typography";
-import { NATIVE_TOKEN_CODE, NETWORK_URLS } from "config/constants";
+import { NATIVE_TOKEN_CODE, NETWORKS } from "config/constants";
 import { TokenTypeWithCustomToken } from "config/types";
 import { formatTokenAmount } from "helpers/formatAmount";
-import { getIconUrlFromIssuer } from "helpers/getIconUrlFromIssuer";
+import { getIconUrl } from "helpers/getIconUrl";
 import useColors, { ThemeColors } from "hooks/useColors";
 import { t } from "i18next";
 import React from "react";
@@ -27,7 +27,7 @@ interface SwapHistoryItemData {
   stellarExpertUrl: string;
   date: string;
   fee: string;
-  networkUrl: NETWORK_URLS;
+  network: NETWORKS;
   themeColors: ThemeColors;
 }
 
@@ -39,7 +39,7 @@ export const mapSwapHistoryItem = async ({
   stellarExpertUrl,
   date,
   fee,
-  networkUrl,
+  network,
   themeColors,
 }: SwapHistoryItemData): Promise<HistoryItemData> => {
   const {
@@ -59,19 +59,23 @@ export const mapSwapHistoryItem = async ({
   const destIcon =
     destTokenCodeFinal === NATIVE_TOKEN_CODE
       ? logos.stellar
-      : await getIconUrlFromIssuer({
-          issuerKey: tokenIssuer || "",
-          tokenCode: destTokenCodeFinal || "",
-          networkUrl,
+      : await getIconUrl({
+          asset: {
+            code: destTokenCodeFinal || "",
+            issuer: tokenIssuer || "",
+          },
+          network,
         });
 
   const sourceIcon =
     srcTokenCode === NATIVE_TOKEN_CODE
       ? logos.stellar
-      : await getIconUrlFromIssuer({
-          issuerKey: sourceTokenIssuer || "",
-          tokenCode: srcTokenCode || "",
-          networkUrl,
+      : await getIconUrl({
+          asset: {
+            code: sourceTokenIssuer || "",
+            issuer: srcTokenCode || "",
+          },
+          network,
         });
 
   const ActionIconComponent = (

--- a/src/ducks/tokenIcons.ts
+++ b/src/ducks/tokenIcons.ts
@@ -112,7 +112,6 @@ const processIconBatches = async (params: {
       try {
         // Parse the cache key to get token details
         const [tokenCode, issuerKey] = cacheKey.split(":");
-
         const imageUrl = await getIconUrl({
           asset: {
             code: tokenCode,
@@ -312,6 +311,12 @@ export const useTokenIconsStore = create<TokenIconsState>()(
               };
               // eslint-disable-next-line no-param-reassign
               prev[`${curr.code}:${curr.issuer}`] = icon;
+
+              // We should cache icons by contract ID as well, to be used when adding new tokens by C address.
+              if (curr.contract) {
+                // eslint-disable-next-line no-param-reassign
+                prev[`${curr.code}:${curr.contract}`] = icon;
+              }
             }
             return prev;
           },

--- a/src/helpers/getIconUrl.ts
+++ b/src/helpers/getIconUrl.ts
@@ -5,7 +5,6 @@ import { getIconUrlFromTokensLists } from "helpers/getIconUrlFromTokensLists";
 export const getIconUrl = async ({
   asset,
   network,
-  networkUrl,
 }: {
   asset: {
     issuer?: string;
@@ -13,8 +12,8 @@ export const getIconUrl = async ({
     code?: string;
   };
   network: NETWORKS;
-  networkUrl: NETWORK_URLS;
 }): Promise<string> => {
+  const networkUrl = NETWORK_URLS[network];
   const iconFromList = await getIconUrlFromTokensLists({ asset, network });
   if (iconFromList) return iconFromList;
 

--- a/src/helpers/getIconUrl.ts
+++ b/src/helpers/getIconUrl.ts
@@ -1,0 +1,31 @@
+import { NETWORKS, NETWORK_URLS } from "config/constants";
+import { getIconUrlFromIssuer } from "helpers/getIconUrlFromIssuer";
+import { getIconUrlFromTokensLists } from "helpers/getIconUrlFromTokensLists";
+
+export const getIconUrl = async ({
+  asset,
+  network,
+  networkUrl,
+}: {
+  asset: {
+    issuer?: string;
+    contractId?: string;
+    code?: string;
+  };
+  network: NETWORKS;
+  networkUrl: NETWORK_URLS;
+}): Promise<string> => {
+  const iconFromList = await getIconUrlFromTokensLists({ asset, network });
+  if (iconFromList) return iconFromList;
+
+  if (asset.issuer && asset.code) {
+    return getIconUrlFromIssuer({
+      issuerKey: asset.issuer,
+      tokenCode: asset.code,
+      networkUrl,
+    });
+  }
+
+  // same fallback case as getIconUrlFromIssuer
+  return "";
+};

--- a/src/helpers/getIconUrlFromTokensLists.ts
+++ b/src/helpers/getIconUrlFromTokensLists.ts
@@ -1,0 +1,53 @@
+import { NETWORKS } from "config/constants";
+import {
+  TOKEN_LISTS_API_SERVICES,
+  fetchVerifiedTokens,
+} from "services/verified-token-lists";
+
+/**
+ * Retrieves the icon URL for a given asset from verified Stellar token lists.
+ *
+ * This function searches through a set of verified token lists for a token
+ * that matches either the asset's `contractId` or `issuer`. If a matching token
+ * with an icon is found, the function returns the icon URL.
+ *
+ * @param {Object} params - Parameters for icon URL retrieval.
+ * @param {Object} params.asset - The asset to find the icon for.
+ * @param {string} [params.asset.contractId] - The contract ID of the asset (optional C Address).
+ * @param {string} [params.asset.issuer] - The issuer of the asset (optional G address).
+ * @param {NETWORKS} params.network - The Stellar network to use (e.g., PUBLIC, TESTNET).
+ * @returns {Promise<string | undefined>} A promise that resolves to the token's icon URL if found, or `undefined` if no match exists.
+ *
+ * @example
+ * const iconUrl = await getIconUrlFromTokensLists({
+ *   asset: { contractId: "C...", issuer: "G..." },
+ *   network: NETWORKS.PUBLIC
+ * });
+ */
+
+export const getIconUrlFromTokensLists = async ({
+  asset,
+  network,
+}: {
+  asset: {
+    issuer?: string;
+    contractId?: string;
+  };
+  network: NETWORKS;
+}) => {
+  const { contractId, issuer } = asset;
+  const verifiedTokens = await fetchVerifiedTokens({
+    tokenListsApiServices: TOKEN_LISTS_API_SERVICES,
+    network,
+  });
+
+  const match = verifiedTokens.find(
+    (token) =>
+      token?.icon &&
+      ((contractId &&
+        token.contract?.toLowerCase() === contractId.toLowerCase()) ||
+        (issuer && token.issuer?.toLowerCase() === issuer.toLowerCase())),
+  );
+
+  return match?.icon;
+};

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -76,7 +76,7 @@ export const TabNavigator = () => {
   });
 
   // Fetch icons whenever balances are updated
-  useFetchTokenIcons(networkDetails.networkUrl);
+  useFetchTokenIcons(networkDetails.network);
 
   // Start polling for balance and price updates
   usePricedBalancesPolling({

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -646,7 +646,7 @@ export const handleContractLookup = async (
     issuer,
     isNative: false,
     tokenType: isSacContract
-      ? getTokenType(contractId)
+      ? getTokenType(tokenDetails.name)
       : TokenTypeWithCustomToken.CUSTOM_TOKEN,
     decimals: tokenDetails.decimals,
     name: tokenDetails.name,

--- a/src/services/verified-token-lists/api.ts
+++ b/src/services/verified-token-lists/api.ts
@@ -1,0 +1,54 @@
+import { NETWORKS } from "config/constants";
+import { logger } from "config/logger";
+import { createApiService } from "services/apiFactory";
+import { DEFAULT_TOKENS_LISTS } from "services/verified-token-lists/constants";
+import {
+  TokenListReponseItem,
+  TokenListResponse,
+} from "services/verified-token-lists/types";
+
+export const TOKEN_LISTS_API_SERVICES = {
+  [NETWORKS.PUBLIC]: DEFAULT_TOKENS_LISTS.PUBLIC!.map(({ url }) =>
+    createApiService({ baseURL: url }),
+  ),
+  [NETWORKS.TESTNET]: DEFAULT_TOKENS_LISTS.TESTNET!.map(({ url }) =>
+    createApiService({ baseURL: url }),
+  ),
+};
+
+export const fetchVerifiedTokens = async ({
+  tokenListsApiServices,
+  network,
+}: {
+  tokenListsApiServices: Partial<
+    Record<NETWORKS, ReturnType<Awaited<typeof createApiService>>[]>
+  >;
+  network: NETWORKS;
+}) => {
+  const apiServices = tokenListsApiServices[network] || [];
+  const assetListPromises = apiServices.map(async (service) => {
+    try {
+      const res = await service.get<TokenListResponse>("");
+      return res.data;
+    } catch (err) {
+      logger.error(
+        "fetchVerifiedTokens",
+        `Error retrieving verified tokens from token list: ${service.getInstance().getUri()}`,
+        err,
+      );
+      return null;
+    }
+  });
+
+  const results = await Promise.allSettled(assetListPromises);
+  // combine verified tokens across token lists.
+  return results
+    .filter(
+      (res): res is PromiseFulfilledResult<TokenListResponse> =>
+        res.status === "fulfilled" && res.value != null,
+    )
+    .reduce(
+      (prev, curr) => prev.concat(curr.value.assets),
+      [] as TokenListReponseItem[],
+    );
+};

--- a/src/services/verified-token-lists/constants.ts
+++ b/src/services/verified-token-lists/constants.ts
@@ -1,0 +1,25 @@
+import { NETWORKS } from "config/constants";
+import { TokensLists } from "services/verified-token-lists/types";
+
+export const DEFAULT_TOKENS_LISTS: Partial<TokensLists> = {
+  [NETWORKS.PUBLIC]: [
+    {
+      url: "https://api.stellar.expert/explorer/public/asset-list/top50",
+      isEnabled: true,
+    },
+    {
+      url: "https://raw.githubusercontent.com/soroswap/token-list/main/tokenList.json",
+      isEnabled: true,
+    },
+    {
+      url: "https://lobstr.co/api/v1/sep/assets/curated.json",
+      isEnabled: true,
+    },
+  ],
+  [NETWORKS.TESTNET]: [
+    {
+      url: "https://api.stellar.expert/explorer/testnet/asset-list/top50",
+      isEnabled: true,
+    },
+  ],
+};

--- a/src/services/verified-token-lists/index.ts
+++ b/src/services/verified-token-lists/index.ts
@@ -1,0 +1,3 @@
+export * from "./constants";
+export * from "./types";
+export * from "./api";

--- a/src/services/verified-token-lists/types.ts
+++ b/src/services/verified-token-lists/types.ts
@@ -1,0 +1,30 @@
+import { NETWORKS } from "config/constants";
+
+export interface TokensListItem {
+  url: string;
+  isEnabled: boolean;
+}
+
+export type TokensLists = {
+  [K in NETWORKS]: TokensListItem[];
+};
+
+export interface TokenListReponseItem {
+  code: string;
+  issuer: string;
+  contract: string;
+  org?: string; // org is not optional in the spec but lobstr list does not adhere in this case
+  domain: string;
+  icon: string;
+  decimals: number;
+  name?: string;
+}
+
+export interface TokenListResponse {
+  name: string;
+  description: string;
+  network: string;
+  version: string;
+  provider: string;
+  assets: TokenListReponseItem[];
+}


### PR DESCRIPTION
Closes #246 

- Adds cache for all icons on the default token list.
- Adds helpers to get icons from token lists.
- Adds wrapper helper to get icons by token list first, the fallback to fetching by issuer.
- Adds mock for `apiService` and a mock token list response.
- Adds unit tests for new helpers.

IOS: 
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-29 at 13 25 37" src="https://github.com/user-attachments/assets/7554a2fc-7f08-4663-93f7-e09bd05f94b4" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-28 at 14 09 27" src="https://github.com/user-attachments/assets/bdfb4cfa-bc72-4f70-a45c-85a4bac5d83d" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-29 at 14 20 33" src="https://github.com/user-attachments/assets/81676c33-10a9-41f7-9759-08d32cc261c4" />

Android:
<img width="1080" height="2220" alt="Screenshot_1756499588" src="https://github.com/user-attachments/assets/21c34b8a-772f-494c-ae85-64c12e4f2fc9" />

<img width="1080" height="2220" alt="Screenshot_1756499640" src="https://github.com/user-attachments/assets/bff8c5da-7b7a-47de-9095-85e04b2383ca" />
