### PR TITLE
add error handling for wallet connect and freighter qr code auto scan

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -371,6 +371,26 @@ export enum QRCodeSource {
 export type QRCodeSourceType = `${QRCodeSource}`;
 
 /**
+ * QR Code validation result types
+ */
+export enum QRCodeType {
+  STELLAR_ADDRESS = "stellar_address",
+  UNKNOWN = "unknown",
+}
+
+/**
+ * QR Code validation error types
+ */
+export enum QRCodeError {
+  SELF_SEND = "self_send",
+  INVALID_FORMAT = "invalid_format",
+}
+
+/**
+ * QR Code validation result interface
+ */
+
+/**
  * Helper function to check if a string is a valid QR code source
  */
 export const isValidQRCodeSource = (

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -131,7 +131,8 @@
     "inputPlaceholder": "WalletConnect URI",
     "connect": "Connect",
     "pairingError": "Failed to pair",
-    "invalidUriError": "Please enter a valid QR Code URI"
+    "invalidUriError": "Please enter a valid QR Code URI",
+    "invalidQrScanUriError": "Invalid WalletConnect Address"
   },
   "qrCodeScannerScreen": {
     "title": "Scan to send"

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -804,7 +804,8 @@
     "inputPlaceholder": "URI do WalletConnect",
     "connect": "Conectar",
     "pairingError": "Falha ao parear",
-    "invalidUriError": "Por favor, insira um URI do WalletConnect válido"
+    "invalidUriError": "Por favor, insira um URI do WalletConnect válido",
+    "invalidQrScanUriError": "Endereço WalletConnect Inválido"
   },
   "qrCodeScannerScreen": {
     "title": "Escanear para enviar"


### PR DESCRIPTION
Closes #339 

@CassioMG  @sdfcharles  -> Also added error message for invalid QR codes ,not only when self QR code. I know we talked before about not throwing erros and keep scanning, but maybe a toast for the user to know it was scanned, just invalid? and keep the camera view open. If not desired for invalid codes, let me know, then I can just remove this part of the code

https://github.com/user-attachments/assets/cc2f4e49-8de2-4348-bbd5-a0b9a3c1274d

