### PR TITLE
[iOS Release Workflow] Automatically set most recent Xcode version

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -139,7 +139,7 @@ jobs:
           echo "Available Xcode versions:"
           ls -1 /Applications | grep -i Xcode || echo "No Xcode found"
 
-      - name: Set xcode version
+      - name: Set latest stable Xcode version
         run: |
           # Find all stable Xcode versions (exclude Release_Candidate, RC, beta, Beta)
           XCODE_PATHS=$(ls -1d /Applications/Xcode*.app 2>/dev/null | grep -v -E "(Release_Candidate|RC|beta|Beta)" || true)
@@ -176,7 +176,7 @@ jobs:
           echo "Selected Xcode: $LATEST_XCODE (Version: $LATEST_VERSION)"
           sudo xcode-select -s "$LATEST_XCODE"
 
-      - name: Verify Xcode Version
+      - name: Verify selected Xcode Version
         run: xcodebuild -version
 
       - name: Set ref


### PR DESCRIPTION
### What

Automatically set most recent stable Xcode version on iOS Release workflow.
Set macOS to 26 and display image information.
Log more debug info (e.g. print detected release branches).

### Why

So that devs don't need to worry about manually updating it every time Xcode upgrades.

<img width="1496" height="1216" alt="Screenshot 2025-11-18 at 14 39 10" src="https://github.com/user-attachments/assets/ddb698fb-34c7-4130-a645-30e599ae1355" />

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
