### PR TITLE
[Feature Flags] Accept several "on" variants

### DIFF
--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -7,6 +7,9 @@ import { create } from "zustand";
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
+// Amplitude variant values that are considered "on"
+const ON_VARIANT_VALUES = ["on", "true", "enabled", "yes"];
+
 // Feature flags configuration arrays
 const BOOLEAN_FLAGS = [
   "swap_enabled",
@@ -120,7 +123,7 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
           if (BOOLEAN_FLAGS.includes(key as (typeof BOOLEAN_FLAGS)[number])) {
             const booleanKey = key as keyof BooleanFeatureFlags;
             (updates as BooleanFeatureFlags)[booleanKey] =
-              variant.value === "on";
+              ON_VARIANT_VALUES.includes(variant.value);
           }
           // Handle version flags - use value directly after parsing version strings
           else if (
@@ -136,7 +139,7 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
             COMPLEX_FLAGS.includes(key as (typeof COMPLEX_FLAGS)[number])
           ) {
             const complexKey = key as keyof ComplexFeatureFlags;
-            const enabled = variant.value === "on";
+            const enabled = ON_VARIANT_VALUES.includes(variant.value);
             const flagValue = {
               enabled,
               payload: enabled ? variant.payload : undefined,


### PR DESCRIPTION
### What

Allow more flexibility on which feature-flag values are considered "on", so now any of the following values will be considered valid "on" values: `"on", "true", "enabled", "yes"`

### Why

Amplitude does not allow us to have 2 variants of the same feature flag with the same value which makes it more difficult for us to branch different experimental values for different environments (e.g. Dev and Prod envs).

This PR allow us to use multiple variations of the "on" value so that we could clearly set different payloads for different envs [like the below](https://app.amplitude.com/experiment/dev-sdf/300468/config/660901/configure). With this we also mitigate the chances of someone editing the "Prod" values while actually testing something in "Dev" env.

<img width="447" height="433" alt="Screenshot 2025-11-12 at 14 45 45" src="https://github.com/user-attachments/assets/536a431b-bc7b-47fb-aa6b-0b0e2201dbbd" />
<img width="1080" height="700" alt="Screenshot 2025-11-12 at 14 43 58" src="https://github.com/user-attachments/assets/f3c5d851-6492-498e-869f-9166ae2b0066" />


### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
