### PR TITLE
[CHORE] bump versions on both platforms

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,8 +84,8 @@ android {
         applicationId "org.stellar.freighterwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 28
-        versionName "1.4.23"
+        versionCode 29
+        versionName "1.5.23"
     }
     signingConfigs {
         debug {

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
@@ -345,7 +345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.23;
+				MARKETING_VERSION = 1.5.23;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -369,7 +369,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 4JWM8JNM37;
 				INFOPLIST_FILE = "freighter-mobile/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -377,7 +377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.23;
+				MARKETING_VERSION = 1.5.23;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
### What

Bump app version to `1.5.23` and build version to `29` on both platforms.

### Why

To account for version numbers of an emergency release issued to fix some memo issues ([thread](https://stellarfoundation.slack.com/archives/C03347FNAHK/p1759185520095049?thread_ts=1758747795.010159&cid=C03347FNAHK)).

### Known limitations

[TODO or N/A]

### Checklist

#### PR structure

- [ ] This PR does not mix refactoring changes with feature changes (break it
      down into smaller PRs if not).
- [ ] This PR has reasonably narrow scope (break it down into smaller PRs if
      not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting
      these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on
      Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new funcionalities.
- [ ] I've checked with the product team if we should add metrics to these
      changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting
      these changes with the design team and they've approved the changes.
