### PR TITLE
[Save to Photos] Use only write permissions on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,11 +3,8 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.USE_BIOMETRIC" />
   <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
     android:maxSdkVersion="32" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <queries>
     <intent>


### PR DESCRIPTION
We had some back and forth issues with Android permissions while implementing and testing this feature and ended up leaving broader permissions since it seemed to fix an error on saving photos on Android 14 and below but Google Play rejected the app because we shouldn't need read permissions if we are only writing to file.

It turns out the underlying issue was related to malformed file names with spaces and special characters, e.g.: `...FTC #0...png`.

So this PR fixes that by removing the read permissions and sanitizing the file name while writing to the external storage.

I've tested it from `Android 10` up to `Android 16` and it seems to be working just fine. It should also be working on lower versions down to `Android 7`.