### PR TITLE
Ensure collectible size adapts to the screen size

### DIFF
--- a/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
+++ b/src/components/screens/CollectibleDetailsScreen/CollectibleDetailsScreen.tsx
@@ -6,6 +6,7 @@ import { BaseLayout } from "components/layout/BaseLayout";
 import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
+import { DEFAULT_PADDING } from "config/constants";
 import { logger } from "config/logger";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { useCollectiblesStore } from "ducks/collectibles";
@@ -14,7 +15,10 @@ import useAppTranslation from "hooks/useAppTranslation";
 import { useCollectibleDetailsHeader } from "hooks/useCollectibleDetailsHeader";
 import useColors from "hooks/useColors";
 import React, { useMemo, useCallback } from "react";
-import { Linking, ScrollView, View } from "react-native";
+import { Dimensions, Linking, ScrollView, View } from "react-native";
+
+// Get window width once at module level for better performance
+const { width: windowWidth } = Dimensions.get("window");
 
 type CollectibleDetailsScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -191,7 +195,10 @@ export const CollectibleDetailsScreen: React.FC<CollectibleDetailsScreenProps> =
           contentContainerStyle={{ paddingBottom: pxValue(40) }}
         >
           {/* Collectible Image */}
-          <View className="w-[354px] h-[354px] rounded-[32px] overflow-hidden mt-2 mb-6">
+          <View
+            className="w-full rounded-[32px] overflow-hidden mt-2 mb-6"
+            style={{ height: windowWidth - 2 * pxValue(DEFAULT_PADDING) }}
+          >
             <CollectibleImage
               imageUri={collectible.image}
               placeholderIconSize={90}


### PR DESCRIPTION
The frame was wrongly using a fixed width and height instead of making it adapt to the screen size.

### Before fix
<img width="400" height="1067" alt="Screenshot 2025-09-08 at 09 48 27" src="https://github.com/user-attachments/assets/ffb98b7d-b233-44f6-a865-61fd516836b7" />

### After fix
<img width="400" height="1067" alt="Screenshot 2025-09-08 at 09 46 28" src="https://github.com/user-attachments/assets/b9dbde84-4ea2-4f7c-8e9c-760813cc3d0b" />