### PR TITLE
Fade transition between scan and receive QR screens

### DIFF
--- a/__tests__/helpers/navigationOptions.test.ts
+++ b/__tests__/helpers/navigationOptions.test.ts
@@ -1,0 +1,43 @@
+import { NativeStackNavigationOptions } from "@react-navigation/native-stack";
+import { withTransitionOverride } from "helpers/navigationOptions";
+
+describe("withTransitionOverride", () => {
+  const baseOptions: NativeStackNavigationOptions = {
+    animation: "slide_from_bottom",
+    animationDuration: 300,
+    animationTypeForReplace: "push",
+  };
+
+  it("returns the base options unchanged when the route has no params", () => {
+    const result = withTransitionOverride(baseOptions, {});
+    expect(result).toBe(baseOptions);
+  });
+
+  it("returns the base options unchanged when transition is undefined", () => {
+    const result = withTransitionOverride(baseOptions, {
+      params: { transition: undefined },
+    });
+    expect(result).toBe(baseOptions);
+  });
+
+  it("overrides animation when transition is provided", () => {
+    const result = withTransitionOverride(baseOptions, {
+      params: { transition: "fade" },
+    });
+    expect(result.animation).toBe("fade");
+  });
+
+  it("preserves other base options when overriding animation", () => {
+    const result = withTransitionOverride(baseOptions, {
+      params: { transition: "fade" },
+    });
+    expect(result.animationDuration).toBe(300);
+    expect(result.animationTypeForReplace).toBe("push");
+  });
+
+  it("does not mutate the base options object", () => {
+    const snapshot = { ...baseOptions };
+    withTransitionOverride(baseOptions, { params: { transition: "fade" } });
+    expect(baseOptions).toEqual(snapshot);
+  });
+});

--- a/__tests__/hooks/useClearTransitionParam.test.tsx
+++ b/__tests__/hooks/useClearTransitionParam.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useClearTransitionParam } from "hooks/useClearTransitionParam";
+
+describe("useClearTransitionParam", () => {
+  const createNavigation = () => {
+    const unsubscribe = jest.fn();
+    let registeredCallback: (() => void) | undefined;
+    const addListener = jest.fn(
+      (_event: "transitionEnd", callback: () => void) => {
+        registeredCallback = callback;
+        return unsubscribe;
+      },
+    );
+    const setParams = jest.fn();
+    return {
+      navigation: { setParams, addListener },
+      unsubscribe,
+      triggerTransitionEnd: () => registeredCallback?.(),
+    };
+  };
+
+  it("does not subscribe when transition is undefined", () => {
+    const { navigation } = createNavigation();
+    renderHook(() => useClearTransitionParam(navigation, undefined));
+    expect(navigation.addListener).not.toHaveBeenCalled();
+    expect(navigation.setParams).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to transitionEnd when a transition is provided", () => {
+    const { navigation } = createNavigation();
+    renderHook(() => useClearTransitionParam(navigation, "fade"));
+    expect(navigation.addListener).toHaveBeenCalledWith(
+      "transitionEnd",
+      expect.any(Function),
+    );
+    expect(navigation.setParams).not.toHaveBeenCalled();
+  });
+
+  it("clears the transition param when transitionEnd fires", () => {
+    const { navigation, triggerTransitionEnd } = createNavigation();
+    renderHook(() => useClearTransitionParam(navigation, "fade"));
+    triggerTransitionEnd();
+    expect(navigation.setParams).toHaveBeenCalledWith({
+      transition: undefined,
+    });
+  });
+
+  it("unsubscribes after firing once", () => {
+    const { navigation, unsubscribe, triggerTransitionEnd } =
+      createNavigation();
+    renderHook(() => useClearTransitionParam(navigation, "fade"));
+    triggerTransitionEnd();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes on unmount even if transitionEnd never fires", () => {
+    const { navigation, unsubscribe } = createNavigation();
+    const { unmount } = renderHook(() =>
+      useClearTransitionParam(navigation, "fade"),
+    );
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
+++ b/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
@@ -58,7 +58,8 @@ const AccountQRCodeScreen: React.FC<AccountQRCodeScreenProps> = ({
     showNavigationAsCloseButton ? Icon.Scan : Icon.HelpCircle;
 
   const handleWalletConnectNavigation = () => {
-    // TODO: add comment to link with navigation.replace(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN) on useWalletConnectQrCodeScanner
+    // Paired with the replace in useWalletConnectQrCodeScanner.handleHeaderRight,
+    // which fades from ScanQRCodeScreen back to this screen.
     navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN, {
       source: QRCodeSource.WALLET_CONNECT,
       transition: "fade",

--- a/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
+++ b/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
@@ -55,23 +55,10 @@ const AccountQRCodeScreen: React.FC<AccountQRCodeScreenProps> = ({
     showNavigationAsCloseButton ? Icon.Scan : Icon.HelpCircle;
 
   const handleWalletConnectNavigation = () => {
-    // WalletConnect flow: Navigate between QR Scan and QR Address screens
-    const routes = navigation.getState()?.routes ?? [];
-    const scanRouteIndex = routes.findIndex(
-      (r) => r.name === ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN,
-    );
-
-    // If the scan route is already in the stack, pop to it
-    // Otherwise, navigate to it
-    if (scanRouteIndex !== -1) {
-      navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN, {
-        source: QRCodeSource.WALLET_CONNECT,
-      });
-    } else {
-      navigation.navigate(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN, {
-        source: QRCodeSource.WALLET_CONNECT,
-      });
-    }
+    // TODO: add comment to link with navigation.replace(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN) on useWalletConnectQrCodeScanner
+    navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN, {
+      source: QRCodeSource.WALLET_CONNECT,
+    });
   };
 
   const handleHelpModalPress = () => {

--- a/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
+++ b/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
@@ -58,6 +58,7 @@ const AccountQRCodeScreen: React.FC<AccountQRCodeScreenProps> = ({
     // TODO: add comment to link with navigation.replace(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN) on useWalletConnectQrCodeScanner
     navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN, {
       source: QRCodeSource.WALLET_CONNECT,
+      transition: "fade",
     });
   };
 

--- a/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
+++ b/src/components/screens/AccountQRCodeScreen/AccountQRCodeScreen.tsx
@@ -15,6 +15,7 @@ import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { pxValue } from "helpers/dimensions";
 import { truncateAddress } from "helpers/stellar";
 import useAppTranslation from "hooks/useAppTranslation";
+import { useClearTransitionParam } from "hooks/useClearTransitionParam";
 import { useClipboard } from "hooks/useClipboard";
 import useColors from "hooks/useColors";
 import useGetActiveAccount from "hooks/useGetActiveAccount";
@@ -38,6 +39,8 @@ const AccountQRCodeScreen: React.FC<AccountQRCodeScreenProps> = ({
   const { t } = useAppTranslation();
   const { copyToClipboard } = useClipboard();
   const explanationModalRef = useRef<BottomSheetModal>(null);
+
+  useClearTransitionParam(navigation, route.params?.transition);
 
   // useLayoutEffect is the official recommended hook to use for setting up
   // the navigation headers to prevent UI flickering.

--- a/src/components/screens/ScanQRCodeScreen.tsx
+++ b/src/components/screens/ScanQRCodeScreen.tsx
@@ -8,6 +8,7 @@ import Icon from "components/sds/Icon";
 import { getDefaultQRCodeSource, QRCodeSource } from "config/constants";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import useAppTranslation from "hooks/useAppTranslation";
+import { useClearTransitionParam } from "hooks/useClearTransitionParam";
 import useColors from "hooks/useColors";
 import { useQRCodeScreenScanner } from "hooks/useQRCodeScreenScanner";
 import React from "react";
@@ -29,9 +30,14 @@ type ScanQRCodeScreenProps = NativeStackScreenProps<
  * @param {ScanQRCodeScreenProps} props - Component props including navigation
  * @returns {JSX.Element} The rendered component
  */
-const ScanQRCodeScreen: React.FC<ScanQRCodeScreenProps> = ({ route }) => {
+const ScanQRCodeScreen: React.FC<ScanQRCodeScreenProps> = ({
+  route,
+  navigation,
+}) => {
   const { t } = useAppTranslation();
   const { themeColors } = useColors();
+
+  useClearTransitionParam(navigation, route.params?.transition);
 
   // Get the source from route params, default to address_input
   const source = route.params?.source || getDefaultQRCodeSource();

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,10 +1,13 @@
 import { NavigatorScreenParams } from "@react-navigation/native";
+import { NativeStackNavigationOptions } from "@react-navigation/native-stack";
 import {
   BiometricsSource,
   NETWORKS,
   QRCodeSource,
   SWAP_SELECTION_TYPES,
 } from "config/constants";
+
+export type ScreenTransition = NativeStackNavigationOptions["animation"];
 
 /**
  * ROUTE NAMING CONVENTIONS FOR ANALYTICS
@@ -142,9 +145,11 @@ export type RootStackParamList = {
   [ROOT_NAVIGATOR_ROUTES.SETTINGS_STACK]: undefined;
   [ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN]: {
     showNavigationAsCloseButton?: boolean;
+    transition?: ScreenTransition;
   };
   [ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN]: {
     source?: QRCodeSource;
+    transition?: ScreenTransition;
   };
   [ROOT_NAVIGATOR_ROUTES.CONNECTED_APPS_SCREEN]: undefined;
   [ROOT_NAVIGATOR_ROUTES.BUY_XLM_STACK]: NavigatorScreenParams<AddFundsStackParamList>;

--- a/src/helpers/navigationOptions.tsx
+++ b/src/helpers/navigationOptions.tsx
@@ -59,3 +59,19 @@ export const getScreenOptionsNoHeader = (): NativeStackNavigationOptions => ({
   headerShown: false,
   ...getStackBottomNavigateOptions(),
 });
+
+/**
+ * Wrap navigation options so a route can override the animation by passing
+ * `transition` in its params. Used for ad-hoc transition overrides (e.g. the
+ * fade between `ScanQRCodeScreen` and `AccountQRCodeScreen`) without changing
+ * the defaults for other entry points into the same screen.
+ */
+export const withTransitionOverride = (
+  options: NativeStackNavigationOptions,
+  route: {
+    params?: { transition?: NativeStackNavigationOptions["animation"] };
+  },
+): NativeStackNavigationOptions => {
+  const transition = route.params?.transition;
+  return transition ? { ...options, animation: transition } : options;
+};

--- a/src/hooks/useClearTransitionParam.ts
+++ b/src/hooks/useClearTransitionParam.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+/**
+ * Clears the `transition` route param once after a screen mounts. Used by
+ * routes that accept a `transition` override so the override only drives the
+ * entry animation — subsequent pops (e.g. tapping the close button) then use
+ * the screen's default animation from `getScreenBottomNavigateOptions` /
+ * `getScreenOptionsNoHeader`.
+ */
+export const useClearTransitionParam = (
+  navigation: {
+    setParams: (params: { transition?: undefined }) => void;
+  },
+  transition: string | undefined,
+) => {
+  useEffect(() => {
+    if (transition) {
+      navigation.setParams({ transition: undefined });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};

--- a/src/hooks/useClearTransitionParam.ts
+++ b/src/hooks/useClearTransitionParam.ts
@@ -1,22 +1,30 @@
 import { useEffect } from "react";
 
 /**
- * Clears the `transition` route param once after a screen mounts. Used by
- * routes that accept a `transition` override so the override only drives the
- * entry animation — subsequent pops (e.g. tapping the close button) then use
- * the screen's default animation from `getScreenBottomNavigateOptions` /
- * `getScreenOptionsNoHeader`.
+ * Clears the `transition` route param after the screen's entry transition
+ * completes. Used by routes that accept a `transition` override so the
+ * override only drives the entry animation — subsequent pops (e.g. tapping
+ * the close button) then use the screen's default animation from
+ * `getScreenBottomNavigateOptions` / `getScreenOptionsNoHeader`.
+ *
+ * Waits for `transitionEnd` rather than clearing on mount so native-stack
+ * does not re-resolve options mid-transition and cancel the in-flight entry
+ * animation.
  */
 export const useClearTransitionParam = (
   navigation: {
     setParams: (params: { transition?: undefined }) => void;
+    addListener: (event: "transitionEnd", callback: () => void) => () => void;
   },
   transition: string | undefined,
 ) => {
   useEffect(() => {
-    if (transition) {
+    if (!transition) return undefined;
+    const unsubscribe = navigation.addListener("transitionEnd", () => {
       navigation.setParams({ transition: undefined });
-    }
+      unsubscribe();
+    });
+    return unsubscribe;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/src/hooks/useWalletConnectQrCodeScanner.tsx
+++ b/src/hooks/useWalletConnectQrCodeScanner.tsx
@@ -138,7 +138,8 @@ export const useWalletConnectQrCodeScanner = (): QRCodeScreenReturn => {
 
   // Handle header right button press (for wallet connect)
   const handleHeaderRight = useCallback(() => {
-    navigation.navigate(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN, {
+    // TODO: add comment to link with navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN) on AccountQRCodeScreen
+    navigation.replace(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN, {
       showNavigationAsCloseButton: true,
     });
   }, [navigation]);

--- a/src/hooks/useWalletConnectQrCodeScanner.tsx
+++ b/src/hooks/useWalletConnectQrCodeScanner.tsx
@@ -141,6 +141,7 @@ export const useWalletConnectQrCodeScanner = (): QRCodeScreenReturn => {
     // TODO: add comment to link with navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN) on AccountQRCodeScreen
     navigation.replace(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN, {
       showNavigationAsCloseButton: true,
+      transition: "fade",
     });
   }, [navigation]);
 

--- a/src/hooks/useWalletConnectQrCodeScanner.tsx
+++ b/src/hooks/useWalletConnectQrCodeScanner.tsx
@@ -138,7 +138,8 @@ export const useWalletConnectQrCodeScanner = (): QRCodeScreenReturn => {
 
   // Handle header right button press (for wallet connect)
   const handleHeaderRight = useCallback(() => {
-    // TODO: add comment to link with navigation.replace(ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN) on AccountQRCodeScreen
+    // Paired with the replace in AccountQRCodeScreen.handleWalletConnectNavigation,
+    // which fades from AccountQRCodeScreen back to this screen.
     navigation.replace(ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN, {
       showNavigationAsCloseButton: true,
       transition: "fade",

--- a/src/navigators/RootNavigator.tsx
+++ b/src/navigators/RootNavigator.tsx
@@ -37,6 +37,7 @@ import {
   getStackBottomNavigateOptions,
   getScreenOptionsNoHeader,
   getScreenBottomNavigateOptions,
+  withTransitionOverride,
 } from "helpers/navigationOptions";
 import { triggerFaceIdOnboarding } from "helpers/postOnboardingBiometrics";
 import { useAnalyticsPermissions } from "hooks/useAnalyticsPermissions";
@@ -231,14 +232,19 @@ export const RootNavigator = () => {
           <RootStack.Screen
             name={ROOT_NAVIGATOR_ROUTES.ACCOUNT_QR_CODE_SCREEN}
             component={AccountQRCodeScreen}
-            options={getScreenBottomNavigateOptions(
-              t("accountQRCodeScreen.title"),
-            )}
+            options={({ route }) =>
+              withTransitionOverride(
+                getScreenBottomNavigateOptions(t("accountQRCodeScreen.title")),
+                route,
+              )
+            }
           />
           <RootStack.Screen
             name={ROOT_NAVIGATOR_ROUTES.SCAN_QR_CODE_SCREEN}
             component={ScanQRCodeScreen}
-            options={getScreenOptionsNoHeader()}
+            options={({ route }) =>
+              withTransitionOverride(getScreenOptionsNoHeader(), route)
+            }
           />
           <RootStack.Screen
             name={ROOT_NAVIGATOR_ROUTES.CONNECTED_APPS_SCREEN}


### PR DESCRIPTION
## Summary

Closes #829.

- Cross-fade the navigation transition between `ScanQRCodeScreen` and `AccountQRCodeScreen` when the user toggles via the right-header button. Every other entry point (Home, Send search contacts, Add Funds) keeps the existing `slide_from_bottom` animation.
- Added a tiny `withTransitionOverride` navigation helper + `ScreenTransition` route-param type so any screen can opt a specific transition in via `navigation.replace(route, { transition: "fade" })` without changing its defaults for other callers.
- After the fade entry completes, a `useClearTransitionParam` hook drops the `transition` param so the subsequent pop (e.g. tapping the close button) uses the screen's default slide-to-bottom animation rather than fading back out.

## Video

https://github.com/user-attachments/assets/b5000bca-d15e-4436-97ff-dd2468ba35cf

## Test plan

- [x] Home → `ScanQRCodeScreen`: slides up from bottom (unchanged)
- [x] `ScanQRCodeScreen` → `AccountQRCodeScreen` via right header: cross-fades
- [x] `AccountQRCodeScreen` → `ScanQRCodeScreen` via right header: cross-fades
- [x] Either QR screen → tap close (`X`): slides down to Home (not a fade-out)
- [x] `SendSearchContacts` → `ScanQRCodeScreen`: slides up from bottom (unchanged)
- [x] `AddFundsScreen` → `AccountQRCodeScreen`: slides up from bottom (unchanged)
- [x] Unit tests cover `withTransitionOverride` and `useClearTransitionParam` (`yarn test`)

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)