### PR TITLE
Bump protocol version to 25

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -141,7 +141,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1234567890
-        versionName "1.11.24"
+        versionName "1.11.25"
     }
 
     buildTypes {

--- a/ios/freighter-mobile.xcodeproj/project.pbxproj
+++ b/ios/freighter-mobile.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.24;
+				MARKETING_VERSION = 1.11.25;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -542,7 +542,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.24;
+				MARKETING_VERSION = 1.11.25;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -740,7 +740,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.24;
+				MARKETING_VERSION = 1.11.25;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -775,7 +775,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.24;
+				MARKETING_VERSION = 1.11.25;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/freighter-mobile/Info-Dev.plist
+++ b/ios/freighter-mobile/Info-Dev.plist
@@ -17,7 +17,7 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.11.24</string>
+		<string>1.11.25</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleURLTypes</key>

--- a/ios/freighter-mobile/Info.plist
+++ b/ios/freighter-mobile/Info.plist
@@ -17,7 +17,7 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.11.24</string>
+		<string>1.11.25</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freighter-mobile",
-  "version": "1.11.24",
+  "version": "1.11.25",
   "license": "Apache-2.0",
   "scripts": {
     "android": "yarn android-dev",


### PR DESCRIPTION
### What

Bumping protocol version to 25.

### Why

Protocol 25 (X-Ray) is already live and working fine on Freighter.

### Known limitations

N/A

### Checklist

#### PR structure

- [ ] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [ ] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
