### PR TITLE
Fix Android local dev: Metro double-launch, stale autolinking, bundle load

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ react {
     //   The list of variants to that are debuggable. For those we're going to
     //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
-    // debuggableVariants = ["liteDebug", "prodDebug"]
+    debuggableVariants = ["devDebug", "prodDebug"]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.

--- a/android/app/src/dev/res/xml/network_security_config.xml
+++ b/android/app/src/dev/res/xml/network_security_config.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Network security config for the dev flavor only.
-  Allows cleartext HTTP to loopback addresses so the WalletConnect mock-dapp
-  server at http://127.0.0.1:3001 is reachable from the emulator during E2E tests,
-  and so Metro bundler at http://localhost:8081 works in debug builds.
+  Allows cleartext HTTP to loopback and emulator-host aliases so the WalletConnect
+  mock-dapp server at http://127.0.0.1:3001 is reachable from the emulator during
+  E2E tests, and so Metro bundler works in debug builds regardless of whether RN
+  resolves the host to localhost (physical device via adb reverse), 10.0.2.2
+  (stock Android emulator), or 10.0.3.2 (Genymotion).
 -->
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="false">127.0.0.1</domain>
         <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">10.0.3.2</domain>
     </domain-config>
 </network-security-config>

--- a/scripts/gradle-clean
+++ b/scripts/gradle-clean
@@ -2,5 +2,5 @@
 
 export LANG=en_US.UTF-8
 echo '   Removing Gradle cache and build artifacts...'
-(cd android && rm -rf .gradle && rm -rf app/.cxx && rm -rf app/build && ./gradlew clean) || true
+(cd android && rm -rf .gradle && rm -rf app/.cxx && rm -rf app/build && rm -rf build && ./gradlew clean) || true
 echo '   ✅ Gradle clean complete'


### PR DESCRIPTION
### What

Three independent fixes for paper cuts in the local Android dev loop, found while investigating an "Unable to load script" red-screen error:

1. **[android/app/build.gradle](android/app/build.gradle)** — set `debuggableVariants = ["devDebug", "prodDebug"]` in the `react {}` block.
2. **[scripts/gradle-clean](scripts/gradle-clean)** — also remove the top-level `android/build/` directory.
3. **[android/app/src/dev/res/xml/network_security_config.xml](android/app/src/dev/res/xml/network_security_config.xml)** — allowlist `10.0.2.2` and `10.0.3.2` in addition to the existing `127.0.0.1` / `localhost`.

### Why

#### 1. `debuggableVariants`
Without this, the RN Gradle plugin runs `createBundleDev(Debug|Release)JsAndAssets` on every debug install. The plugin skips bundling only for variants listed in `debuggableVariants`, and the default is `["debug"]`. This project uses `dev`/`prod` flavors combined with `debug`/`release` build types, so the real variant names are `devDebug`, `prodDebug`, `devRelease`, `prodRelease` — none of which match the default. Symptoms:

- `yarn android` prints a second "Welcome to Metro" banner in the install terminal (the bundling task's one-shot Metro invocation) on top of the real dev server window.
- Debug builds take longer because JS is being bundled into the APK unnecessarily.

The build.gradle file itself calls out this exact case in its comments.

#### 2. `gradle-clean` completeness
`yarn gradle-clean` only removed `android/.gradle` and `android/app/build/`. It did **not** remove `android/build/`, which holds `generated/autolinking/autolinking.json`. The RN Gradle plugin reuses this cached file if present. When a new native module is installed (in my case `react-native-keyboard-controller`), the stale JSON has no entry for it, autolinking silently skips it, and at runtime the app errors:

```
The package 'react-native-keyboard-controller' doesn't seem to be linked.
```

This survived multiple `yarn gradle-clean && yarn android` cycles until I manually `rm -rf android/build`.

#### 3. Cleartext allowlist for emulator host
The dev-flavor `network_security_config.xml` was introduced in #743 with a cleartext allowlist of only `127.0.0.1` and `localhost`. But RN's `AndroidInfoHelpers.getServerHost()` picks **`10.0.2.2`** as the bundler host by default on stock Android emulators (the special alias for the host's loopback). Since `10.0.2.2` wasn't on the allowlist, Android's network-security policy silently dropped the `/index.bundle` fetch — producing the "Unable to load script" red screen while Metro, the port binding, and `adb reverse` all looked healthy.

Adding `10.0.2.2` (stock emulator) and `10.0.3.2` (Genymotion, for completeness) restores the expected default path. The prod flavor's strict cleartext block is unchanged.

### Known limitations

None. Each fix is local to the Android dev loop and has no effect on prod builds, CI, or iOS.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS. _(N/A — Android-only)_
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens. _(N/A — Android-only)_
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes. _(N/A — build/infra config only)_

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.