### PR TITLE
[FIX] Improve balance Items percentage comparison

### DIFF
--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -1,6 +1,9 @@
 import { TokenIcon } from "components/TokenIcon";
 import { Text } from "components/sds/Typography";
-import { DEFAULT_PRESS_DELAY } from "config/constants";
+import {
+  DEFAULT_PRESS_DELAY,
+  POSITIVE_PRICE_CHANGE_THRESHOLD,
+} from "config/constants";
 import { THEME } from "config/theme";
 import { PricedBalance } from "config/types";
 import { isLiquidityPool } from "helpers/balances";
@@ -73,7 +76,9 @@ export const DefaultRightContent: React.FC<{ balance: PricedBalance }> = ({
             sm
             medium
             color={
-              balance.percentagePriceChange24h?.gt(0)
+              balance.percentagePriceChange24h?.gte(
+                POSITIVE_PRICE_CHANGE_THRESHOLD,
+              )
                 ? THEME.colors.status.success
                 : THEME.colors.text.secondary
             }

--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -4,7 +4,6 @@ import {
   DEFAULT_PRESS_DELAY,
   POSITIVE_PRICE_CHANGE_THRESHOLD,
 } from "config/constants";
-import { THEME } from "config/theme";
 import { PricedBalance } from "config/types";
 import { isLiquidityPool } from "helpers/balances";
 import { px } from "helpers/dimensions";
@@ -13,6 +12,7 @@ import {
   formatFiatAmount,
   formatPercentageAmount,
 } from "helpers/formatAmount";
+import useColors from "hooks/useColors";
 import React, { ReactNode } from "react";
 import { TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
@@ -62,6 +62,7 @@ interface BalanceRowProps {
 export const DefaultRightContent: React.FC<{ balance: PricedBalance }> = ({
   balance,
 }) => {
+  const { themeColors } = useColors();
   const isLP = isLiquidityPool(balance);
   const width = isLP ? 20 : 115;
 
@@ -79,8 +80,8 @@ export const DefaultRightContent: React.FC<{ balance: PricedBalance }> = ({
               balance.percentagePriceChange24h?.gte(
                 POSITIVE_PRICE_CHANGE_THRESHOLD,
               )
-                ? THEME.colors.status.success
-                : THEME.colors.text.secondary
+                ? themeColors.status.success
+                : themeColors.text.secondary
             }
           >
             {formatPercentageAmount(balance.percentagePriceChange24h)}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,6 +11,7 @@ export const DEFAULT_PADDING = 24;
 export const DEFAULT_ICON_SIZE = 24;
 export const DEFAULT_DEBOUNCE_DELAY = 500;
 export const DEFAULT_RECOMMENDED_STELLAR_FEE = "100";
+export const POSITIVE_PRICE_CHANGE_THRESHOLD = new BigNumber(0.01);
 
 export const TOGGLE_ANIMATION_DURATION = 400;
 


### PR DESCRIPTION
Added new condition to the percentage color comparison: 

- before: greater than 0 
- now: greater than 0.01


https://github.com/user-attachments/assets/2ee1d771-748f-4184-aa59-f598dea94969