### PR TITLE
Cap CI Xcode version at 26.3 to fix iOS build

### DIFF
--- a/scripts/setup-xcode-latest-stable
+++ b/scripts/setup-xcode-latest-stable
@@ -4,6 +4,10 @@
 
 set -e
 
+# Maximum allowed Xcode major.minor version.
+# Bump this once all Pods (especially `fmt`) compile cleanly on the next Xcode.
+MAX_XCODE_VERSION="26.3"
+
 # Find all beta/RC Xcode versions to identify base versions to exclude
 BETA_XCODE_PATHS=$(ls -1d /Applications/Xcode*.app 2>/dev/null | grep -E "(Release_Candidate|RC|beta|Beta)" || true)
 
@@ -44,15 +48,23 @@ for XCODE_PATH in $XCODE_PATHS; do
     # Extract major.minor version for comparison
     BASE_VERSION=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
     
-    # Check if this base version should be excluded
+    # Check if this version exceeds the maximum allowed version
     SHOULD_EXCLUDE=false
-    for EXCLUDED_BASE in $EXCLUDED_BASE_VERSIONS; do
-      if [ "$BASE_VERSION" = "$EXCLUDED_BASE" ]; then
-        echo "Excluding $XCODE_PATH (Version: $VERSION, Base: $BASE_VERSION matches excluded base version)"
-        SHOULD_EXCLUDE=true
-        break
-      fi
-    done
+    if [ -n "$MAX_XCODE_VERSION" ] && [ "$(printf '%s\n%s' "$MAX_XCODE_VERSION" "$BASE_VERSION" | sort -V | head -n1)" != "$BASE_VERSION" ]; then
+      echo "Excluding $XCODE_PATH (Version: $VERSION exceeds max allowed $MAX_XCODE_VERSION)"
+      SHOULD_EXCLUDE=true
+    fi
+
+    # Check if this base version should be excluded (beta/RC)
+    if [ "$SHOULD_EXCLUDE" = "false" ]; then
+      for EXCLUDED_BASE in $EXCLUDED_BASE_VERSIONS; do
+        if [ "$BASE_VERSION" = "$EXCLUDED_BASE" ]; then
+          echo "Excluding $XCODE_PATH (Version: $VERSION, Base: $BASE_VERSION matches excluded base version)"
+          SHOULD_EXCLUDE=true
+          break
+        fi
+      done
+    fi
     
     if [ "$SHOULD_EXCLUDE" = "false" ]; then
       printf "%s\t%s\n" "$VERSION" "$XCODE_PATH" >> "$TEMP_FILE"


### PR DESCRIPTION
### What

Cap the auto-selected Xcode version at 26.3 in the CI setup script.

### Why

Xcode 26.4 (recently launched on March 24, 2026) ships a stricter Clang that breaks the `fmt` CocoaPod with `consteval` errors:

```
ios/Pods/fmt/include/fmt/format-inl.h:59:24: error: call to consteval function
'fmt::basic_format_string<...>::basic_format_string<FMT_COMPILE_STRING, 0>'
is not a constant expression
```

The `setup-xcode-latest-stable` script auto-selects the highest non-beta Xcode on the runner. Since 26.4 is now available on CI runners, all iOS builds fail.

### Changes

Added a `MAX_XCODE_VERSION` variable at the top of `scripts/setup-xcode-latest-stable` that caps selection at 26.3. Versions above the cap are excluded before the sort, so CI will pick 26.3.x as the latest allowed version.

To bump later, just change the single variable at the top of the script once the `fmt` pod (or its consumer) is updated.

### Known limitations

N/A — this is a temporary cap until pod compatibility is resolved.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes.
- [x] This PR has reasonably narrow scope.
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] Version comparison logic tested locally (26.4 excluded, 26.3 included, 26.2 included).

#### Release

- [x] This is not a breaking change.