### PR TITLE
Discover grid UI polish + close all tabs

### DIFF
--- a/__tests__/hooks/useBrowserActions.test.tsx
+++ b/__tests__/hooks/useBrowserActions.test.tsx
@@ -65,6 +65,7 @@ describe("useBrowserActions", () => {
   };
 
   const mockStore = {
+    tabs: [],
     activeTabId: "tab-123",
     goToPage: jest.fn(),
     closeTab: jest.fn(),
@@ -268,9 +269,8 @@ describe("useBrowserActions", () => {
       const { result } = renderHook(() => useBrowserActions(mockWebViewRef));
 
       const actions = result.current.contextMenuActions;
-      expect(actions).toHaveLength(2);
+      expect(actions).toHaveLength(1);
       // The order might be different due to iOS/Android platform differences
-      expect(actions.map((a) => a.title)).toContain("discovery.closeAllTabs");
       expect(actions.map((a) => a.title)).toContain("discovery.closeThisTab");
     });
 

--- a/src/components/screens/DiscoveryScreen/DiscoveryScreen.tsx
+++ b/src/components/screens/DiscoveryScreen/DiscoveryScreen.tsx
@@ -214,6 +214,11 @@ export const DiscoveryScreen: React.FC<DiscoveryScreenProps> = () => {
     ],
   );
 
+  const handleCloseAllTabs = useCallback(() => {
+    browserActions.handleCloseAllTabs();
+    handleNewTabFromOverview();
+  }, [browserActions, handleNewTabFromOverview]);
+
   if (!activeTab) {
     return (
       <BaseLayout>
@@ -283,6 +288,7 @@ export const DiscoveryScreen: React.FC<DiscoveryScreenProps> = () => {
           onClose={handleHideTabs}
           onSwitchTab={handleSwitchTab}
           onCloseTab={handleCloseSpecificTab}
+          onCloseAllTabs={handleCloseAllTabs}
           newTabId={newTabId}
         />
       </Animated.View>

--- a/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
+++ b/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
@@ -1,6 +1,6 @@
-import { DefaultListFooter } from "components/DefaultListFooter";
 import { CustomHeaderButton } from "components/layout/CustomHeaderButton";
 import { TabPreview } from "components/screens/DiscoveryScreen/components";
+import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import {
@@ -11,6 +11,7 @@ import {
 import { useBrowserTabsStore } from "ducks/browserTabs";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
+import useColors from "hooks/useColors";
 import React from "react";
 import { View, TouchableOpacity, FlatList } from "react-native";
 
@@ -49,13 +50,23 @@ interface TabOverviewProps {
   onNewTab: () => void;
   onSwitchTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
+  onCloseAllTabs: () => void;
   newTabId?: string | null;
 }
 
 // Memoize to avoid unnecessary expensive re-renders
 const TabOverview: React.FC<TabOverviewProps> = React.memo(
-  ({ onClose, onNewTab, onSwitchTab, onCloseTab, newTabId }) => {
+  ({
+    onClose,
+    onNewTab,
+    onSwitchTab,
+    onCloseTab,
+    onCloseAllTabs,
+    newTabId,
+  }) => {
     const { tabs, isTabActive } = useBrowserTabsStore();
+    const { t } = useAppTranslation();
+    const { themeColors } = useColors();
 
     // Filter out the specific new tab being added to prevent showing
     // its preview while it's being added so we have a smoother UI transition
@@ -77,9 +88,24 @@ const TabOverview: React.FC<TabOverviewProps> = React.memo(
           numColumns={2}
           columnWrapperStyle={{
             justifyContent: "space-between",
-            marginBottom: pxValue(14),
+            marginBottom: pxValue(16),
           }}
-          ListFooterComponent={DefaultListFooter}
+          ListFooterComponent={
+            <View className="mx-auto mt-3 mb-1">
+              <Button
+                secondary
+                icon={
+                  <Icon.XCircle
+                    color={themeColors.foreground.primary}
+                    size={18}
+                  />
+                }
+                onPress={onCloseAllTabs}
+              >
+                {t("discovery.closeAllTabs")}
+              </Button>
+            </View>
+          }
           contentContainerStyle={{ padding: pxValue(DEFAULT_PADDING) }}
           keyExtractor={(tab) => tab.id}
           renderItem={({ item: tab }) => (

--- a/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
+++ b/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_PRESS_DELAY,
 } from "config/constants";
 import { useBrowserTabsStore } from "ducks/browserTabs";
+import { isHomepageUrl } from "helpers/browser";
 import { pxValue } from "helpers/dimensions";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
@@ -74,6 +75,11 @@ const TabOverview: React.FC<TabOverviewProps> = React.memo(
       ? tabs.filter((tab) => tab.id !== newTabId)
       : tabs;
 
+    // Check if we should show the "Close all tabs" button
+    // Hide it if there's only 1 tab and it's the homepage
+    const shouldShowCloseAllButton =
+      tabs.length > 1 || (tabs.length === 1 && !isHomepageUrl(tabs[0]?.url));
+
     return (
       <View className="relative flex-1">
         <TabOverviewHeader
@@ -91,20 +97,22 @@ const TabOverview: React.FC<TabOverviewProps> = React.memo(
             marginBottom: pxValue(16),
           }}
           ListFooterComponent={
-            <View className="mx-auto mt-3 mb-1">
-              <Button
-                secondary
-                icon={
-                  <Icon.XCircle
-                    color={themeColors.foreground.primary}
-                    size={18}
-                  />
-                }
-                onPress={onCloseAllTabs}
-              >
-                {t("discovery.closeAllTabs")}
-              </Button>
-            </View>
+            shouldShowCloseAllButton ? (
+              <View className="mx-auto mt-3 mb-1">
+                <Button
+                  secondary
+                  icon={
+                    <Icon.XCircle
+                      color={themeColors.foreground.primary}
+                      size={18}
+                    />
+                  }
+                  onPress={onCloseAllTabs}
+                >
+                  {t("discovery.closeAllTabs")}
+                </Button>
+              </View>
+            ) : null
           }
           contentContainerStyle={{ padding: pxValue(DEFAULT_PADDING) }}
           keyExtractor={(tab) => tab.id}

--- a/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
+++ b/src/components/screens/DiscoveryScreen/components/TabOverview.tsx
@@ -28,7 +28,7 @@ const TabOverviewHeader: React.FC<TabOverviewHeaderProps> = ({
   const { t } = useAppTranslation();
 
   return (
-    <View className="flex-row items-center justify-between px-6 py-4 border-b border-border-primary">
+    <View className="flex-row items-center justify-between px-6 py-4">
       <CustomHeaderButton position="left" icon={Icon.X} onPress={onClose} />
       <Text lg semiBold>
         {tabsCount > 1

--- a/src/components/screens/DiscoveryScreen/components/TabPreview.tsx
+++ b/src/components/screens/DiscoveryScreen/components/TabPreview.tsx
@@ -75,8 +75,8 @@ const TabPreview: React.FC<TabPreviewProps> = React.memo(
 
     return (
       <View
-        className={`w-full h-full rounded-lg bg-background-secondary overflow-hidden relative ${
-          isActive ? "border-2 border-primary" : "border border-border-primary"
+        className={`w-full h-full rounded-[16px] bg-background-secondary overflow-hidden relative ${
+          isActive ? "border-[2px] border-primary" : ""
         }`}
       >
         {renderPreviewContent}
@@ -84,11 +84,11 @@ const TabPreview: React.FC<TabPreviewProps> = React.memo(
         {/* Close button */}
         <TouchableOpacity
           onPress={onClose}
-          className="absolute top-2 right-2 w-6 h-6 rounded-full bg-background-tertiary justify-center items-center"
+          className="absolute top-3 right-3 w-6 h-6 rounded-full border-[1px] border-border-primary bg-background-primary justify-center items-center"
         >
           <Icon.X
             size={pxValue(BROWSER_CONSTANTS.TAB_PREVIEW_CLOSE_ICON_SIZE)}
-            color={themeColors.base[1]}
+            color={themeColors.foreground.primary}
           />
         </TouchableOpacity>
       </View>

--- a/src/components/screens/DiscoveryScreen/components/UrlBar.tsx
+++ b/src/components/screens/DiscoveryScreen/components/UrlBar.tsx
@@ -26,7 +26,7 @@ const UrlBar: React.FC<UrlBarProps> = React.memo(
 
     return (
       <View
-        className="flex-row items-center gap-3 border-b border-border-primary"
+        className="flex-row items-center gap-3"
         style={{
           paddingHorizontal: pxValue(DEFAULT_PADDING),
           paddingBottom: pxValue(13),

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -308,8 +308,8 @@ export const BROWSER_CONSTANTS = {
   TAB_SWITCH_SPINNER_DELAY: 500,
   TAB_SWITCH_SPINNER_DURATION: 200,
   TAB_PREVIEW_FAVICON_SIZE: 32,
-  TAB_PREVIEW_CLOSE_ICON_SIZE: 12,
-  TAB_PREVIEW_TILE_SIZE: "w-[48%] h-64",
+  TAB_PREVIEW_CLOSE_ICON_SIZE: 14,
+  TAB_PREVIEW_TILE_SIZE: "w-[47.7%] h-[202px]",
 
   // dApps work differently depending on the user agent, let's use the below for consistent behavior
   DISCOVERY_USER_AGENT: `Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1 FreighterMobile/${APP_VERSION}`,

--- a/src/hooks/useBrowserActions.ts
+++ b/src/hooks/useBrowserActions.ts
@@ -16,7 +16,7 @@ import { WebView } from "react-native-webview";
 export const useBrowserActions = (
   webViewRef: React.RefObject<WebView | null>,
 ) => {
-  const { activeTabId, goToPage, closeTab, closeAllTabs, getActiveTab } =
+  const { tabs, activeTabId, goToPage, closeTab, closeAllTabs, getActiveTab } =
     useBrowserTabsStore();
 
   const { t } = useAppTranslation();
@@ -116,15 +116,19 @@ export const useBrowserActions = (
     // If on homepage, only show close actions
     if (isOnHomepage) {
       const homepageActions = [
-        {
-          title: t("discovery.closeAllTabs"),
-          systemIcon: Platform.select({
-            ios: "xmark.circle.fill",
-            android: "close",
-          }),
-          onPress: handleCloseAllTabs,
-          destructive: true,
-        },
+        ...(tabs.length > 1
+          ? [
+              {
+                title: t("discovery.closeAllTabs"),
+                systemIcon: Platform.select({
+                  ios: "xmark.circle.fill",
+                  android: "close",
+                }),
+                onPress: handleCloseAllTabs,
+                destructive: true,
+              },
+            ]
+          : []),
         {
           title: t("discovery.closeThisTab"),
           systemIcon: Platform.select({
@@ -188,6 +192,7 @@ export const useBrowserActions = (
     return isIOS ? allActions.reverse() : allActions;
   }, [
     isOnHomepage,
+    tabs.length,
     t,
     handleOpenInBrowser,
     handleShare,


### PR DESCRIPTION
Closes #307 

This PR applies UI polishes on discover grid to match what we have on Figma and also adds a "Close all tabs" button as the footer component.

### iOS

### Android