### PR TITLE
Only enable Collectibles on Mainnet

### DIFF
--- a/__tests__/helpers/collectibles.test.ts
+++ b/__tests__/helpers/collectibles.test.ts
@@ -460,10 +460,12 @@ describe("collectibles helpers", () => {
           symbol: "TC",
           collectibles: [
             {
+              owner: "test-owner-address",
               token_id: "token1",
               token_uri: "https://example.com/metadata1.json",
             },
             {
+              owner: "test-owner-address",
               token_id: "token2",
               token_uri: "https://example.com/metadata2.json",
             },

--- a/__tests__/hooks/useCollectibleDetailsHeader.test.tsx
+++ b/__tests__/hooks/useCollectibleDetailsHeader.test.tsx
@@ -91,6 +91,7 @@ describe("useCollectibleDetailsHeader", () => {
   const defaultParams = {
     collectionAddress: "test-collection-address",
     collectibleName: "Test NFT",
+    tokenId: "test-token-id",
   };
 
   it("should return handler functions", () => {
@@ -127,6 +128,7 @@ describe("useCollectibleDetailsHeader", () => {
       useCollectibleDetailsHeader({
         collectionAddress: "test-collection",
         collectibleName: undefined,
+        tokenId: "test-token-id",
       }),
     );
 

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -66,6 +66,7 @@ interface Props {
  *
  * Features:
  * - Tab switching between Tokens and Collectibles
+ * - Collectibles tab only shown for PUBLIC network
  * - Memoized content rendering for performance
  * - Dynamic tab styling based on active state
  * - Callback support for tab changes and item interactions
@@ -92,6 +93,11 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
     const { themeColors } = useColors();
 
     const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
+
+    const shouldHideCollectibles = useMemo(
+      () => hideCollectibles || network !== NETWORKS.PUBLIC,
+      [hideCollectibles, network],
+    );
 
     /**
      * Handles tab switching and triggers the optional onTabChange callback
@@ -199,13 +205,13 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
      */
     const renderContent = useMemo(() => {
       // If collectibles are hidden, we should render tokens content only
-      if (hideCollectibles || activeTab === TabType.TOKENS) {
+      if (shouldHideCollectibles || activeTab === TabType.TOKENS) {
         return renderTokensContent;
       }
 
       return renderCollectiblesContent;
     }, [
-      hideCollectibles,
+      shouldHideCollectibles,
       activeTab,
       renderTokensContent,
       renderCollectiblesContent,
@@ -228,7 +234,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
       >
         <View className="flex-row items-center gap-3 mb-4">
           <TouchableOpacity
-            disabled={hideCollectibles}
+            disabled={shouldHideCollectibles}
             className="py-2"
             onPress={() => handleTabChange(TabType.TOKENS)}
           >
@@ -244,7 +250,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
             </Text>
           </TouchableOpacity>
 
-          {!hideCollectibles && (
+          {!shouldHideCollectibles && (
             <TouchableOpacity
               className="py-2"
               onPress={() => handleTabChange(TabType.COLLECTIBLES)}


### PR DESCRIPTION
Our backend is pointing to Mainnet only so let's hide it on Testnet for now.

This PR also fixes some tsc errors from previous collectibles PR.

https://github.com/user-attachments/assets/4b23e2b4-fba2-49e8-a113-f6c2e9c5a2b7
