### PR TITLE
Script to set app version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "c-install": "yarn gradle-clean && yarn node-clean && yarn install",
     "reset-env": "sh ./scripts/reset-env",
     "r-install": "yarn reset-env && yarn rebuild freighter-mobile",
-    "generate-splashscreen": "yarn react-native-bootsplash generate splashscreen/freighter-logo.png --platforms=android,ios --background=161616 --logo-width=206 --assets-output=assets/bootsplash --flavor=main"
+    "generate-splashscreen": "yarn react-native-bootsplash generate splashscreen/freighter-logo.png --platforms=android,ios --background=161616 --logo-width=206 --assets-output=assets/bootsplash --flavor=main",
+    "set-app-version": "node ./scripts/set-app-version"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/set-app-version
+++ b/scripts/set-app-version
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+function usage(message) {
+  if (message) {
+    console.error(`Error: ${message}`);
+  }
+  console.error("Usage: scripts/set-app-version <version>");
+  process.exit(1);
+}
+
+const [, , version] = process.argv;
+
+if (!version) {
+  usage("Version is required");
+}
+
+const rootDir = path.join(__dirname, "..");
+
+function updateFile(filePath, updater) {
+  const absolutePath = path.join(rootDir, filePath);
+  const original = fs.readFileSync(absolutePath, "utf8");
+  const updated = updater(original);
+
+  if (original === updated) {
+    console.warn(`⚠️  No changes applied to ${filePath}`);
+  } else {
+    fs.writeFileSync(absolutePath, updated, "utf8");
+    console.log(`✅ Updated ${filePath}`);
+  }
+}
+
+const plistRegex = new RegExp(
+  "(<key>CFBundleShortVersionString</key>\\s*<string>)([^<]+)(</string>)",
+  "g",
+);
+
+updateFile("android/app/build.gradle", (contents) =>
+  contents.replace(/versionName\s+"[^"]+"/g, `versionName "${version}"`),
+);
+
+updateFile("ios/freighter-mobile/Info.plist", (contents) =>
+  contents.replace(plistRegex, `$1${version}$3`),
+);
+
+updateFile("ios/freighter-mobile/Info-Dev.plist", (contents) =>
+  contents.replace(plistRegex, `$1${version}$3`),
+);
+
+updateFile("ios/freighter-mobile.xcodeproj/project.pbxproj", (contents) =>
+  contents.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`),
+);
+
+console.log(`🎯 App version set to ${version}`);
+


### PR DESCRIPTION
### What

Add a script and a yarn command to set the app version in all expected places.

### Why

So devs can easily set a new app version with a command like `yarn set-app-version 1.8.24`.

This script will also soon be used in a "New Release" workflow which should automatically create the Release PR with the given app version.

### Known limitations

N/A

### Checklist

#### PR structure

- [ ] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [ ] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
