### PR TITLE
[Amplitude] Ensure Bundle Id is always accessible on feature-flag targeting

### DIFF
--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -1,7 +1,7 @@
 import { logger } from "config/logger";
 import { isAndroid } from "helpers/device";
-import { getAppVersion } from "helpers/version";
-import { Platform } from "react-native";
+import { getBundleId } from "react-native-device-info";
+import { ANALYTICS_CONFIG } from "services/analytics/constants";
 import { getExperimentClient } from "services/analytics/core";
 import { create } from "zustand";
 
@@ -56,8 +56,12 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
 
       await experimentClient.fetch({
         user_properties: {
-          platform: Platform.OS,
-          version: getAppVersion(),
+          // We need to explicitly pass the "Bundle Id" here to make sure the
+          // correct flag values will be assigned regardless if (iOS) users
+          // have ever enabled tracking permission or not.
+          // Other common properties like "Platform" and "Version" appear to be
+          // always forwarded regardless of tracking permission.
+          [ANALYTICS_CONFIG.BUNDLE_ID_KEY]: getBundleId(),
         },
       });
 

--- a/src/services/analytics/constants.ts
+++ b/src/services/analytics/constants.ts
@@ -43,4 +43,5 @@ export const ANALYTICS_CONFIG = {
   DEFAULT_ENABLED: Platform.OS !== "ios",
   INCLUDE_COMMON_CONTEXT: true,
   THROTTLE_DUPLICATE_EVENTS: true,
+  BUNDLE_ID_KEY: "Bundle Id",
 } as const;

--- a/src/services/analytics/core.ts
+++ b/src/services/analytics/core.ts
@@ -46,7 +46,7 @@ const setAmplitudeUserProperties = (): void => {
 
     // Let's set bundle id as a user property so we could easily
     // filter mobile Prod and Dev users in Amplitude.
-    identify.set("Bundle Id", getBundleId());
+    identify.set(ANALYTICS_CONFIG.BUNDLE_ID_KEY, getBundleId());
 
     amplitude.identify(identify);
 


### PR DESCRIPTION
### What

Ensure `Bundle Id` is always accessible for all users on Amplitude's feature-flag targeting.

### Why

This `custom` `Bundle Id` user property is not set for iOS users that have never accepted the "Allow Tracking" request pop-up, but we can explicitly pass it when fetching the feature flags which solves the issue for feature-flag targeting.

This same issue does not happen for `default` Amplitude user properties like `Platform` and `Version` so that we don't need to worry about those as they are always accessible for user targeting regardless of the tracking permission.

Se below how the `default` Amplitude user properties are categorized as **`Amplitude User Properties`** with the blue icon, those are **always accessible for targeting** regardless of tracking permission state. On the other hand, the `custom` user properties are categorized as just **`User Properties`** with a generic avatar icon, those are **only accessible when tracking permission is enabled** but we can explicitly pass them as arguments on the [feature flag fetching call](https://github.com/stellar/freighter-mobile/pull/474/files#diff-68e7049bc8416662d3c777931b4146b6780d62eca00452862495a9469d1f4752R57-R66) to ensure the evaluation is correct for the user.
<img width="1528" height="312" alt="Screenshot 2025-10-10 at 15 39 44" src="https://github.com/user-attachments/assets/6437632f-b451-48f3-a59b-ac1062b679e2" />

### Known limitations

Although we can solve this issue specifically for the feature-flag targeting those users `will still not appear on Amplitude dashboards` as they `have not granted tracking permission` which is the expected behavior.

### Playing with Feature Flag targeting on iOS user with Tracking permission Disabled

[Screen Recording 2025-10-10 at 15.09.07.webm](https://github.com/user-attachments/assets/efe972b7-6819-4428-8542-a287feb972d5)

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
