### PR TITLE
Always require memo on error + UI tweaks

### DIFF
--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -90,10 +90,10 @@ export const DefaultRightContent: React.FC<{ balance: PricedBalance }> = ({
   );
 };
 
-const renderContent = (children: ReactNode, onPress?: () => void) => {
+const renderContent = (children: ReactNode, onPress?: () => void, isSingleRow?: boolean) => {
   if (onPress) {
     return (
-      <TouchableOpacity onPress={onPress} delayPressIn={DEFAULT_PRESS_DELAY}>
+      <TouchableOpacity onPress={onPress} delayPressIn={isSingleRow ? 0 : DEFAULT_PRESS_DELAY}>
         {children}
       </TouchableOpacity>
     );
@@ -133,4 +133,5 @@ export const BalanceRow: React.FC<BalanceRowProps> = ({
       )}
     </BalanceRowContainer>,
     onPress,
+    isSingleRow,
   );

--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -90,10 +90,17 @@ export const DefaultRightContent: React.FC<{ balance: PricedBalance }> = ({
   );
 };
 
-const renderContent = (children: ReactNode, onPress?: () => void, isSingleRow?: boolean) => {
+const renderContent = (
+  children: ReactNode,
+  onPress?: () => void,
+  isSingleRow?: boolean,
+) => {
   if (onPress) {
     return (
-      <TouchableOpacity onPress={onPress} delayPressIn={isSingleRow ? 0 : DEFAULT_PRESS_DELAY}>
+      <TouchableOpacity
+        onPress={onPress}
+        delayPressIn={isSingleRow ? 0 : DEFAULT_PRESS_DELAY}
+      >
         {children}
       </TouchableOpacity>
     );

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -140,7 +140,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
   // We should only wrap in TouchableOpacity if onPress is provided
   // otherwise it would steal the touch event from the parent
   const IconWrapper = onPress ? TouchableOpacity : View;
-  
+
   return (
     <View
       className={`flex flex-col items-center ${title ? "gap-[12px]" : ""} ${isDisabled ? "opacity-50" : "opacity-100"}`}

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -132,17 +132,21 @@ export const IconButton: React.FC<IconButtonProps> = ({
   disabled = false,
   testID,
 }) => {
-  const isDisabled = disabled || !onPress;
+  const isDisabled = disabled;
   const { themeColors } = useColors();
   const sizeConfig = getSizeClasses(size);
   const variantStyles = getVariantStyles(variant, isDisabled, themeColors);
 
+  // We should only wrap in TouchableOpacity if onPress is provided
+  // otherwise it would steal the touch event from the parent
+  const IconWrapper = onPress ? TouchableOpacity : View;
+  
   return (
     <View
       className={`flex flex-col items-center ${title ? "gap-[12px]" : ""} ${isDisabled ? "opacity-50" : "opacity-100"}`}
       testID={testID ?? "icon-button-container"}
     >
-      <TouchableOpacity
+      <IconWrapper
         onPress={onPress}
         disabled={isDisabled}
         testID={`icon-button-${title?.toLowerCase() ?? "button"}`}
@@ -153,7 +157,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
         }}
       >
         <Icon color={variantStyles.iconColor} size={sizeConfig.icon} />
-      </TouchableOpacity>
+      </IconWrapper>
       {title && (
         <Text md medium secondary>
           {title}

--- a/src/components/screens/HomeScreen/ManageAccountBottomSheet.tsx
+++ b/src/components/screens/HomeScreen/ManageAccountBottomSheet.tsx
@@ -49,9 +49,10 @@ const ManageAccountBottomSheet: React.FC<ManageAccountBottomSheetProps> = ({
             <Text md primary semiBold>
               {t("home.manageAccount.title")}
             </Text>
-            <TouchableOpacity onPress={onPressAddAnotherWallet}>
-              <Icon.PlusCircle color={themeColors.base[1]} />
-            </TouchableOpacity>
+            {/* Add a ghost icon here so the title remains centered */}
+            <View className="opacity-0">
+              <Icon.X />
+            </View>
           </View>
         }
       >
@@ -60,7 +61,8 @@ const ManageAccountBottomSheet: React.FC<ManageAccountBottomSheetProps> = ({
           showsVerticalScrollIndicator={false}
           alwaysBounceVertical={false}
           contentContainerStyle={{
-            paddingTop: pxValue(24),
+            paddingTop: pxValue(10),
+            paddingBottom: pxValue(20),
           }}
         >
           {accounts.map((account) => (

--- a/src/components/screens/SendScreen/components/ContactRow.tsx
+++ b/src/components/screens/SendScreen/components/ContactRow.tsx
@@ -13,6 +13,7 @@ interface ContactRowProps {
   name?: string;
   onPress?: () => void;
   onDotsPress?: () => void;
+  isSingleRow?: boolean;
   rightElement?: React.ReactNode;
   className?: string;
   testID?: string;
@@ -29,6 +30,7 @@ export const ContactRow: React.FC<ContactRowProps> = ({
   name,
   onPress,
   onDotsPress,
+  isSingleRow,
   rightElement,
   className,
   testID,
@@ -77,7 +79,7 @@ export const ContactRow: React.FC<ContactRowProps> = ({
     <TouchableOpacity
       className={`flex-row w-full h-[44px] justify-between items-center ${className || ""}`}
       onPress={onPress}
-      delayPressIn={DEFAULT_PRESS_DELAY}
+      delayPressIn={isSingleRow ? 0 : DEFAULT_PRESS_DELAY}
       testID={testID}
     >
       <View className="flex-row items-center flex-1 mr-4">

--- a/src/components/screens/SendScreen/components/SendReviewBottomSheet.tsx
+++ b/src/components/screens/SendScreen/components/SendReviewBottomSheet.tsx
@@ -190,7 +190,7 @@ const SendReviewBottomSheet: React.FC<SendReviewBottomSheetProps> = ({
   };
 
   const isLoading = isValidatingMemo || isBuilding;
-  const isDisabled = isRequiredMemoMissing || !transactionXDR || isLoading;
+  const isDisabled = !transactionXDR || isLoading;
 
   /**
    * Renders the confirm button with different states based on memo validation

--- a/src/components/screens/SendScreen/screens/TransactionAmountScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionAmountScreen.tsx
@@ -548,28 +548,29 @@ const TransactionAmountScreen: React.FC<TransactionAmountScreenProps> = ({
           <View className="rounded-[16px] py-[12px] max-xs:py-[8px] px-[16px] bg-background-tertiary">
             {selectedBalance && (
               <BalanceRow
+                isSingleRow
+                onPress={navigateToSelectTokenScreen}
                 balance={selectedBalance}
                 rightContent={
                   <IconButton
                     Icon={Icon.ChevronRight}
                     size="sm"
                     variant="ghost"
-                    onPress={navigateToSelectTokenScreen}
                   />
                 }
-                isSingleRow
               />
             )}
           </View>
           <View className="rounded-[16px] py-[12px] max-xs:py-[8px] px-[16px] bg-background-tertiary">
             <ContactRow
+              isSingleRow
+              onPress={navigateToSelectContactScreen}
               address={recipientAddress}
               rightElement={
                 <IconButton
                   Icon={Icon.ChevronRight}
                   size="sm"
                   variant="ghost"
-                  onPress={navigateToSelectContactScreen}
                 />
               }
             />

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -47,13 +47,14 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
           style={{ marginHorizontal: pxValue(DEFAULT_PADDING) }}
         >
           <ContactRow
+            isSingleRow
+            onPress={navigateToSelectContactScreen}
             address={recipientAddress}
             rightElement={
               <IconButton
                 Icon={Icon.ChevronRight}
                 size="sm"
                 variant="ghost"
-                onPress={navigateToSelectContactScreen}
               />
             }
           />

--- a/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionTokenScreen.tsx
@@ -51,11 +51,7 @@ const TransactionTokenScreen: React.FC<TransactionTokenScreenProps> = ({
             onPress={navigateToSelectContactScreen}
             address={recipientAddress}
             rightElement={
-              <IconButton
-                Icon={Icon.ChevronRight}
-                size="sm"
-                variant="ghost"
-              />
+              <IconButton Icon={Icon.ChevronRight} size="sm" variant="ghost" />
             }
           />
         </View>

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -33,7 +33,7 @@ import useColors from "hooks/useColors";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
 import { useRightHeaderMenu } from "hooks/useRightHeader";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { View, Text as RNText } from "react-native";
+import { View, Text as RNText, TouchableOpacity } from "react-native";
 import { analytics } from "services/analytics";
 
 type SwapAmountScreenProps = NativeStackScreenProps<
@@ -360,16 +360,16 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
           <View className="rounded-[16px] py-[12px] px-[16px] bg-background-tertiary">
             {sourceBalance && (
               <BalanceRow
+                isSingleRow
                 balance={sourceBalance}
+                onPress={navigateToSelectSourceTokenScreen}
                 rightContent={
                   <IconButton
                     Icon={Icon.ChevronRight}
                     size="sm"
                     variant="ghost"
-                    onPress={navigateToSelectSourceTokenScreen}
                   />
                 }
-                isSingleRow
               />
             )}
           </View>
@@ -377,19 +377,22 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
           <View className="rounded-[16px] py-[12px] px-[16px] bg-background-tertiary">
             {destinationBalance ? (
               <BalanceRow
+                isSingleRow  
                 balance={destinationBalance}
-                isSingleRow
+                onPress={navigateToSelectDestinationTokenScreen}
                 rightContent={
                   <IconButton
                     Icon={Icon.ChevronRight}
                     size="sm"
                     variant="ghost"
-                    onPress={navigateToSelectDestinationTokenScreen}
                   />
                 }
               />
             ) : (
-              <View className="flex-row w-full h-[44px] justify-between items-center">
+              <TouchableOpacity
+                className="flex-row w-full h-[44px] justify-between items-center"
+                onPress={navigateToSelectDestinationTokenScreen}
+              >
                 <View className="flex-row items-center flex-1 mr-4">
                   <View className="flex-row items-center gap-16px">
                     <View className="w-[40px] h-[40px] rounded-full border justify-center items-center mr-4 bg-gray-3 border-gray-6 p-[7.5px]">
@@ -407,9 +410,8 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
                   Icon={Icon.ChevronRight}
                   size="sm"
                   variant="ghost"
-                  onPress={navigateToSelectDestinationTokenScreen}
                 />
-              </View>
+              </TouchableOpacity>
             )}
           </View>
         </View>

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -377,7 +377,7 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
           <View className="rounded-[16px] py-[12px] px-[16px] bg-background-tertiary">
             {destinationBalance ? (
               <BalanceRow
-                isSingleRow  
+                isSingleRow
                 balance={destinationBalance}
                 onPress={navigateToSelectDestinationTokenScreen}
                 rightContent={

--- a/src/hooks/useValidateTransactionMemo.ts
+++ b/src/hooks/useValidateTransactionMemo.ts
@@ -168,11 +168,9 @@ export const useValidateTransactionMemo = (incomingXdr?: string | null) => {
       } catch (error) {
         logger.error("Memo Validation", "Error validating memo", error);
 
-        if (error instanceof Error && "accountId" in error) {
-          setIsMemoMissing(true);
-        } else {
-          setIsMemoMissing(false);
-        }
+        // If there's any error, we assume the memo is missing to be safe
+        // so we prevent lost of funds due to a missing memo.
+        setIsMemoMissing(true);
       } finally {
         setIsValidatingMemo(false);
       }


### PR DESCRIPTION
This PR makes a change so that memo is always required whenever there is an error during memo check.
E.g.: if horizon goes down and we are unable to check if memo is required then we'll always require it to prevent users losing funds due to a possibly missing memo.

This PR also applies some other UI tweaks like:
- Greater touching area on Send and Swap amount screen selectors
- Remove duplicate header "+" button for "Add wallet" functionality

https://github.com/user-attachments/assets/4b87c8dd-1f8f-450f-9fb4-2ec592490622

### Blue area is now touchable
<img width="350" height="1084" alt="Screenshot 2025-09-04 at 15 15 45" src="https://github.com/user-attachments/assets/cd470dcc-2f35-49ef-bb51-33641464f1e0" />
