### PR TITLE
[New Release workflow] Use tag to reference last release version

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -47,12 +48,15 @@ jobs:
         run: |
           set -eo pipefail
 
-          release_tag_pattern='^v[0-9]\+\.[0-9]\+\.[0-9]\+$'
-          last_release_tag=$(git tag -l | grep -E "$release_tag_pattern" | sort -V | tail -n 1 || true)
+          # Find the latest version tag (e.g., v1.8.24)
+          # Use --sort=-version:refname to sort tags by version in descending order
+          last_release_tag=$(git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
 
           if [ -n "$last_release_tag" ]; then
+            echo "Found last release tag: $last_release_tag"
             commits=$(git log "${last_release_tag}..HEAD" --pretty=format:'- %s' --no-merges 2>/dev/null || true)
           else
+            echo "No release tag found, including all commits"
             commits=$(git log --pretty=format:'- %s' --no-merges 2>/dev/null || true)
           fi
 


### PR DESCRIPTION
### What

Change the workflow to use `tag` instead of `commit message` to find a reference for the last release.

### Why

Using `tag` is more `accurate` and `reliable` than commit messages.

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
