### PR TITLE
Fix Android build

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3007,7 +3007,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.11.1):
+  - RNScreens (4.20.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3034,10 +3034,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.11.1)
+    - RNScreens/common (= 4.20.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.11.1):
+  - RNScreens/common (4.20.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3705,7 +3705,7 @@ SPEC CHECKSUMS:
   RNLocalize: a0ec66afe0980934cfe13f3bc30f476443388a36
   RNPermissions: a774e9e55b559f85daa96e926d90fda1a0e9b941
   RNReanimated: 3c450abad323c7d57a98d34ab9ff642c18da9021
-  RNScreens: d64f01363a5ae12e2998784f9527d7a8ffb04e93
+  RNScreens: 714e10b6b554f7dc7ad9f78dcf36dc8e3fc73415
   RNScrypt: 3e8612600c93aaa3bfa7849b6d1a4ab61613e2af
   RNSentry: bbaa7ef3a4b131bc947de327ed9e47a054ce0978
   RNSVG: 6c39befcfad06eec55b40c19a030b2d9eca63334

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-native-reanimated": "4.1.2",
     "react-native-responsive-screen": "1.4.2",
     "react-native-safe-area-context": "5.5.2",
-    "react-native-screens": "4.11.1",
+    "react-native-screens": "4.20.0",
     "react-native-scrypt": "1.2.1",
     "react-native-svg": "15.13.0",
     "react-native-view-shot": "4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9919,7 +9919,7 @@ __metadata:
     react-native-reanimated: "npm:4.1.2"
     react-native-responsive-screen: "npm:1.4.2"
     react-native-safe-area-context: "npm:5.5.2"
-    react-native-screens: "npm:4.11.1"
+    react-native-screens: "npm:4.20.0"
     react-native-scrypt: "npm:1.2.1"
     react-native-svg: "npm:15.13.0"
     react-native-svg-transformer: "npm:1.5.0"
@@ -15078,7 +15078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:^1.1.7, react-native-is-edge-to-edge@npm:^1.2.1":
+"react-native-is-edge-to-edge@npm:^1.2.1":
   version: 1.2.1
   resolution: "react-native-is-edge-to-edge@npm:1.2.1"
   peerDependencies:
@@ -15198,17 +15198,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:4.11.1":
-  version: 4.11.1
-  resolution: "react-native-screens@npm:4.11.1"
+"react-native-screens@npm:4.20.0":
+  version: 4.20.0
+  resolution: "react-native-screens@npm:4.20.0"
   dependencies:
     react-freeze: "npm:^1.0.0"
-    react-native-is-edge-to-edge: "npm:^1.1.7"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/88a33ba419bd571cc318e80d25eb172f5829677f2dd80dcb69cbeaa6a35ba26214e0e82af87baa375182afe41a276e8ef1a9d13b826f662f3a389982492c2879
+  checksum: 10c0/f5d18bef4bee5b65470f76048dd3511d4ef18d1cf3566b6479a70a67e75c92aca3549342ee96c418e68997380dc562fbf4e63b5d411975c2265f106fecb242cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What

Android build started failing after the changes from the [Pins all dependencies PR](https://github.com/stellar/freighter-mobile/pull/671) due to `react-native-screens` using a deprecated React Native API (`ShadowNode::Shared`). Upgrading the `react-native-screens` fixed the issue.

### Why

So we can build and install the Android app again.

<img width="923" height="983" alt="Screenshot 2026-01-22 at 16 55 31" src="https://github.com/user-attachments/assets/b4fab18c-5c95-4524-9a3d-3f0db3194f41" />

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
