### PR TITLE
Fix blank system bar strips on Android 15+ edge-to-edge

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,6 +2,14 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <!--
+          Paint the window backdrop with the app's dark chrome color. Under Android 15+
+          enforced edge-to-edge, the system bars are transparent and show this window
+          background. Without this, Theme.AppCompat.DayNight resolves to the system's
+          light background on a light-mode phone, leaving white strips at the top and
+          bottom of the screen.
+        -->
+        <item name="android:windowBackground">@color/bootsplash_background</item>
     </style>
 
     <style name="BootTheme" parent="Theme.BootSplash">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -53,7 +53,11 @@ export const App = (): React.JSX.Element => {
 
   return (
     <KeyboardProvider>
-      <GestureHandlerRootView>
+      {/* Paints the area behind transparent system bars under Android 15+
+          enforced edge-to-edge so the status/nav strips match app chrome. */}
+      <GestureHandlerRootView
+        style={{ flex: 1, backgroundColor: THEME.colors.background.default }}
+      >
         <SafeAreaProvider>
           <ToastProvider>
             <BottomSheetModalProvider>


### PR DESCRIPTION
### What

On devices running **Android 15+ (API 35+)**, the status bar and bottom navigation bar strips rendered **pure white** at the top and bottom of every screen, visibly breaking the app's dark chrome.

Two-part fix so the strips show the app's dark chrome color (`#161616`) in every edge-to-edge scenario:

1. **[android/app/src/main/res/values/styles.xml](android/app/src/main/res/values/styles.xml)** — set `android:windowBackground` on `AppTheme` to the `@color/bootsplash_background` resource (already `#161616`). This is the Android window's backdrop and is visible through the transparent system bars regardless of the RN view layout.
2. **[src/components/App.tsx](src/components/App.tsx)** — paint `GestureHandlerRootView` with `THEME.colors.background.default` as a safety net at the RN layer, in case any view-tree configuration leaves a gap where the window background would otherwise show.

### Why

Starting with Android 15 (API 35), the OS **enforces** edge-to-edge for apps targeting API 35+: `WindowCompat.setDecorFitsSystemWindows(true)` is ignored, system bars are forced transparent, and the app is responsible for painting the area behind them. Our `AppTheme` inherits from `Theme.AppCompat.DayNight.NoActionBar`, which resolves to the system's **light** window background on a light-mode phone — producing the white strips. `Appearance.setColorScheme("dark")` in JS only affects RN components, not the Android window theme, so it couldn't fix this on its own.

Setting `android:windowBackground` on the theme is the authoritative, native-level fix — it pins the backdrop color regardless of OS version or system dark/light mode. The RN-level `GestureHandlerRootView` backgroundColor adds a second layer of defense in case a future view-tree change leaves a gap.

iOS is intentionally untouched — `styles.xml` is Android-only, and iOS's existing status-bar-overlay behavior already relies on the content underneath to paint correctly (which `BaseLayout` handles).

### Before / After

#### Before

<img width="350" alt="white-edges" src="https://github.com/user-attachments/assets/8b02a5f6-9775-4abb-87a6-465ce7d165ce" />


#### After

<img width="350" alt="Screenshot 2026-04-22 at 17 32 10" src="https://github.com/user-attachments/assets/faf8757e-f233-49a7-84d1-1b3ee0cd061e" />

<img width="350" alt="Screenshot 2026-04-22 at 17 20 07" src="https://github.com/user-attachments/assets/09a06529-19b2-40e3-a154-ef9a9db8f970" />


### Known limitations

None. The change applies to all Android versions (harmless on pre-15 where `StatusBar backgroundColor` still paints on top) and has no effect on iOS.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [x] I have tried to break these changes while extensively testing them.

#### Release

- [x] This is not a breaking change.
- [x] This PR adds JSDocs to new functionalities.