### PR TITLE
[New Release workflow] Fix env param name

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -163,7 +163,7 @@ jobs:
                 name: "iOS Release",
                 inputs: {
                   ref_name: branch,
-                  env: "dev",
+                  buildEnv: "dev",
                   upload_to_testflight: "yes",
                   release_notes: releaseNotes
                 }
@@ -173,7 +173,7 @@ jobs:
                 name: "Android Release",
                 inputs: {
                   ref_name: branch,
-                  env: "dev",
+                  buildEnv: "dev",
                   upload_to_google_play: "yes",
                   release_notes: releaseNotes
                 }


### PR DESCRIPTION
### What

Fix workflow "env" param name to be "buildEnd" instead.

### Why

We've changed this param name for the iOS and Android workflows [on this other PR](https://github.com/stellar/freighter-mobile/pull/557) but forgot to apply the same change to the "New Release" workflow.

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
