### PR TITLE
[New Release workflow] Dispatch dev builds + Release notes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,6 +23,10 @@ on:
         options:
           - "yes"
           - "no"
+      release_notes:
+        description: Optional release notes override (supports Markdown)
+        type: string
+        default: ""
   schedule:
     # Runs every day at midnight PST/PDT time (8am UTC/GMT)
     - cron: "0 8 * * *"
@@ -146,6 +150,13 @@ jobs:
             echo "UPLOAD_TO_GOOGLE_PLAY=${{ github.event.inputs.upload_to_google_play }}" >> $GITHUB_ENV
             # Translate env input to Android flavor (dev/prod map directly to flavor dimension)
             export ANDROID_FLAVOR="${{ github.event.inputs.env }}"
+          fi
+          if [[ "${{ github.event_name }}" != "schedule" && "${{ github.event.inputs.release_notes }}" != "" ]]; then
+            {
+              echo "RELEASE_NOTES_OVERRIDE<<EOF"
+              echo "${{ github.event.inputs.release_notes }}"
+              echo "EOF"
+            } >> $GITHUB_ENV
           fi
           ./scripts/gh-android-env >> $GITHUB_ENV
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,6 +23,10 @@ on:
         options:
           - "yes"
           - "no"
+      release_notes:
+        description: Optional release notes override (supports Markdown)
+        type: string
+        default: ""
   schedule:
     # Runs every day at midnight PST/PDT time (8am UTC/GMT)
     - cron: "0 8 * * *"
@@ -153,6 +157,13 @@ jobs:
             else
               export IOS_SCHEME=""
             fi
+          fi
+          if [[ "${{ github.event_name }}" != "schedule" && "${{ github.event.inputs.release_notes }}" != "" ]]; then
+            {
+              echo "RELEASE_NOTES_OVERRIDE<<EOF"
+              echo "${{ github.event.inputs.release_notes }}"
+              echo "EOF"
+            } >> $GITHUB_ENV
           fi
           ./scripts/gh-ios-env >> $GITHUB_ENV
 

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -8,6 +8,14 @@ on:
         description: App version (e.g. 1.8.24)
         required: true
         type: string
+      release_description:
+        description: >
+          Release notes / PR description (supports Markdown). This content is
+          reused for the pull request body, TestFlight notes, and Google Play
+          notes.
+        required: false
+        default: ""
+        type: string
 
 jobs:
   create_release_branch:
@@ -57,15 +65,26 @@ jobs:
           git push --set-upstream origin "$RELEASE_BRANCH"
 
       - name: Create pull request
+        id: create_pr
         uses: actions/github-script@v8
         env:
           APP_VERSION: ${{ env.APP_VERSION }}
           RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }}
+          PR_DESCRIPTION: ${{ inputs.release_description }}
         with:
           script: |
             const title = `v${process.env.APP_VERSION}`;
             const branch = process.env.RELEASE_BRANCH;
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+            const rawBody = process.env.PR_DESCRIPTION || "";
+            const trimmedBody = rawBody.trim();
+            const body = trimmedBody.length > 0 ? rawBody : `Automated release for v${process.env.APP_VERSION}.`;
+
+            async function setOutputs(pr) {
+              core.notice(`Pull request ready: ${pr.html_url}`);
+              core.setOutput("pr_number", pr.number.toString());
+              core.setOutput("pr_url", pr.html_url);
+            }
 
             try {
               const { data } = await github.rest.pulls.create({
@@ -74,13 +93,73 @@ jobs:
                 head: branch,
                 base: "main",
                 title,
-                body: `Automated release for v${process.env.APP_VERSION}.`
+                body
               });
-              core.notice(`Pull request created: ${data.html_url}`);
+              await setOutputs(data);
             } catch (error) {
               if (error.status === 422) {
                 core.warning(`Pull request could not be created automatically: ${error.message}`);
+                const { data: existing } = await github.rest.pulls.list({
+                  owner,
+                  repo,
+                  head: `${owner}:${branch}`,
+                  base: "main",
+                  state: "open"
+                });
+
+                if (existing.length > 0) {
+                  await setOutputs(existing[0]);
+                } else {
+                  throw error;
+                }
               } else {
                 throw error;
               }
+            }
+
+      - name: Trigger dev builds (initial QA)
+        uses: actions/github-script@v8
+        env:
+          APP_VERSION: ${{ env.APP_VERSION }}
+          RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }}
+          PR_DESCRIPTION: ${{ inputs.release_description }}
+        with:
+          script: |
+            const branch = process.env.RELEASE_BRANCH;
+            const rawDescription = process.env.PR_DESCRIPTION || "";
+            const releaseNotes = rawDescription.trim().length > 0 ? rawDescription : "";
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+            const workflows = [
+              {
+                workflow_id: "ios.yml",
+                name: "iOS Release",
+                inputs: {
+                  ref_name: branch,
+                  env: "dev",
+                  upload_to_testflight: "yes",
+                  release_notes: releaseNotes
+                }
+              },
+              {
+                workflow_id: "android.yml",
+                name: "Android Release",
+                inputs: {
+                  ref_name: branch,
+                  env: "dev",
+                  upload_to_google_play: "yes",
+                  release_notes: releaseNotes
+                }
+              }
+            ];
+
+            for (const workflow of workflows) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: workflow.workflow_id,
+                ref: branch,
+                inputs: workflow.inputs
+              });
+              core.notice(`Triggered ${workflow.name} workflow (${workflow.workflow_id}) for ${branch}`);
             }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,6 +93,25 @@ def write_android_changelog(notes)
   File.write(default_path, notes)
 end
 
+def release_notes
+  return @release_notes if defined?(@release_notes)
+
+  override = ENV["RELEASE_NOTES_OVERRIDE"]
+
+  if override.to_s.strip.empty?
+    @release_notes_source = :default
+    @release_notes = default_release_notes
+  else
+    @release_notes_source = :override
+    @release_notes = override
+  end
+end
+
+def release_notes_override?
+  release_notes
+  @release_notes_source == :override
+end
+
 def testflight?
   ENV["UPLOAD_TO_TESTFLIGHT"] != "no"
 end
@@ -136,8 +155,9 @@ platform :ios do
 
   lane :upload_build do
     if testflight?
-      notes = default_release_notes
-      UI.message "📝 Using TestFlight release notes:\n#{notes}"
+      notes = release_notes
+      header = release_notes_override? ? "📝 Using release notes override for TestFlight:" : "📝 Using default TestFlight release notes:"
+      UI.message "#{header}\n#{notes}"
       upload_to_testflight(
         skip_waiting_for_build_processing: true,
         changelog: notes
@@ -204,8 +224,9 @@ platform :android do
 
   lane :upload_build do
     if google_play?
-      notes = default_release_notes
-      UI.message "📝 Using Google Play release notes:\n#{notes}"
+      notes = release_notes
+      header = release_notes_override? ? "📝 Using release notes override for Google Play:" : "📝 Using default Google Play release notes:"
+      UI.message "#{header}\n#{notes}"
       write_android_changelog(notes)
       upload_to_play_store(
         track: "internal",


### PR DESCRIPTION
### What

This PR applies some improvements to the "New Release" workflow:
- Add another input for the `Release Notes`. This copy will be used to populate the `PR description` as well as the release notes on `Testflight` and `Google Play builds`.
- After creating the PR with the given Release Notes this workflow will `automatically dispatch iOS and Android dev builds` based on the release branch so the team can start QAing it.
- The `nightly dev builds` will still keep the `default release notes` as illustrated [in this other PR](https://github.com/stellar/freighter-mobile/pull/540).

### Why

So we spend less time with manual work during release cycles.

### Known limitations

Since this PR also changes the Fastfile I'll need to merge it right away in order to fully test this new workflow, but please `feel free to leave any post merge comments`.

### Checklist

#### PR structure

- [ ] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [ ] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
