### PR TITLE
Avoid clearing memo during transaction building

### DIFF
--- a/src/components/screens/SendScreen/screens/TransactionAmountScreen.tsx
+++ b/src/components/screens/SendScreen/screens/TransactionAmountScreen.tsx
@@ -91,7 +91,6 @@ const TransactionAmountScreen: React.FC<TransactionAmountScreenProps> = ({
     selectedTokenId,
     saveSelectedTokenId,
     saveRecipientAddress,
-    saveMemo,
     resetSettings,
   } = useTransactionSettingsStore();
 
@@ -410,7 +409,6 @@ const TransactionAmountScreen: React.FC<TransactionAmountScreenProps> = ({
     };
 
     processTransaction();
-    saveMemo("");
   };
 
   const handleProcessingScreenClose = () => {

--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -1,3 +1,4 @@
+import { APP_VERSION } from "config/constants";
 import { logger } from "config/logger";
 import { isAndroid } from "helpers/device";
 import { Platform } from "react-native";
@@ -14,6 +15,7 @@ interface FeatureFlagsData {
 
 interface FeatureFlagsParams {
   platform: string;
+  version: string;
 }
 
 interface RemoteConfigState {
@@ -42,6 +44,7 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
     try {
       const params: FeatureFlagsParams = {
         platform: Platform.OS,
+        version: APP_VERSION,
       };
 
       const response = await freighterBackendV2.get<FeatureFlagsData>(


### PR DESCRIPTION
### What

Removed the `saveMemo("")` to avoid clearing the memo before the transaction was processed 

### Why

there were a issue reported that the memo wasn't passed as a build parameter #406 
[slack thread](https://cheesecake.slack.com/archives/C03347FNAHK/p1758747795010159)

### Known limitations

N/A

### Checklist

#### PR structure

- [ ] This PR does not mix refactoring changes with feature changes (break it
      down into smaller PRs if not).
- [ ] This PR has reasonably narrow scope (break it down into smaller PRs if
      not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting
      these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on
      Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new funcionalities.
- [ ] I've checked with the product team if we should add metrics to these
      changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting
      these changes with the design team and they've approved the changes.

fixes #406 