### PR TITLE
Remove nightly build skip mechanism for active release branches

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -107,38 +107,7 @@ env:
   E2E_TEST_RECOVERY_PHRASE: ""
 
 jobs:
-  # Scheduled nightly builds should not overwrite the dev build
-  # when a release candidate branch is active (branches starting with "release" or "emergency-release").
-  check_release_branch:
-    runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Check for active release branch
-        id: check
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Check for branches named "release" or "emergency-release", or starting with "release/" or "emergency-release/"
-          RELEASE_BRANCHES=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" | sed 's/.*refs\/heads\///' | grep -E '^(release$|release/|emergency-release$|emergency-release/)' || true)
-
-          if [ -n "$RELEASE_BRANCHES" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Active release branch(es) detected:"
-            echo "$RELEASE_BRANCHES" | while read -r branch; do
-              echo "  - $branch"
-            done
-            echo "Skipping scheduled daily dev build."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build:
-    needs: check_release_branch
-    if: needs.check_release_branch.outputs.skip == 'false'
     name: Build Android
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 45

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -96,38 +96,7 @@ env:
   E2E_TEST_RECOVERY_PHRASE: ""
 
 jobs:
-  # Scheduled nightly builds should not overwrite the dev build
-  # when a release candidate branch is active (branches starting with "release" or "emergency-release").
-  check_release_branch:
-    runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Check for active release branch
-        id: check
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Check for branches named "release" or "emergency-release", or starting with "release/" or "emergency-release/"
-          RELEASE_BRANCHES=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" | sed 's/.*refs\/heads\///' | grep -E '^(release$|release/|emergency-release$|emergency-release/)' || true)
-
-          if [ -n "$RELEASE_BRANCHES" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Active release branch(es) detected:"
-            echo "$RELEASE_BRANCHES" | while read -r branch; do
-              echo "  - $branch"
-            done
-            echo "Skipping scheduled daily dev build."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build:
-    needs: check_release_branch
-    if: needs.check_release_branch.outputs.skip == 'false'
     name: Build iOS
     runs-on: macos-26-xlarge
     timeout-minutes: 60


### PR DESCRIPTION
### What

- Removes the `check_release_branch` pre-job and its skip logic from both iOS and Android release workflows
- Nightly scheduled builds now always run and distribute a new build from the tip of `main`, regardless of active release/emergency-release branches

### Why

The original intent was to avoid overwriting a dev build while a release was in progress. In practice this caused nightly builds to silently stop during release cycles, leaving the dev channel stale. We are changing our feature release process now so that Charles should QA features before they are merged to main to assess its UI/UX expectations so that our "Beta QA phase" should be quicker and work more as a "smoke test". In this new scenario having a fresh nightly build from `main` is more valuable than protecting the previous dev build.

On Testflight we can always select previous build to install if needed, and on Android the app is not auto-updated when a new version hits Google Play so you can keep the release candidate build installed without worrying about it being overwritten.

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
