### PR TITLE
Allow automatic Collectibles fetching

### DIFF
--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -18,7 +18,7 @@ import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
-import React, { useCallback, useMemo, useEffect, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { TouchableOpacity, View, FlatList, RefreshControl } from "react-native";
 
 /**
@@ -66,13 +66,6 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
 
     // Local state for managing refresh UI only
     const [isRefreshing, setIsRefreshing] = useState(false);
-
-    // Fetch collectibles when component mounts
-    useEffect(() => {
-      if (account?.publicKey && network) {
-        fetchCollectibles({ publicKey: account.publicKey, network });
-      }
-    }, [fetchCollectibles, account?.publicKey, network]);
 
     const handleRefresh = useCallback(() => {
       if (account?.publicKey && network) {
@@ -150,7 +143,7 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
             ListFooterComponent={DefaultListFooter}
             refreshControl={
               <RefreshControl
-                refreshing={isRefreshing}
+                refreshing={isRefreshing || isLoading}
                 tintColor={themeColors.secondary}
                 onRefresh={handleRefresh}
               />

--- a/src/components/TokensCollectiblesTabs.tsx
+++ b/src/components/TokensCollectiblesTabs.tsx
@@ -10,6 +10,7 @@ import {
   ROOT_NAVIGATOR_ROUTES,
   RootStackParamList,
 } from "config/routes";
+import { useCollectiblesStore } from "ducks/collectibles";
 import { isIOS } from "helpers/device";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -92,6 +93,10 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
     const { t } = useAppTranslation();
     const { themeColors } = useColors();
 
+    const isCollectiblesLoading = useCollectiblesStore(
+      (state) => state.isLoading,
+    );
+
     const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
 
     const shouldHideCollectibles = useMemo(
@@ -155,6 +160,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
             ios: "plus.rectangle.on.rectangle",
             android: "add_box",
           }),
+          disabled: isCollectiblesLoading,
           onPress: () =>
             navigation.navigate(ROOT_NAVIGATOR_ROUTES.ADD_COLLECTIBLE_SCREEN),
         },
@@ -162,7 +168,7 @@ export const TokensCollectiblesTabs: React.FC<Props> = React.memo(
 
       // Reverse the array for iOS to match Android behavior
       return isIOS ? actions.reverse() : actions;
-    }, [t, navigation]);
+    }, [t, navigation, isCollectiblesLoading]);
 
     /**
      * Renders the tokens/balances list content

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -312,15 +312,6 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
         publicKey,
       });
 
-      if (collectiblesContracts.length === 0) {
-        // No collectibles to fetch, set empty state
-        set({
-          collections: [],
-          isLoading: false,
-        });
-        return;
-      }
-
       // Transform local storage data to API format
       const contracts = collectiblesContracts.map((contract) => ({
         id: contract.contractId,

--- a/src/hooks/useFetchCollectibles.ts
+++ b/src/hooks/useFetchCollectibles.ts
@@ -1,0 +1,59 @@
+import { NETWORKS } from "config/constants";
+import { useCollectiblesStore } from "ducks/collectibles";
+import { useEffect } from "react";
+
+/**
+ * Parameters for fetching collectibles
+ * @property {string} [publicKey] - The Stellar account public key
+ * @property {NETWORKS} [network] - The Stellar network to fetch from (e.g., PUBLIC, TESTNET)
+ */
+interface FetchCollectiblesParams {
+  publicKey?: string;
+  network?: NETWORKS;
+}
+
+/**
+ * Hook to fetch and manage collectibles for a Stellar account.
+ *
+ * Automatically fetches account collectibles when:
+ * - The component mounts
+ * - The public key changes
+ * - The network changes
+ *
+ * @param {FetchCollectiblesParams} params - The parameters for fetching collectibles
+ * @param {string} [params.publicKey] - The Stellar account public key
+ * @param {NETWORKS} [params.network] - The Stellar network to fetch from
+ *
+ * @example
+ * // Basic usage
+ * function AccountCollectibles() {
+ *   useFetchCollectibles({
+ *     publicKey: "GBBD...",
+ *     network: NETWORKS.PUBLIC
+ *   });
+ *   // ... rest of the component
+ * }
+ *
+ * @remarks
+ * - Uses the collectibles store to manage state
+ * - Automatically refetches when dependencies change
+ * - Prevents duplicate requests with built-in loading state check
+ * - Only fetches when both publicKey and network are provided
+ */
+export const useFetchCollectibles = ({
+  publicKey,
+  network,
+}: FetchCollectiblesParams) => {
+  const fetchCollectibles = useCollectiblesStore(
+    (state) => state.fetchCollectibles,
+  );
+
+  useEffect(() => {
+    if (publicKey && network) {
+      fetchCollectibles({
+        publicKey,
+        network,
+      });
+    }
+  }, [fetchCollectibles, publicKey, network]);
+};

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -10,6 +10,7 @@ import { THEME } from "config/theme";
 import { useAuthenticationStore } from "ducks/auth";
 import { useProtocolsStore } from "ducks/protocols";
 import { px, pxValue } from "helpers/dimensions";
+import { useFetchCollectibles } from "hooks/useFetchCollectibles";
 import { useFetchPricedBalances } from "hooks/useFetchPricedBalances";
 import { useFetchTokenIcons } from "hooks/useFetchTokenIcons";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
@@ -72,6 +73,12 @@ export const TabNavigator = () => {
   // Fetch balances when component mounts or when publicKey/network changes
   useFetchPricedBalances({
     publicKey: publicKey ?? "",
+    network: networkDetails.network,
+  });
+
+  // Fetch collectibles when component mounts or when publicKey/network changes
+  useFetchCollectibles({
+    publicKey,
     network: networkDetails.network,
   });
 


### PR DESCRIPTION
This PR makes it so the app will fetch Collectibles early on Home screen using only the wallet public key so that users don't necessarily need to manually add a Collectible beforehand to trigger the fetching.


https://github.com/user-attachments/assets/24e79c65-b8cc-4e7d-8581-8a05dc20dd74

