### PR TITLE
Remove Blockaid response from event properties

### DIFF
--- a/src/services/blockaid/api.ts
+++ b/src/services/blockaid/api.ts
@@ -49,7 +49,6 @@ export const scanToken = async (
     const scanResult = response.data.data as Blockaid.TokenScanResponse;
 
     analytics.track(AnalyticsEvent.BLOCKAID_TOKEN_SCAN, {
-      response: scanResult,
       tokenCode,
       network,
     });
@@ -88,7 +87,6 @@ export const scanBulkTokens = async (
     const scanResult = response.data.data as Blockaid.TokenBulkScanResponse;
 
     analytics.track(AnalyticsEvent.BLOCKAID_BULK_TOKEN_SCAN, {
-      response: scanResult,
       addressList,
       network,
     });
@@ -123,7 +121,6 @@ export const scanSite = async (
     const scanResult = response.data.data as Blockaid.SiteScanResponse;
 
     analytics.track(AnalyticsEvent.BLOCKAID_SITE_SCAN, {
-      response: scanResult,
       url,
       network,
     });
@@ -162,7 +159,6 @@ export const scanTransaction = async (
       .data as Blockaid.StellarTransactionScanResponse;
 
     analytics.track(AnalyticsEvent.BLOCKAID_TRANSACTION_SCAN, {
-      response: scanResult,
       xdr,
       url,
       network,


### PR DESCRIPTION
### What

Remove Blockaid response from analytics event properties.

### Why

So we prevent dynamically creating event properties on the fly which would lead to excessive properties count on Amplitude.

Thread: https://stellarfoundation.slack.com/archives/C03347FNAHK/p1759341443407059

### Known limitations

[TODO or N/A]

### Checklist

#### PR structure

- [ ] This PR does not mix refactoring changes with feature changes (break it
      down into smaller PRs if not).
- [ ] This PR has reasonably narrow scope (break it down into smaller PRs if
      not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting
      these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on
      Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small
      iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small
      Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these
      changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting
      these changes with the design team and they've approved the changes.
