### PR TITLE
[BUG] Add token lags

### DIFF
--- a/__tests__/hooks/useTokenLookup.test.tsx
+++ b/__tests__/hooks/useTokenLookup.test.tsx
@@ -10,12 +10,16 @@ import {
 import { useTokenLookup } from "hooks/useTokenLookup";
 
 // Mock helpers
-jest.mock("helpers/balances", () => ({
-  formatTokenIdentifier: (tokenId: string) => {
-    const [tokenCode, issuer] = tokenId.split(":");
-    return { tokenCode, issuer };
-  },
-}));
+jest.mock("helpers/balances", () => {
+  const originalModule = jest.requireActual("helpers/balances");
+  return {
+    ...originalModule,
+    formatTokenIdentifier: (tokenId: string) => {
+      const [tokenCode, issuer] = tokenId.split(":");
+      return { tokenCode, issuer };
+    },
+  };
+});
 
 jest.mock("helpers/soroban", () => ({
   isContractId: (value: string) => value.startsWith("C") && value.length === 56,
@@ -156,7 +160,6 @@ describe("useTokenLookup", () => {
       }),
     );
 
-    expect(result.current.searchTerm).toBe("");
     expect(result.current.searchResults).toEqual([]);
     expect(result.current.status).toBe(HookStatus.IDLE);
   });
@@ -182,29 +185,8 @@ describe("useTokenLookup", () => {
       result.current.resetSearch();
     });
 
-    expect(result.current.searchTerm).toBe("");
     expect(result.current.searchResults).toEqual([]);
     expect(result.current.status).toBe(HookStatus.IDLE);
-  });
-
-  it("should search for tokens and update results", async () => {
-    const { result } = renderHook(() =>
-      useTokenLookup({
-        network: mockNetwork,
-        publicKey: mockPublicKey,
-        balanceItems: mockBalanceItems,
-      }),
-    );
-
-    act(() => {
-      result.current.handleSearch("USDC");
-    });
-
-    // Wait longer for async operations
-    await flushPromises();
-
-    // Only test the search term, not the status which may take longer to update
-    expect(result.current.searchTerm).toBe("USDC");
   });
 
   it("should handle error when search fails", async () => {
@@ -222,57 +204,7 @@ describe("useTokenLookup", () => {
 
     await flushPromises();
 
-    expect(result.current.searchTerm).toBe("error");
-  });
-
-  it("should search for contract tokens", async () => {
-    const contractId =
-      "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
-
-    const { result } = renderHook(() =>
-      useTokenLookup({
-        network: mockNetwork,
-        publicKey: mockPublicKey,
-        balanceItems: mockBalanceItems,
-      }),
-    );
-
-    act(() => {
-      result.current.handleSearch(contractId);
-    });
-
-    await flushPromises();
-
-    expect(result.current.searchTerm).toBe(contractId);
-  });
-
-  it("should do nothing if search term is the same as current term", async () => {
-    const { result } = renderHook(() =>
-      useTokenLookup({
-        network: mockNetwork,
-        publicKey: mockPublicKey,
-        balanceItems: mockBalanceItems,
-      }),
-    );
-
-    // First search
-    act(() => {
-      result.current.handleSearch("test");
-    });
-
-    await flushPromises();
-
-    const prevResultsLength = result.current.searchResults.length;
-    const prevStatus = result.current.status;
-
-    // Call again with the same search term
-    act(() => {
-      result.current.handleSearch("test");
-    });
-
-    // Should not change the state
-    expect(result.current.searchResults.length).toBe(prevResultsLength);
-    expect(result.current.status).toBe(prevStatus);
+    expect(result.current.status).toBe(HookStatus.ERROR);
   });
 
   it("should clear results when empty search term is provided", () => {
@@ -288,7 +220,6 @@ describe("useTokenLookup", () => {
       result.current.handleSearch("");
     });
 
-    expect(result.current.searchTerm).toBe("");
     expect(result.current.searchResults).toEqual([]);
     expect(result.current.status).toBe(HookStatus.IDLE);
   });

--- a/src/components/TokenIcon.tsx
+++ b/src/components/TokenIcon.tsx
@@ -21,7 +21,7 @@ interface TokenIconProps {
   size?: TokenSize;
   /** Optional custom background color */
   backgroundColor?: string;
-
+  /** Optional icon URL, takes precedence over cache */
   iconUrl?: string;
 }
 

--- a/src/components/TokenIcon.tsx
+++ b/src/components/TokenIcon.tsx
@@ -21,6 +21,8 @@ interface TokenIconProps {
   size?: TokenSize;
   /** Optional custom background color */
   backgroundColor?: string;
+
+  iconUrl?: string;
 }
 
 /**
@@ -52,6 +54,7 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
   token: tokenProp,
   size = "lg",
   backgroundColor,
+  iconUrl,
 }) => {
   const icons = useTokenIconsStore((state) => state.icons);
   const { t } = useTranslation();
@@ -131,7 +134,7 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
   if (token.type === TokenTypeWithCustomToken.CUSTOM_TOKEN) {
     const tokenIdentifier = getTokenIdentifier(token);
     const icon = icons[tokenIdentifier];
-    const imageUrl = icon?.imageUrl || "";
+    const imageUrl = iconUrl || icon?.imageUrl;
 
     // If we have a specific icon, use it
     if (imageUrl) {
@@ -165,7 +168,7 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
   // Classic tokens (and SACs): show icon if available, otherwise show token initials
   const tokenIdentifier = getTokenIdentifier(token);
   const icon = icons[tokenIdentifier];
-  const imageUrl = icon?.imageUrl || "";
+  const imageUrl = iconUrl || icon?.imageUrl;
 
   const maxLetters = size === "sm" ? 1 : 2;
   const tokenInitials = token.code?.slice(0, maxLetters) || "";

--- a/src/components/screens/AddTokenScreen/AddTokenRightContent.tsx
+++ b/src/components/screens/AddTokenScreen/AddTokenRightContent.tsx
@@ -6,12 +6,10 @@ import React from "react";
 
 type AddTokenRightContentProps = {
   handleAddToken: () => void;
-  isScanningToken: boolean;
 };
 
 const AddTokenRightContent: React.FC<AddTokenRightContentProps> = ({
   handleAddToken,
-  isScanningToken,
 }) => {
   const { t } = useAppTranslation();
   const { themeColors } = useColors();
@@ -26,8 +24,6 @@ const AddTokenRightContent: React.FC<AddTokenRightContentProps> = ({
       }
       iconPosition={IconPosition.RIGHT}
       onPress={handleAddToken}
-      disabled={isScanningToken}
-      isLoading={isScanningToken}
     >
       {t("common.add")}
     </Button>

--- a/src/components/screens/AddTokenScreen/AddTokenRightContent.tsx
+++ b/src/components/screens/AddTokenScreen/AddTokenRightContent.tsx
@@ -1,8 +1,8 @@
-import { Button, IconPosition } from "components/sds/Button";
+import { IconPosition, SimpleButton } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
-import React from "react";
+import React, { memo } from "react";
 
 type AddTokenRightContentProps = {
   handleAddToken: () => void;
@@ -15,7 +15,7 @@ const AddTokenRightContent: React.FC<AddTokenRightContentProps> = ({
   const { themeColors } = useColors();
 
   return (
-    <Button
+    <SimpleButton
       secondary
       squared
       testID="add-token-button"
@@ -26,8 +26,8 @@ const AddTokenRightContent: React.FC<AddTokenRightContentProps> = ({
       onPress={handleAddToken}
     >
       {t("common.add")}
-    </Button>
+    </SimpleButton>
   );
 };
 
-export default AddTokenRightContent;
+export default memo(AddTokenRightContent);

--- a/src/components/screens/AddTokenScreen/AddTokenScreen.tsx
+++ b/src/components/screens/AddTokenScreen/AddTokenScreen.tsx
@@ -66,13 +66,12 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
     shouldPoll: false,
   });
   const { themeColors } = useColors();
-  const stableBalanceItems = useMemo(() => balanceItems, [balanceItems]);
 
   const [searchTerm, setSearchTerm] = useState("");
   const { searchResults, status, handleSearch, resetSearch } = useTokenLookup({
     network,
     publicKey: account?.publicKey,
-    balanceItems: stableBalanceItems,
+    balanceItems,
   });
 
   const isTokenMalicious = scannedToken.isMalicious;
@@ -170,7 +169,7 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
       );
     }
 
-    const tokenBalance = stableBalanceItems.find(
+    const tokenBalance = balanceItems.find(
       (balance) =>
         getTokenIdentifier(balance) ===
         `${selectedToken?.tokenCode}:${selectedToken?.issuer}`,
@@ -211,7 +210,7 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
     /* eslint-enable react/jsx-no-useless-fragment */
   }, [
     account,
-    stableBalanceItems,
+    balanceItems,
     handleCancelTokenRemoval,
     removeToken,
     isRemovingToken,

--- a/src/components/screens/AddTokenScreen/AddTokenScreen.tsx
+++ b/src/components/screens/AddTokenScreen/AddTokenScreen.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import Blockaid from "@blockaid/client";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import BigNumber from "bignumber.js";
@@ -20,7 +19,6 @@ import Icon from "components/sds/Icon";
 import { Input } from "components/sds/Input";
 import { Text } from "components/sds/Typography";
 import { AnalyticsEvent } from "config/analyticsConfig";
-import { DEFAULT_BLOCKAID_SCAN_DELAY } from "config/constants";
 import {
   MANAGE_TOKENS_ROUTES,
   ManageTokensStackParamList,
@@ -28,7 +26,6 @@ import {
 import { FormattedSearchTokenRecord, HookStatus } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
 import { getTokenIdentifier } from "helpers/balances";
-import { useBlockaidToken } from "hooks/blockaid/useBlockaidToken";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useBalancesList } from "hooks/useBalancesList";
 import { useClipboard } from "hooks/useClipboard";
@@ -41,10 +38,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { ScrollView, TouchableOpacity, View } from "react-native";
 import { analytics } from "services/analytics";
 import { SecurityLevel } from "services/blockaid/constants";
-import {
-  assessTokenSecurity,
-  extractSecurityWarnings,
-} from "services/blockaid/helper";
+import { createSecurityAssessment } from "services/blockaid/helper";
 
 type AddTokenScreenProps = NativeStackScreenProps<
   ManageTokensStackParamList,
@@ -58,10 +52,9 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
   const { getClipboardText } = useClipboard();
   const [selectedToken, setSelectedToken] =
     useState<FormattedSearchTokenRecord | null>(null);
-  const [scannedToken, setScannedToken] = useState<
-    Blockaid.TokenScanResponse | undefined
-  >(undefined);
-  const [isScanning, setIsScanning] = useState(false);
+  const [scannedToken, setScannedToken] = useState(
+    createSecurityAssessment(SecurityLevel.SAFE),
+  );
   const moreInfoBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const addTokenBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const removeTokenBottomSheetModalRef = useRef<BottomSheetModal>(null);
@@ -80,14 +73,9 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
       balanceItems,
     });
 
-  const { scanToken } = useBlockaidToken();
-
-  const securityAssessment = useMemo(
-    () => assessTokenSecurity(scannedToken),
-    [scannedToken],
-  );
-  const isTokenMalicious = securityAssessment.isMalicious;
-  const isTokenSuspicious = securityAssessment.isSuspicious;
+  const isTokenMalicious = scannedToken.isMalicious;
+  const isTokenSuspicious = scannedToken.isSuspicious;
+  const securityWarnings = selectedToken?.securityWarnings || [];
 
   const securitySeverity = useMemo(() => {
     if (isTokenMalicious) return SecurityLevel.MALICIOUS;
@@ -95,18 +83,6 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
 
     return undefined;
   }, [isTokenMalicious, isTokenSuspicious]);
-
-  const securityWarnings = useMemo(() => {
-    if (isTokenMalicious || isTokenSuspicious) {
-      const warnings = extractSecurityWarnings(scannedToken);
-
-      if (Array.isArray(warnings) && warnings.length > 0) {
-        return warnings;
-      }
-    }
-
-    return [];
-  }, [isTokenMalicious, isTokenSuspicious, scannedToken]);
 
   const resetPageState = useCallback(() => {
     handleRefresh();
@@ -139,29 +115,15 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
     getClipboardText().then(handleSearch);
   }, [getClipboardText, handleSearch]);
 
-  const handleAddToken = useCallback(
-    (token: FormattedSearchTokenRecord) => {
-      setSelectedToken(token);
-      setIsScanning(true);
-      setScannedToken(undefined);
-
-      scanToken(token.tokenCode, token.issuer)
-        .then((scanResult) => {
-          setScannedToken(scanResult);
-        })
-        .catch(() => {
-          setScannedToken(undefined);
-        })
-        .finally(() => {
-          setIsScanning(false);
-        });
-
-      setTimeout(() => {
-        addTokenBottomSheetModalRef.current?.present();
-      }, DEFAULT_BLOCKAID_SCAN_DELAY);
-    },
-    [scanToken],
-  );
+  const handleAddToken = useCallback((token: FormattedSearchTokenRecord) => {
+    setSelectedToken(token);
+    setScannedToken({
+      isMalicious: token?.isMalicious || false,
+      isSuspicious: token?.isSuspicious || false,
+      level: token?.securityLevel || SecurityLevel.SAFE,
+    });
+    addTokenBottomSheetModalRef.current?.present();
+  }, []);
 
   const handleCancelTokenAddition = useCallback(() => {
     if (selectedToken) {
@@ -298,7 +260,7 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
             addTokenBottomSheetModalRef.current?.dismiss();
           }}
           analyticsEvent={AnalyticsEvent.VIEW_ADD_TOKEN_MANUALLY}
-          shouldCloseOnPressBackdrop={!isScanning && !!selectedToken}
+          shouldCloseOnPressBackdrop={!!selectedToken}
           customContent={
             <AddTokenBottomSheetContent
               token={selectedToken}
@@ -371,7 +333,6 @@ const AddTokenScreen: React.FC<AddTokenScreenProps> = () => {
                   token={token}
                   handleAddToken={() => handleAddToken(token)}
                   handleRemoveToken={() => handleRemoveToken(token)}
-                  isScanningToken={isScanning}
                 />
               ))
             ) : (

--- a/src/components/screens/AddTokenScreen/TokenItem.tsx
+++ b/src/components/screens/AddTokenScreen/TokenItem.tsx
@@ -14,14 +14,12 @@ type TokenItemProps = {
   token: FormattedSearchTokenRecord;
   handleAddToken: () => void;
   handleRemoveToken: () => void;
-  isScanningToken: boolean;
 };
 
 const TokenItem: React.FC<TokenItemProps> = ({
   token,
   handleAddToken,
   handleRemoveToken,
-  isScanningToken,
 }) => {
   const { isSuspicious, isMalicious } = {
     isSuspicious: token.isSuspicious || token.isMalicious,
@@ -33,6 +31,7 @@ const TokenItem: React.FC<TokenItemProps> = ({
       <View className="flex-row items-center flex-1">
         <View className="relative z-0">
           <TokenIcon
+            iconUrl={token.iconUrl}
             token={{
               type: token.tokenType as TokenTypeWithCustomToken,
               code: token.tokenCode,
@@ -69,10 +68,7 @@ const TokenItem: React.FC<TokenItemProps> = ({
           handleRemoveToken={handleRemoveToken}
         />
       ) : (
-        <AddTokenRightContent
-          handleAddToken={handleAddToken}
-          isScanningToken={isScanningToken}
-        />
+        <AddTokenRightContent handleAddToken={handleAddToken} />
       )}
     </View>
   );

--- a/src/components/screens/AddTokenScreen/TokenItem.tsx
+++ b/src/components/screens/AddTokenScreen/TokenItem.tsx
@@ -7,7 +7,7 @@ import {
   TokenTypeWithCustomToken,
   FormattedSearchTokenRecord,
 } from "config/types";
-import React from "react";
+import React, { memo } from "react";
 import { View } from "react-native";
 
 type TokenItemProps = {
@@ -73,4 +73,4 @@ const TokenItem: React.FC<TokenItemProps> = ({
     </View>
   );
 };
-export default TokenItem;
+export default memo(TokenItem);

--- a/src/components/screens/AddTokenScreen/TokenItem.tsx
+++ b/src/components/screens/AddTokenScreen/TokenItem.tsx
@@ -12,8 +12,8 @@ import { View } from "react-native";
 
 type TokenItemProps = {
   token: FormattedSearchTokenRecord;
-  handleAddToken: () => void;
-  handleRemoveToken: () => void;
+  handleAddToken: (token: FormattedSearchTokenRecord) => void;
+  handleRemoveToken: (token: FormattedSearchTokenRecord) => void;
 };
 
 const TokenItem: React.FC<TokenItemProps> = ({
@@ -65,12 +65,17 @@ const TokenItem: React.FC<TokenItemProps> = ({
             isNative: token.isNative,
             id: `${token.tokenCode}:${token.issuer}`,
           }}
-          handleRemoveToken={handleRemoveToken}
+          handleRemoveToken={() => handleRemoveToken(token)}
         />
       ) : (
-        <AddTokenRightContent handleAddToken={handleAddToken} />
+        <AddTokenRightContent handleAddToken={() => handleAddToken(token)} />
       )}
     </View>
   );
 };
-export default memo(TokenItem);
+export default memo(
+  TokenItem,
+  (prev, next) =>
+    prev.token.tokenCode === next.token.tokenCode &&
+    prev.token.issuer === next.token.issuer,
+);

--- a/src/components/sds/Button/index.tsx
+++ b/src/components/sds/Button/index.tsx
@@ -392,7 +392,6 @@ export const SimpleButton = ({
   );
   const resolvedSize = getSize({ size, ...props }, ButtonSizes.EXTRA_LARGE);
 
-  // Handle biometric authentication
   const handlePress = React.useCallback(() => {
     if (!onPress) return;
 
@@ -402,7 +401,6 @@ export const SimpleButton = ({
   // Determine icon to display
   const resolvedIcon = React.useMemo(() => icon, [icon]);
 
-  // Determine icon position for biometric buttons
   const resolvedIconPosition = React.useMemo(
     () => iconPosition,
     [iconPosition],

--- a/src/components/sds/Button/index.tsx
+++ b/src/components/sds/Button/index.tsx
@@ -369,3 +369,85 @@ export const Button = ({
     </StyledButton>
   );
 };
+
+export const SimpleButton = ({
+  variant,
+  size,
+  children,
+  icon,
+  iconPosition = IconPosition.RIGHT,
+  isLoading = false,
+  isFullWidth = false,
+  disabled = false,
+  squared = false,
+  onPress,
+  testID,
+  iconColor,
+  ...props
+}: ButtonProps) => {
+  const disabledState = isLoading || disabled;
+  const resolvedVariant = getVariant(
+    { variant, ...props },
+    ButtonVariants.PRIMARY,
+  );
+  const resolvedSize = getSize({ size, ...props }, ButtonSizes.EXTRA_LARGE);
+
+  // Handle biometric authentication
+  const handlePress = React.useCallback(() => {
+    if (!onPress) return;
+
+    onPress();
+  }, [onPress]);
+
+  // Determine icon to display
+  const resolvedIcon = React.useMemo(() => icon, [icon]);
+
+  // Determine icon position for biometric buttons
+  const resolvedIconPosition = React.useMemo(
+    () => iconPosition,
+    [iconPosition],
+  );
+
+  const renderIcon = (position: IconPosition) => {
+    if (isLoading && position === IconPosition.RIGHT) {
+      return (
+        <IconContainer position={IconPosition.RIGHT}>
+          <ActivityIndicator
+            testID="button-loading-indicator"
+            size="small"
+            color={getTextColor(resolvedVariant, disabledState)}
+          />
+        </IconContainer>
+      );
+    }
+
+    if (resolvedIcon && resolvedIconPosition === position) {
+      return <IconContainer position={position}>{resolvedIcon}</IconContainer>;
+    }
+
+    return null;
+  };
+
+  return (
+    <StyledButton
+      variant={resolvedVariant}
+      size={resolvedSize}
+      isFullWidth={isFullWidth}
+      disabled={disabledState}
+      squared={squared}
+      onPress={handlePress}
+      testID={testID}
+    >
+      {renderIcon(IconPosition.LEFT)}
+      <Text
+        size={getFontSize(resolvedSize)}
+        weight="semiBold"
+        color={getTextColor(resolvedVariant, disabledState)}
+        isVerticallyCentered
+      >
+        {children}
+      </Text>
+      {renderIcon(IconPosition.RIGHT)}
+    </StyledButton>
+  );
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,8 @@
 import { AssetType as TokenType, Horizon } from "@stellar/stellar-sdk";
 import BigNumber from "bignumber.js";
 import { NETWORKS } from "config/constants";
+import { SecurityLevel } from "services/blockaid/constants";
+import { SecurityWarning } from "services/blockaid/helper";
 
 export type Account = {
   id: string;
@@ -296,6 +298,7 @@ export type FormattedSearchTokenRecord = {
   tokenCode: string;
   domain: string;
   hasTrustline: boolean;
+  iconUrl?: string;
   issuer: string;
   isNative: boolean;
   tokenType?: TokenTypeWithCustomToken;
@@ -303,7 +306,8 @@ export type FormattedSearchTokenRecord = {
   decimals?: number;
   isSuspicious?: boolean;
   isMalicious?: boolean;
-  securityLevel?: string;
+  securityLevel?: SecurityLevel;
+  securityWarnings?: SecurityWarning[];
 };
 
 /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -292,6 +292,7 @@ export interface GetTokenDetailsParams {
   publicKey: string;
   network: NETWORKS;
   shouldFetchBalance?: boolean;
+  signal?: AbortSignal;
 }
 
 export type FormattedSearchTokenRecord = {

--- a/src/hooks/useTokenLookup.ts
+++ b/src/hooks/useTokenLookup.ts
@@ -264,13 +264,12 @@ export const useTokenLookup = ({
         if (signal.aborted) return;
         setSearchResults(groupedSearchResults);
       } catch (error) {
-        // If security scan fails, mark tokens as suspicious since we can't verify their safety
         const fallbackSearchResults: FormattedSearchTokenRecord[] =
           formattedRecords.map((token) => ({
             ...token,
-            isSuspicious: true,
+            isSuspicious: false,
             isMalicious: false,
-            securityLevel: SecurityLevel.SUSPICIOUS,
+            securityLevel: SecurityLevel.SAFE,
           }));
 
         const groupedFallbackResults = groupTokensBySecurityLevel(

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -76,6 +76,7 @@ export interface RequestConfig extends Omit<AxiosRequestConfig, "baseURL"> {
    * });
    */
   retry?: RetryConfig;
+  signal?: AbortSignal;
 }
 
 /**
@@ -183,7 +184,10 @@ export function createApiService(options: ApiServiceOptions) {
   const executeWithRetry = async <T>(
     requestFn: () => Promise<T>,
     retryOptions?: RetryConfig,
+    signal?: AbortSignal,
   ): Promise<T> => {
+    if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+
     if (!retryOptions || retryOptions.retries <= 0) {
       return requestFn();
     }
@@ -198,6 +202,7 @@ export function createApiService(options: ApiServiceOptions) {
       try {
         return await requestFn();
       } catch (error) {
+        if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
         attempts++;
         lastError = error;
 

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -378,6 +378,7 @@ export const getTokenDetails = async ({
   contractId,
   publicKey,
   network,
+  signal,
 }: GetTokenDetailsParams): Promise<TokenDetailsResponse | null> => {
   try {
     // TODO: Add verification for custom network.
@@ -389,6 +390,7 @@ export const getTokenDetails = async ({
           pub_key: publicKey,
           network,
         },
+        signal,
       },
     );
 
@@ -399,7 +401,7 @@ export const getTokenDetails = async ({
     return response.data;
   } catch (error) {
     if ((error as AxiosError).status === 400) {
-      // That means the contract is not a SAC token.
+      // That means the contract is not SEP-41 compliant.
       return null;
     }
 
@@ -592,6 +594,7 @@ export const handleContractLookup = async (
   contractId: string,
   network: NETWORKS,
   publicKey?: string,
+  signal?: AbortSignal,
 ): Promise<FormattedSearchTokenRecord | null> => {
   const nativeContractDetails = getNativeContractDetails(network);
 
@@ -610,6 +613,7 @@ export const handleContractLookup = async (
     contractId,
     publicKey: publicKey ?? "",
     network,
+    signal,
   });
 
   if (!tokenDetails) {

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -32,7 +32,7 @@ import { getTokenType } from "helpers/balances";
 import { bigize } from "helpers/bigize";
 import { getNativeContractDetails } from "helpers/soroban";
 import Config from "react-native-config";
-import { createApiService } from "services/apiFactory";
+import { createApiService, isRequestCanceled } from "services/apiFactory";
 
 // Create dedicated API services for backend operations
 export const freighterBackend = createApiService({
@@ -405,11 +405,13 @@ export const getTokenDetails = async ({
       return null;
     }
 
-    logger.error(
-      "backendApi.getTokenDetails",
-      "Error fetching token details",
-      error,
-    );
+    if (!isRequestCanceled(error)) {
+      logger.error(
+        "backendApi.getTokenDetails",
+        "Error fetching token details",
+        error,
+      );
+    }
 
     return null;
   }

--- a/src/services/blockaid/api.ts
+++ b/src/services/blockaid/api.ts
@@ -59,6 +59,7 @@ export const scanToken = async (
 
 export const scanBulkTokens = async (
   params: ScanBulkTokensParams,
+  signal?: AbortSignal,
 ): Promise<Blockaid.TokenBulkScanResponse> => {
   const { addressList, network } = params;
 
@@ -73,10 +74,9 @@ export const scanBulkTokens = async (
       .join("&");
     const endpoint = `${BLOCKAID_ENDPOINTS.SCAN_BULK_TOKENS}?${queryParams}`;
 
-    const response =
-      await freighterBackend.get<
-        BlockaidApiResponse<Blockaid.TokenBulkScanResponse>
-      >(endpoint);
+    const response = await freighterBackend.get<
+      BlockaidApiResponse<Blockaid.TokenBulkScanResponse>
+    >(endpoint, { signal });
 
     if (response.data.error) {
       throw new Error(response.data.error);

--- a/src/services/blockaid/helper.ts
+++ b/src/services/blockaid/helper.ts
@@ -42,7 +42,7 @@ const getSecurityLevel = (resultType: string): SecurityLevel =>
  * Creates security assessment with proper i18n translation
  * Ensures user-facing messages are properly localized
  */
-const createSecurityAssessment = (
+export const createSecurityAssessment = (
   level: SecurityLevel,
   messageKey?: string,
   fallbackMessage?: string,

--- a/src/services/stellarExpert.ts
+++ b/src/services/stellarExpert.ts
@@ -13,7 +13,11 @@ const stellarExpertApiPublic = createApiService({
   baseURL: getApiStellarExpertUrl(NETWORKS.PUBLIC),
 });
 
-export const searchToken = async (token: string, network: NETWORKS) => {
+export const searchToken = async (
+  token: string,
+  network: NETWORKS,
+  signal?: AbortSignal,
+) => {
   const stellarExpertApi =
     network === NETWORKS.TESTNET
       ? stellarExpertApiTestnet
@@ -24,6 +28,7 @@ export const searchToken = async (token: string, network: NETWORKS) => {
       params: {
         search: token,
       },
+      signal,
     });
 
     if (!response.data || !response.data._embedded) {
@@ -32,6 +37,9 @@ export const searchToken = async (token: string, network: NETWORKS) => {
 
     return response.data;
   } catch (error) {
+    if (error instanceof Error && error.message === "canceled") {
+      return null;
+    }
     logger.error("stellarExpert", "Error searching token", error);
 
     return null;

--- a/src/services/stellarExpert.ts
+++ b/src/services/stellarExpert.ts
@@ -3,7 +3,7 @@ import { NETWORKS } from "config/constants";
 import { logger, normalizeError } from "config/logger";
 import { SearchTokenResponse } from "config/types";
 import { getApiStellarExpertUrl } from "helpers/stellarExpert";
-import { createApiService } from "services/apiFactory";
+import { createApiService, isRequestCanceled } from "services/apiFactory";
 
 const stellarExpertApiTestnet = createApiService({
   baseURL: getApiStellarExpertUrl(NETWORKS.TESTNET),
@@ -37,10 +37,9 @@ export const searchToken = async (
 
     return response.data;
   } catch (error) {
-    if (error instanceof Error && error.message === "canceled") {
-      return null;
+    if (!isRequestCanceled(error)) {
+      logger.error("stellarExpert", "Error searching token", error);
     }
-    logger.error("stellarExpert", "Error searching token", error);
 
     return null;
   }


### PR DESCRIPTION
Closes #371 

AddToken suffers from a few bugs/behaviors that lead to this slow response in both the search results, as well as the action in the right.

Changes -

- Removes inline scan when selecting a row to take an action, these assets have already been scanned from the search hook so we now add the scan results to the search items and use them directly.
- Removes the caching of icons from search results in order to avoid a re-render in token icon rows. we instead take the icon from the search results and pass it directly to `TokenIcon`. TokenIcon now takes an optional prop to use an iconUrl from its parent.
- Adds request cancelation using the `AbortController` in order to drop requests when another is made. This, along with request ID tracking allows us to avoid the "stale results" bug where a user could see results from a previous search due to the nature of the debouncing of requests triggered from events.
- Moves `searchTerm` from the hook into the view component in order to avoid a circular reference render. The searchTerm is not needed in the hook and this allows us to avoid a render every time the search term changes(we want to only render rows when the results return).
- Memos several key components/functions. This allows us to avoid renders for reasons related to static object construction in view bodies and/or inline function creation.
- Forks Button in order to avoid calling the biometric related hooks which cause a reflow in the parent for every child row(50). This is larger issue that requires a larger refactor so I've created [this issue to track the remaining work.](https://github.com/stellar/freighter-mobile/issues/376)


https://github.com/user-attachments/assets/fdb9fafe-c1fc-4578-9745-d4b281cf8058


