### PR TITLE
feature: filter asset balance changes by public key

### DIFF
--- a/src/helpers/assetBalanceChanges.ts
+++ b/src/helpers/assetBalanceChanges.ts
@@ -105,9 +105,18 @@ export async function processAssetBalanceChanges(
     return [];
   }
 
+  // Filter to only include changes where the user is involved (as sender or receiver)
+  const relevantChanges = changes.filter(
+    (change) => change.to === publicKey || change.from === publicKey,
+  );
+
+  if (relevantChanges.length === 0) {
+    return [];
+  }
+
   // Process each change into a summary
   const summaries = await Promise.all(
-    changes.map((change) =>
+    relevantChanges.map((change) =>
       processAssetChange(change, publicKey, networkDetails),
     ),
   );


### PR DESCRIPTION
### What
Filters asset balance changes by the active public key on history.

### Why
To only show relevant balance changes in history.

### Known limitations
Will not reveal any balance changes for other keys as a part of your history.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [x] These changes have been tested and confirmed to work as intended on small iOS screens.
- [x] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [x] I've checked with the product team if we should add metrics to these changes.
- [x] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.

Swap with several intermediaries:
<img width="750" height="1334" alt="simulator_screenshot_3BAC7362-7827-4F58-8290-EFEA077F7A27" src="https://github.com/user-attachments/assets/43eafd09-e52d-45d5-a75b-03d182b55da3" />


