### PR TITLE
[Feat] Set Yarn to save-exact on new package installation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""


### PR DESCRIPTION
Reason: Remove the `^` from package.json packages installation, as it allows for approximate versions to be installed.

E.g. App is using v 1.0.0. Developer tries package 1.0.1 but decides to revert it. Or the package was installed in a separate branch -> The code will try to install 1.0.1 because it matches approximate and is saved on the global yarn cache, unless the cache is completely wiped and node_modules removed

This might cause packages and the app itself to be tested in a different version than what is apparently set on the package.json, so undefined behavior. It will also force the Podfile.lock to change in different developers' machines, depending on what they have saved in cache 

~#### PR structure~ -> Not relevant for PR Checklist. Only affects newly added packages


Example regarding the changes. Not retroactive: 
<img width="427" height="324" alt="Screenshot 2025-10-08 at 17 41 33" src="https://github.com/user-attachments/assets/3afa8183-7624-4aac-adcb-3a9bfa295002" />
