### PR TITLE
Shorten Token Search PT placeholder text

### DIFF
--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -557,7 +557,7 @@
     "swapFrom": "Trocar de",
     "swapTo": "Trocar para",
     "title": "Trocar",
-    "searchTokenInputPlaceholder": "Pesquisar nome ou endereço do token",
+    "searchTokenInputPlaceholder": "Pesq. por nome ou endereço",
     "setMax": "Definir máximo",
     "receive": "Receber",
     "chooseToken": "Escolher token",


### PR DESCRIPTION
Closes #420 

Placeholder text breaking is breaking in two lines (Android) for PT when the paste button is present, or ellipsizing on iOS

Placeholder should contain the information in a single line

Due to context, I think it should be clear what it means without mentioning the word 'token' again, but also pinging @sdfcharles , if you agree or have another idea


<img width="707" height="718" alt="Screenshot 2025-09-25 at 13 00 47" src="https://github.com/user-attachments/assets/fd93c1b9-d728-45d6-883d-3dd085a64830" />
<img width="728" height="774" alt="Screenshot 2025-09-25 at 13 00 00" src="https://github.com/user-attachments/assets/6b484fad-c1f7-4127-82bd-6ecda3c5877d" />


### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it
      down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if
      not).
- [x] This PR includes relevant before and after screenshots/videos highlighting
      these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on
      Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new funcionalities.
- [] I've checked with the product team if we should add metrics to these
      changes.
- [x] I've shared relevant before and after screenshots/videos highlighting
      these changes with the design team and they've approved the changes.
