### PR TITLE
Disallow memo on Soroban Transacations

### DIFF
--- a/__tests__/components/TransactionSettingsBottomSheet.test.tsx
+++ b/__tests__/components/TransactionSettingsBottomSheet.test.tsx
@@ -323,7 +323,9 @@ describe("TransactionSettingsBottomSheet - Soroban Transaction Tests", () => {
       />,
     );
 
-    expect(getByText("transactionSettings.memoInfo.sorobanNote")).toBeTruthy();
+    expect(
+      getByText("transactionSettings.memoInfo.sorobanNoteTransaction"),
+    ).toBeTruthy();
   });
 
   it("should clear memo automatically for Soroban transactions", async () => {

--- a/src/components/TransactionSettingsBottomSheet.tsx
+++ b/src/components/TransactionSettingsBottomSheet.tsx
@@ -56,8 +56,8 @@ const TransactionSettingsBottomSheet: React.FC<
     transactionMemo,
     transactionFee,
     transactionTimeout,
-    selectedTokenId,
     recipientAddress,
+    selectedCollectibleDetails,
     saveMemo: saveTransactionMemo,
     saveTransactionFee,
     saveTransactionTimeout,
@@ -77,14 +77,13 @@ const TransactionSettingsBottomSheet: React.FC<
   const memoInfoBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const slippageInfoBottomSheetModalRef = useRef<BottomSheetModal>(null);
 
-  // Check if selected token is a Soroban token (contract ID) or recipient is a Soroban contract
-  const isSorobanToken = selectedTokenId
-    ? isContractId(selectedTokenId)
-    : false;
-  const isSorobanRecipient = recipientAddress
-    ? isContractId(recipientAddress)
-    : false;
-  const isSorobanTransaction = isSorobanToken || isSorobanRecipient;
+  const isCollectibleTransfer =
+    selectedCollectibleDetails?.collectionAddress &&
+    selectedCollectibleDetails?.tokenId;
+
+  const isSorobanRecipient = recipientAddress && isContractId(recipientAddress);
+
+  const isSorobanTransaction = isCollectibleTransfer || isSorobanRecipient;
 
   // Derived values based on context
   const memo = context === TransactionContext.Swap ? "" : transactionMemo;
@@ -116,7 +115,7 @@ const TransactionSettingsBottomSheet: React.FC<
     enforceSettingInputDecimalSeparator(slippage.toString()),
   );
 
-  // Clear memo when Soroban token is selected or recipient is a Soroban contract
+  // Clear memo for Soroban transactions (collectible transfers or Soroban contract recipients)
   useEffect(() => {
     if (isSorobanTransaction && context !== TransactionContext.Swap) {
       saveTransactionMemo("");
@@ -268,15 +267,16 @@ const TransactionSettingsBottomSheet: React.FC<
 
   // Render functions
   const getMemoRow = useCallback(() => {
-    // Recalculate in case values changed
-    const isSorobanTokenCheck = selectedTokenId
-      ? isContractId(selectedTokenId)
-      : false;
-    const isSorobanRecipientCheck = recipientAddress
-      ? isContractId(recipientAddress)
-      : false;
+    // Recalculate in case values changed (avoid shadowing outer scope)
+    const isCollectibleTransferCheck =
+      selectedCollectibleDetails?.collectionAddress &&
+      selectedCollectibleDetails?.tokenId;
+
+    const isSorobanRecipientCheck =
+      recipientAddress && isContractId(recipientAddress);
+
     const isSorobanTransactionCheck =
-      isSorobanTokenCheck || isSorobanRecipientCheck;
+      isCollectibleTransferCheck || isSorobanRecipientCheck;
 
     return (
       <View className="flex-col gap-2 mt-[24px]">
@@ -316,8 +316,8 @@ const TransactionSettingsBottomSheet: React.FC<
     memoError,
     t,
     handleMemoChange,
-    selectedTokenId,
     recipientAddress,
+    selectedCollectibleDetails,
     themeColors.status.warning,
   ]);
 

--- a/src/components/TransactionSettingsBottomSheet.tsx
+++ b/src/components/TransactionSettingsBottomSheet.tsx
@@ -292,7 +292,9 @@ const TransactionSettingsBottomSheet: React.FC<
             isSorobanTransaction ? (
               <View className="flex flex-row items-center gap-2 mt-1">
                 <Text sm secondary color={themeColors.status.warning}>
-                  {t("transactionSettings.memoInfo.sorobanNote")}
+                  {isCollectibleTransfer
+                    ? t("transactionSettings.memoInfo.sorobanNoteCollectible")
+                    : t("transactionSettings.memoInfo.sorobanNoteTransaction")}
                 </Text>
               </View>
             ) : undefined
@@ -307,6 +309,7 @@ const TransactionSettingsBottomSheet: React.FC<
       handleMemoChange,
       themeColors.status.warning,
       isSorobanTransaction,
+      isCollectibleTransfer,
     ],
   );
 

--- a/src/components/TransactionSettingsBottomSheet.tsx
+++ b/src/components/TransactionSettingsBottomSheet.tsx
@@ -117,7 +117,7 @@ const TransactionSettingsBottomSheet: React.FC<
 
   // Clear memo for Soroban transactions (collectible transfers or Soroban contract recipients)
   useEffect(() => {
-    if (isSorobanTransaction && context !== TransactionContext.Swap) {
+    if (isSorobanTransaction) {
       saveTransactionMemo("");
       setLocalMemo("");
     }
@@ -266,19 +266,8 @@ const TransactionSettingsBottomSheet: React.FC<
   };
 
   // Render functions
-  const getMemoRow = useCallback(() => {
-    // Recalculate in case values changed (avoid shadowing outer scope)
-    const isCollectibleTransferCheck =
-      selectedCollectibleDetails?.collectionAddress &&
-      selectedCollectibleDetails?.tokenId;
-
-    const isSorobanRecipientCheck =
-      recipientAddress && isContractId(recipientAddress);
-
-    const isSorobanTransactionCheck =
-      isCollectibleTransferCheck || isSorobanRecipientCheck;
-
-    return (
+  const getMemoRow = useCallback(
+    () => (
       <View className="flex-col gap-2 mt-[24px]">
         <View className="flex flex-row items-center gap-2">
           <Text sm secondary>
@@ -298,9 +287,9 @@ const TransactionSettingsBottomSheet: React.FC<
           value={localMemo}
           onChangeText={handleMemoChange}
           error={memoError}
-          editable={!isSorobanTransactionCheck}
+          editable={!isSorobanTransaction}
           note={
-            isSorobanTransactionCheck ? (
+            isSorobanTransaction ? (
               <View className="flex flex-row items-center gap-2 mt-1">
                 <Text sm secondary color={themeColors.status.warning}>
                   {t("transactionSettings.memoInfo.sorobanNote")}
@@ -310,16 +299,16 @@ const TransactionSettingsBottomSheet: React.FC<
           }
         />
       </View>
-    );
-  }, [
-    localMemo,
-    memoError,
-    t,
-    handleMemoChange,
-    recipientAddress,
-    selectedCollectibleDetails,
-    themeColors.status.warning,
-  ]);
+    ),
+    [
+      localMemo,
+      memoError,
+      t,
+      handleMemoChange,
+      themeColors.status.warning,
+      isSorobanTransaction,
+    ],
+  );
 
   const getSlippageRow = useCallback(
     () => (

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -179,8 +179,15 @@ export const getTokenInvocationArgs = (
   };
 };
 
+/**
+ * Checks if an operation type is a Soroban operation type
+ * Can be used with both Horizon operation records and transaction operations
+ */
+export const isSorobanOperationType = (operationType: string): boolean =>
+  SOROBAN_OPERATION_TYPES.includes(operationType);
+
 const isSorobanOp = (operation: Horizon.ServerApi.OperationRecord) =>
-  SOROBAN_OPERATION_TYPES.includes(operation.type);
+  isSorobanOperationType(operation.type);
 
 export const getAttrsFromSorobanHorizonOp = (
   operation: Horizon.ServerApi.OperationRecord,

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -179,15 +179,13 @@ export const getTokenInvocationArgs = (
   };
 };
 
-/**
- * Checks if an operation type is a Soroban operation type
- * Can be used with both Horizon operation records and transaction operations
- */
-export const isSorobanOperationType = (operationType: string): boolean =>
-  SOROBAN_OPERATION_TYPES.includes(operationType);
+export const isSorobanOp = (
+  operation: Horizon.ServerApi.OperationRecord | Operation,
+) => SOROBAN_OPERATION_TYPES.includes(operation.type);
 
-const isSorobanOp = (operation: Horizon.ServerApi.OperationRecord) =>
-  isSorobanOperationType(operation.type);
+export const hasSorobanOperations = (
+  transaction: ReturnType<typeof TransactionBuilder.fromXDR>,
+) => transaction.operations.some((operation) => isSorobanOp(operation));
 
 export const getAttrsFromSorobanHorizonOp = (
   operation: Horizon.ServerApi.OperationRecord,

--- a/src/hooks/useValidateTransactionMemo.ts
+++ b/src/hooks/useValidateTransactionMemo.ts
@@ -11,20 +11,10 @@ import { usePreferencesStore } from "ducks/preferences";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
 import { cachedFetch } from "helpers/cachedFetch";
 import { isMainnet } from "helpers/networks";
-import { SOROBAN_OPERATION_TYPES } from "helpers/soroban";
+import { hasSorobanOperations } from "helpers/soroban";
 import { getApiStellarExpertIsMemoRequiredListUrl } from "helpers/stellarExpert";
 import { useEffect, useMemo, useState } from "react";
 import { stellarSdkServer } from "services/stellar";
-
-/**
- * Checks if a transaction is a Soroban transaction by examining its operations
- */
-const isSorobanTransaction = (
-  transaction: ReturnType<typeof TransactionBuilder.fromXDR>,
-): boolean =>
-  transaction.operations.some((operation) =>
-    SOROBAN_OPERATION_TYPES.includes(operation.type),
-  );
 
 /**
  * Checks if a memo is required by querying cached memo-required accounts
@@ -123,12 +113,13 @@ export const useValidateTransactionMemo = (incomingXdr?: string | null) => {
     }
 
     // Skip validation for Soroban transactions
-    if (localTransaction && isSorobanTransaction(localTransaction)) {
+    if (localTransaction && hasSorobanOperations(localTransaction)) {
       return false;
     }
 
     return true;
   }, [isMemoValidationEnabled, network, localTransaction]);
+
   const [isMemoMissing, setIsMemoMissing] = useState(shouldValidateMemo);
 
   /**

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -672,7 +672,8 @@
       "description": "Some destination accounts on the Stellar network require a memo to identify your payment.",
       "additionalInfo": "If a required memo is missing or incorrect, your funds may not reach the intended recipient.",
       "sorobanInfo": "Memo is not allowed on Soroban transactions, such as collectible transfers or \"C\" addresses",
-      "sorobanNote": "Memo not allowed for Soroban transactions"
+      "sorobanNoteTransaction": "Memo not allowed for Soroban transactions",
+      "sorobanNoteCollectible": "Memo is not allowed for collectible transfers"
     },
     "slippageInfo": {
       "title": "Allowed slippage",

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -670,7 +670,9 @@
     "memoInfo": {
       "title": "Memo",
       "description": "Some destination accounts on the Stellar network require a memo to identify your payment.",
-      "additionalInfo": "If a required memo is missing or incorrect, your funds may not reach the intended recipient."
+      "additionalInfo": "If a required memo is missing or incorrect, your funds may not reach the intended recipient.",
+      "sorobanInfo": "Memo is not allowed on Soroban transactions, such as collectible transfers or \"C\" addresses",
+      "sorobanNote": "Memo not allowed for Soroban transactions"
     },
     "slippageInfo": {
       "title": "Allowed slippage",

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -671,7 +671,7 @@
       "title": "Memo",
       "description": "Some destination accounts on the Stellar network require a memo to identify your payment.",
       "additionalInfo": "If a required memo is missing or incorrect, your funds may not reach the intended recipient.",
-      "sorobanInfo": "Memo is not allowed on Soroban transactions, such as collectible transfers or \"C\" addresses",
+      "sorobanInfo": "Memo is not allowed on Soroban transactions, such as collectible transfers or \"C\" addresses.",
       "sorobanNoteTransaction": "Memo not allowed for Soroban transactions",
       "sorobanNoteCollectible": "Memo is not allowed for collectible transfers"
     },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -634,7 +634,9 @@
     "memoInfo": {
       "title": "Memo",
       "description": "Algumas contas de destino na rede Stellar requerem um memo para identificar seu pagamento.",
-      "additionalInfo": "Se um memo necessário estiver ausente ou incorreto, seus fundos podem não chegar ao destinatário pretendido."
+      "additionalInfo": "Se um memo necessário estiver ausente ou incorreto, seus fundos podem não chegar ao destinatário pretendido.",
+      "sorobanInfo": "Memo não é permitido em transações Soroban, como transferências de colecionáveis ou endereços \"C\"",
+      "sorobanNote": "Memo não permitido para transações Soroban"
     },
     "slippageInfo": {
       "title": "Deslizamento permitido",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -635,7 +635,7 @@
       "title": "Memo",
       "description": "Algumas contas de destino na rede Stellar requerem um memo para identificar seu pagamento.",
       "additionalInfo": "Se um memo necessário estiver ausente ou incorreto, seus fundos podem não chegar ao destinatário pretendido.",
-      "sorobanInfo": "Memo não é permitido em transações Soroban, como transferências de colecionáveis ou endereços \"C\"",
+      "sorobanInfo": "Memo não é permitido em transações Soroban, como transferências de colecionáveis ou endereços \"C\".",
       "sorobanNoteTransaction": "Memo não permitido para transações Soroban",
       "sorobanNoteCollectible": "Memo não é permitido para transferências de colecionáveis"
     },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -636,7 +636,8 @@
       "description": "Algumas contas de destino na rede Stellar requerem um memo para identificar seu pagamento.",
       "additionalInfo": "Se um memo necessário estiver ausente ou incorreto, seus fundos podem não chegar ao destinatário pretendido.",
       "sorobanInfo": "Memo não é permitido em transações Soroban, como transferências de colecionáveis ou endereços \"C\"",
-      "sorobanNote": "Memo não permitido para transações Soroban"
+      "sorobanNoteTransaction": "Memo não permitido para transações Soroban",
+      "sorobanNoteCollectible": "Memo não é permitido para transferências de colecionáveis"
     },
     "slippageInfo": {
       "title": "Deslizamento permitido",

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -349,11 +349,12 @@ export const buildPaymentTransaction = async (
       networkPassphrase: networkDetails.networkPassphrase,
     });
 
-    if (memo) {
+    const isToContractAddress = isContractId(recipientAddress);
+
+    // Only add memo for non-Soroban transactions
+    if (memo && !isToContractAddress) {
       transactionBuilder.addMemo(new Memo(Memo.text(memo).type, memo));
     }
-
-    const isToContractAddress = isContractId(recipientAddress);
 
     if (isToContractAddress) {
       const token = getTokenForPayment(selectedBalance);
@@ -527,7 +528,6 @@ export const buildSendCollectibleTransaction = async (
     collectionAddress,
     transactionFee,
     transactionTimeout,
-    transactionMemo,
     tokenId,
     network,
     recipientAddress,
@@ -566,10 +566,6 @@ export const buildSendCollectibleTransaction = async (
       xdr.ScVal.scvU32(tokenId), // token_id
     ];
     txBuilder.addOperation(contract.call("transfer", ...transferParams));
-
-    if (transactionMemo) {
-      txBuilder.addMemo(Memo.text(transactionMemo));
-    }
 
     const transaction = txBuilder.build();
     return { tx: transaction, xdr: transaction.toXDR() };


### PR DESCRIPTION
Closes #492 

https://github.com/user-attachments/assets/e88a50f1-b058-4f30-991b-ff627612c1b8


Added a new text here as well (post video recording), to align more with collectible transfers, taking precedence over the C address. Also added the full stop on the info sentence (also post recording)

<img width="325" height="727" alt="Screenshot 2025-10-31 at 14 06 05" src="https://github.com/user-attachments/assets/9da79385-e64f-49dd-b5bc-4b0c2af908a8" />
<img width="308" height="635" alt="Screenshot 2025-10-31 at 14 31 09" src="https://github.com/user-attachments/assets/5963fab8-3c60-4946-85a2-ef8d23e8bc06" />


Android UI (Extra small phone - will be a one liner in any modern phone)

<img width="364" height="668" alt="Screenshot 2025-10-31 at 14 21 00" src="https://github.com/user-attachments/assets/7e15bbae-84df-44b1-963c-702fcd9b878c" />
<img width="370" height="665" alt="Screenshot 2025-10-31 at 14 21 07" src="https://github.com/user-attachments/assets/9a129fa0-fc9a-47aa-86e4-5d973a59a76f" />
<img width="366" height="674" alt="Screenshot 2025-10-31 at 14 21 41" src="https://github.com/user-attachments/assets/14addbbc-70f0-4050-aa6e-be861cad41de" />



#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [x] These changes have been tested and confirmed to work as intended on small iOS screens.
- [x] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [x] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
