### PR TITLE
Detach SecureClipboard podspec from package version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3216,7 +3216,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - SecureClipboard (0.0.1):
+  - SecureClipboard (1.0.0):
     - React-Core
   - Sentry/HybridSDK (8.56.2)
   - SocketRocket (0.7.1)
@@ -3678,7 +3678,7 @@ SPEC CHECKSUMS:
   RNSentry: bbaa7ef3a4b131bc947de327ed9e47a054ce0978
   RNSVG: 6c39befcfad06eec55b40c19a030b2d9eca63334
   RNWorklets: ad0606bee2a8103c14adb412149789c60b72bfb2
-  SecureClipboard: d70b94194e1ca2a2b70accae112881295b8d5032
+  SecureClipboard: ec92bdef9aba3e86b33c1b0c1f0d334fcc171f39
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   VisionCamera: 891edb31806dd3a239c8a9d6090d6ec78e11ee80

--- a/ios/SecureClipboard.podspec
+++ b/ios/SecureClipboard.podspec
@@ -1,17 +1,13 @@
-require "json"
-
-package = JSON.parse(File.read(File.join(__dir__, "..", "package.json")))
-
 Pod::Spec.new do |s|
   s.name         = "SecureClipboard"
-  s.version      = package["version"]
+  s.version      = "1.0.0"
   s.summary      = "Secure clipboard functionality for React Native"
   s.description  = "A React Native module that provides secure clipboard functionality with platform-specific enhancements"
   s.homepage     = "https://github.com/stellar/freighter-mobile"
   s.license      = "MIT"
   s.author       = { "Stellar Development Foundation" => "hello@stellar.org" }
   s.platforms    = { :ios => "11.0" }
-  s.source       = { :git => "https://github.com/stellar/freighter-mobile.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/stellar/freighter-mobile.git" }
   s.source_files = "SecureClipboard.{swift,m}"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
### What

Detach `SecureClipboard` podspec version from `freighter-mobile` package version.

### Why

Since we are now also [setting the freighter-mobile package version](https://github.com/stellar/freighter-mobile/pull/581) on every release bump this means we'd also need to update pods to get the `SecureClipboard` podspec version synced to prevent checksum issues which [would break our iOS release workflow](https://github.com/stellar/freighter-mobile/actions/runs/19648450025/job/56269353964#step:16:801).

So to avoid that extra unnecessary step let's hardcode the `SecureClipboard` podspec version. We would really only need to update the version number once we distribute this pod module externally, in which case we could also only change the version number when there is an actual change in the module instead of tying it to `freighter-mobile` version.

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
