### PR TITLE
[E2E] Remove /e2e comment trigger from CI workflows

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -6,8 +6,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main, release, "v*.*.*"]
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       ref:
@@ -77,19 +75,11 @@ jobs:
     name: Build Android APK
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 120
-    # Run on PR "/e2e" comments, or on normal triggers (PR, push, workflow_dispatch)
-    if: |
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/e2e') ||
-      github.event_name != 'issue_comment'
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
-          ref:
-            ${{ github.event.inputs.ref || (github.event_name == 'issue_comment'
-            && format('refs/pull/{0}/head', github.event.issue.number)) ||
-            github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Make scripts executable
         run: find scripts -type f -exec chmod +x {} \;
@@ -240,10 +230,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
-          ref:
-            ${{ github.event.inputs.ref || (github.event_name == 'issue_comment'
-            && format('refs/pull/{0}/head', github.event.issue.number)) ||
-            github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Make scripts executable
         run: find scripts -type f -exec chmod +x {} \;

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -6,8 +6,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main, release, "v*.*.*"]
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       ref:
@@ -69,19 +67,11 @@ jobs:
     name: Build iOS App
     runs-on: macos-26-xlarge
     timeout-minutes: 120
-    # Run on PR "/e2e" comments, or on normal triggers (PR, push, workflow_dispatch)
-    if: |
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/e2e') ||
-      github.event_name != 'issue_comment'
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
-          ref:
-            ${{ github.event.inputs.ref || (github.event_name == 'issue_comment'
-            && format('refs/pull/{0}/head', github.event.issue.number)) ||
-            github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Make scripts executable
         run: find scripts -type f -exec chmod +x {} \;
@@ -237,10 +227,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
-          ref:
-            ${{ github.event.inputs.ref || (github.event_name == 'issue_comment'
-            && format('refs/pull/{0}/head', github.event.issue.number)) ||
-            github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Make scripts executable
         run: find scripts -type f -exec chmod +x {} \;

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -46,13 +46,13 @@ E2E tests run **locally** (with Maestro CLI + simulator/emulator) or in **CI**
 
 Detailed guides live in `e2e/docs/`:
 
-| Topic                     | File                                                          | Description                                                                                    |
-| ------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **CI & Triggers**         | [ci-and-triggers.md](docs/ci-and-triggers.md)                 | When tests run, branch filters, manual runs (workflow_dispatch, `/e2e`), CI matrix parallelism |
-| **Local Setup & Env**     | [local-setup-and-env.md](docs/local-setup-and-env.md)         | `.env` for E2E, `E2E_TEST_RECOVERY_PHRASE`, how secrets/vars are used in CI                    |
-| **Running Tests**         | [running-tests.md](docs/running-tests.md)                     | Run in CI vs locally, single flow by platform + name                                           |
-| **Artifacts & Debugging** | [artifacts-and-debugging.md](docs/artifacts-and-debugging.md) | Artifact layout, logs, recordings, screenshots, how to debug failures                          |
-| **Creating Tests**        | [creating-tests.md](docs/creating-tests.md)                   | Maestro YAML (API), Maestro Studio, recording flows, best practices (e.g. prefer `testID`)     |
+| Topic                     | File                                                          | Description                                                                                |
+| ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **CI & Triggers**         | [ci-and-triggers.md](docs/ci-and-triggers.md)                 | When tests run, branch filters, manual runs (workflow_dispatch), CI matrix parallelism     |
+| **Local Setup & Env**     | [local-setup-and-env.md](docs/local-setup-and-env.md)         | `.env` for E2E, `E2E_TEST_RECOVERY_PHRASE`, how secrets/vars are used in CI                |
+| **Running Tests**         | [running-tests.md](docs/running-tests.md)                     | Run in CI vs locally, single flow by platform + name                                       |
+| **Artifacts & Debugging** | [artifacts-and-debugging.md](docs/artifacts-and-debugging.md) | Artifact layout, logs, recordings, screenshots, how to debug failures                      |
+| **Creating Tests**        | [creating-tests.md](docs/creating-tests.md)                   | Maestro YAML (API), Maestro Studio, recording flows, best practices (e.g. prefer `testID`) |
 
 ---
 

--- a/e2e/docs/ci-and-triggers.md
+++ b/e2e/docs/ci-and-triggers.md
@@ -9,7 +9,6 @@ covers when they run, how to trigger them manually, and how the CI matrix works.
 flowchart TD
   PR[Pull request] --> BR{Target branch?}
   PU[Push] --> BR
-  IC[Comment /e2e on PR] --> RUN
   WD[workflow_dispatch] --> RUN
   BR --> |main, release, v*.*.*| RUN[Run E2E workflow]
   BR --> |Other| SKIP[Skip]
@@ -19,7 +18,6 @@ flowchart TD
 | --------------------- | -------------------------------------------------------------------------------------------------- |
 | **Pull request**      | `opened`, `synchronize`, `reopened`, `ready_for_review` on `main`, `release`, or `v*.*.*` branches |
 | **Push**              | Same branches as above                                                                             |
-| **Issue comment**     | Comment **exactly** `/e2e` on a PR (runs on that PR's head)                                        |
 | **workflow_dispatch** | Manual run from **Actions** tab                                                                    |
 
 **Branch patterns**: `v*.*.*` matches semantic versions (e.g. `v1.2.3`), not
@@ -27,17 +25,12 @@ arbitrary names like `vrandombranch`.
 
 ## Manual runs
 
-### 1. workflow_dispatch
+Use **workflow_dispatch** to run E2E tests on demand:
 
 1. Open **Actions** → **Android E2E Tests** or **iOS E2E Tests**.
 2. Click **Run workflow**.
 3. Optionally set **ref** (commit hash) or leave empty for default branch.
 4. Run.
-
-### 2. Comment `/e2e` on a PR
-
-Comment **exactly** `/e2e` on a pull request. The workflow runs for that PR's
-head. Build and test jobs use the same ref.
 
 ## CI matrix & parallelism
 


### PR DESCRIPTION
### What

Remove `/e2e` comment trigger from Android and iOS CI workflows.

### Why

https://stellarfoundation.slack.com/archives/C06GHH10005/p1770857290220279?thread_ts=1770851447.997639&cid=C06GHH10005

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
