### PR TITLE
Harden collectible metadata fetch with bounded reads

### DIFF
--- a/__tests__/helpers/collectibles.test.ts
+++ b/__tests__/helpers/collectibles.test.ts
@@ -13,6 +13,7 @@ import {
   saveHiddenCollectiblesStorage,
   transformBackendCollections,
 } from "helpers/collectibles";
+import { fetchMetadataJson } from "helpers/fetchMetadataJson";
 import { dataStorage } from "services/storage/storageFactory";
 
 // Mock dependencies
@@ -44,8 +45,11 @@ jest.mock("i18next", () => ({
   }),
 }));
 
-// Mock fetch globally
-global.fetch = jest.fn();
+// Mock metadata fetch helper so these tests stay focused on
+// transformation behavior rather than network details.
+jest.mock("helpers/fetchMetadataJson", () => ({
+  fetchMetadataJson: jest.fn(),
+}));
 
 describe("collectibles helpers", () => {
   beforeEach(() => {
@@ -491,10 +495,7 @@ describe("collectibles helpers", () => {
     };
 
     beforeEach(() => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: jest.fn().mockResolvedValue(mockMetadata),
-      });
+      (fetchMetadataJson as jest.Mock).mockResolvedValue(mockMetadata);
     });
 
     it("transforms backend collections to frontend format", async () => {
@@ -540,7 +541,9 @@ describe("collectibles helpers", () => {
     });
 
     it("handles metadata fetch failure with fallback", async () => {
-      (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+      (fetchMetadataJson as jest.Mock).mockRejectedValue(
+        new Error("Network error"),
+      );
 
       const result = await transformBackendCollections(mockBackendCollections);
 
@@ -572,10 +575,7 @@ describe("collectibles helpers", () => {
         ],
       };
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: jest.fn().mockResolvedValue(incompleteMetadata),
-      });
+      (fetchMetadataJson as jest.Mock).mockResolvedValue(incompleteMetadata);
 
       const result = await transformBackendCollections(mockBackendCollections);
 
@@ -596,10 +596,9 @@ describe("collectibles helpers", () => {
     });
 
     it("handles HTTP error responses", async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: false,
-        statusText: "Not Found",
-      });
+      (fetchMetadataJson as jest.Mock).mockRejectedValue(
+        new Error("fetchMetadataJson: request failed with 404 Not Found"),
+      );
 
       const result = await transformBackendCollections(mockBackendCollections);
 

--- a/__tests__/helpers/fetchMetadataJson.test.ts
+++ b/__tests__/helpers/fetchMetadataJson.test.ts
@@ -1,0 +1,307 @@
+import {
+  fetchMetadataJson,
+  MAX_METADATA_BYTES,
+  METADATA_FETCH_TIMEOUT_MS,
+} from "helpers/fetchMetadataJson";
+
+type FakeReader = {
+  read: jest.Mock;
+  cancel: jest.Mock;
+};
+
+const makeReader = (chunks: Uint8Array[]): FakeReader => {
+  let i = 0;
+  return {
+    read: jest.fn().mockImplementation(() => {
+      if (i >= chunks.length) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+      const value = chunks[i];
+      i += 1;
+      return Promise.resolve({ done: false, value });
+    }),
+    cancel: jest.fn().mockResolvedValue(undefined),
+  };
+};
+
+const encode = (s: string): Uint8Array =>
+  new Uint8Array(Buffer.from(s, "utf-8"));
+
+const makeResponse = ({
+  ok = true,
+  status = 200,
+  statusText = "OK",
+  contentLength = null,
+  reader = null,
+  text = "",
+}: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  contentLength?: string | null;
+  reader?: FakeReader | null;
+  text?: string;
+} = {}): Response =>
+  ({
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-length" ? contentLength : null,
+    },
+    body: reader ? { getReader: () => reader } : undefined,
+    text: jest.fn().mockResolvedValue(text),
+  }) as unknown as Response;
+
+describe("fetchMetadataJson", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("URL validation", () => {
+    it("rejects empty strings", async () => {
+      await expect(fetchMetadataJson("")).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects null values", async () => {
+      await expect(
+        fetchMetadataJson(null as unknown as string),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects undefined values", async () => {
+      await expect(
+        fetchMetadataJson(undefined as unknown as string),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-string values", async () => {
+      await expect(
+        fetchMetadataJson(123 as unknown as string),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects http:// URLs", async () => {
+      await expect(
+        fetchMetadataJson("http://example.com/metadata.json"),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects file:// URLs", async () => {
+      await expect(fetchMetadataJson("file:///etc/passwd")).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects data: URIs", async () => {
+      await expect(
+        fetchMetadataJson("data:application/json,{}"),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects ftp:// URLs", async () => {
+      await expect(
+        fetchMetadataJson("ftp://example.com/metadata.json"),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects javascript: URLs", async () => {
+      // eslint-disable-next-line no-script-url
+      const scriptUrl = "javascript:alert(1)";
+      await expect(fetchMetadataJson(scriptUrl)).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("accepts https:// URLs", async () => {
+      const body = '{"name":"ok"}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "https://example.com/metadata.json",
+      );
+
+      expect(result).toEqual({ name: "ok" });
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://example.com/metadata.json",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  describe("response handling", () => {
+    it("throws when response.ok is false", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ ok: false, status: 404, statusText: "Not Found" }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/missing.json"),
+      ).rejects.toThrow(/404/);
+    });
+
+    it("parses valid JSON from streamed body", async () => {
+      const body = '{"name":"Test NFT","image":"https://example.com/img.png"}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{
+        name: string;
+        image: string;
+      }>("https://example.com/metadata.json");
+
+      expect(result).toEqual({
+        name: "Test NFT",
+        image: "https://example.com/img.png",
+      });
+    });
+
+    it("throws on invalid JSON", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode("not json")]) }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/bad.json"),
+      ).rejects.toThrow();
+    });
+
+    it("assembles JSON across multiple chunks", async () => {
+      const chunks = [encode('{"name":"Tes'), encode('t NFT","x":1}')];
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader(chunks) }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string; x: number }>(
+        "https://example.com/metadata.json",
+      );
+
+      expect(result).toEqual({ name: "Test NFT", x: 1 });
+    });
+  });
+
+  describe("size limits", () => {
+    it("rejects early when Content-Length exceeds MAX_METADATA_BYTES", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          contentLength: String(MAX_METADATA_BYTES + 1),
+          reader: makeReader([encode("{}")]),
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/huge.json"),
+      ).rejects.toThrow(/too large/i);
+    });
+
+    it("accepts when Content-Length equals MAX_METADATA_BYTES", async () => {
+      const body = "{}";
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          contentLength: String(MAX_METADATA_BYTES),
+          reader: makeReader([encode(body)]),
+        }),
+      );
+
+      const result = await fetchMetadataJson<object>(
+        "https://example.com/ok.json",
+      );
+      expect(result).toEqual({});
+    });
+
+    it("aborts streaming and rejects when body bytes exceed MAX_METADATA_BYTES", async () => {
+      // Simulate a server that omits Content-Length and streams more than the
+      // allowed bytes. The reader yields chunks whose total size exceeds the
+      // limit; the helper must cancel the reader and throw.
+      const bigChunk = new Uint8Array(MAX_METADATA_BYTES / 2);
+      bigChunk.fill(0x61); // 'a'
+      const chunks = [bigChunk, bigChunk, bigChunk]; // 1.5 * MAX
+      const reader = makeReader(chunks);
+      (global.fetch as jest.Mock).mockResolvedValue(makeResponse({ reader }));
+
+      await expect(
+        fetchMetadataJson("https://example.com/streaming-huge.json"),
+      ).rejects.toThrow(/too large/i);
+
+      expect(reader.cancel).toHaveBeenCalled();
+    });
+
+    it("falls back to response.text() when getReader is unavailable", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ text: '{"name":"Fallback"}' }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "https://example.com/metadata.json",
+      );
+      expect(result).toEqual({ name: "Fallback" });
+    });
+
+    it("rejects in fallback path when byte length exceeds MAX_METADATA_BYTES", async () => {
+      const huge = "a".repeat(MAX_METADATA_BYTES + 10);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ text: huge }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/huge-fallback.json"),
+      ).rejects.toThrow(/too large/i);
+    });
+  });
+
+  describe("timeout", () => {
+    it("aborts fetch after METADATA_FETCH_TIMEOUT_MS", async () => {
+      let capturedSignal: AbortSignal | undefined;
+      (global.fetch as jest.Mock).mockImplementation(
+        (_url: string, init: RequestInit) => {
+          capturedSignal = init.signal as AbortSignal;
+          return new Promise((_, reject) => {
+            const s = init.signal as AbortSignal;
+            if (s) {
+              s.addEventListener("abort", () => {
+                reject(
+                  Object.assign(new Error("aborted"), { name: "AbortError" }),
+                );
+              });
+            }
+          });
+        },
+      );
+
+      const promise = fetchMetadataJson("https://example.com/slow.json");
+
+      jest.advanceTimersByTime(METADATA_FETCH_TIMEOUT_MS);
+
+      await expect(promise).rejects.toThrow();
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it("does not abort when fetch resolves before the timeout", async () => {
+      const body = '{"ok":true}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{ ok: boolean }>(
+        "https://example.com/fast.json",
+      );
+
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/__tests__/helpers/fetchMetadataJson.test.ts
+++ b/__tests__/helpers/fetchMetadataJson.test.ts
@@ -214,6 +214,22 @@ describe("fetchMetadataJson", () => {
       expect(bodyCancel).toHaveBeenCalled();
     });
 
+    it("rejects when the final response.url cannot be parsed (fail closed)", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          url: "not a url",
+          reader: makeReader([encode('{"name":"x"}')]),
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/metadata.json"),
+      ).rejects.toThrow(/could not parse final response\.url/);
+      expect(bodyCancel).toHaveBeenCalled();
+    });
+
     it("accepts https→https redirects", async () => {
       (global.fetch as jest.Mock).mockResolvedValue(
         makeResponse({

--- a/__tests__/helpers/fetchMetadataJson.test.ts
+++ b/__tests__/helpers/fetchMetadataJson.test.ts
@@ -141,6 +141,26 @@ describe("fetchMetadataJson", () => {
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
     });
+
+    it("accepts mixed-case HTTPS:// URLs (scheme check is case-insensitive)", async () => {
+      const body = '{"name":"ok"}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "HTTPS://example.com/metadata.json",
+      );
+
+      expect(result).toEqual({ name: "ok" });
+    });
+
+    it("rejects malformed URLs", async () => {
+      await expect(fetchMetadataJson("not a url")).rejects.toThrow(
+        /not a valid URL/,
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe("response handling", () => {

--- a/__tests__/helpers/fetchMetadataJson.test.ts
+++ b/__tests__/helpers/fetchMetadataJson.test.ts
@@ -31,26 +31,33 @@ const makeResponse = ({
   ok = true,
   status = 200,
   statusText = "OK",
+  url = "https://example.com/metadata.json",
   contentLength = null,
   reader = null,
   text = "",
+  bodyCancel = jest.fn().mockResolvedValue(undefined),
 }: {
   ok?: boolean;
   status?: number;
   statusText?: string;
+  url?: string;
   contentLength?: string | null;
   reader?: FakeReader | null;
   text?: string;
+  bodyCancel?: jest.Mock;
 } = {}): Response =>
   ({
     ok,
     status,
     statusText,
+    url,
     headers: {
       get: (name: string) =>
         name.toLowerCase() === "content-length" ? contentLength : null,
     },
-    body: reader ? { getReader: () => reader } : undefined,
+    body: reader
+      ? { getReader: () => reader, cancel: bodyCancel }
+      : { cancel: bodyCancel },
     text: jest.fn().mockResolvedValue(text),
   }) as unknown as Response;
 
@@ -174,6 +181,53 @@ describe("fetchMetadataJson", () => {
       ).rejects.toThrow(/404/);
     });
 
+    it("cancels the response body on a non-OK status", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/err.json"),
+      ).rejects.toThrow();
+      expect(bodyCancel).toHaveBeenCalled();
+    });
+
+    it("rejects when the final response.url has a non-https scheme (redirect bypass)", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          url: "http://evil.example.com/metadata.json",
+          reader: makeReader([encode('{"name":"x"}')]),
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/metadata.json"),
+      ).rejects.toThrow(/non-https/);
+      expect(bodyCancel).toHaveBeenCalled();
+    });
+
+    it("accepts https→https redirects", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          url: "https://cdn.example.com/metadata.json",
+          reader: makeReader([encode('{"name":"ok"}')]),
+        }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "https://example.com/metadata.json",
+      );
+      expect(result).toEqual({ name: "ok" });
+    });
+
     it("parses valid JSON from streamed body", async () => {
       const body = '{"name":"Test NFT","image":"https://example.com/img.png"}';
       (global.fetch as jest.Mock).mockResolvedValue(
@@ -227,6 +281,22 @@ describe("fetchMetadataJson", () => {
       await expect(
         fetchMetadataJson("https://example.com/huge.json"),
       ).rejects.toThrow(/too large/i);
+    });
+
+    it("cancels the response body when Content-Length pre-check rejects", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          contentLength: String(MAX_METADATA_BYTES + 1),
+          reader: makeReader([encode("{}")]),
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/huge.json"),
+      ).rejects.toThrow();
+      expect(bodyCancel).toHaveBeenCalled();
     });
 
     it("accepts when Content-Length equals MAX_METADATA_BYTES", async () => {

--- a/src/helpers/collectibles.ts
+++ b/src/helpers/collectibles.ts
@@ -6,6 +6,7 @@ import {
   CollectibleMetadata,
 } from "config/types";
 import type { Collection, Collectible } from "ducks/collectibles";
+import { fetchMetadataJson } from "helpers/fetchMetadataJson";
 import { t } from "i18next";
 import { BackendCollection } from "services/backend";
 import { dataStorage } from "services/storage/storageFactory";
@@ -243,15 +244,11 @@ export const transformBackendCollections = async (
         const collectibles: Collectible[] = await Promise.all(
           collection.collectibles.map(async (collectible) => {
             try {
-              // Fetch metadata from token_uri
-              const response = await fetch(collectible.token_uri);
-              if (!response.ok) {
-                throw new Error(
-                  `Failed to fetch metadata: ${response.statusText}`,
-                );
-              }
-
-              const metadata = (await response.json()) as CollectibleMetadata;
+              // Fetch metadata from token_uri using fetchMetadataJson for
+              // bounded, resilient reads (https-only, timeout, size cap).
+              const metadata = await fetchMetadataJson<CollectibleMetadata>(
+                collectible.token_uri,
+              );
 
               // Check if collectible is hidden
               const isHidden = isCollectibleHidden(

--- a/src/helpers/fetchMetadataJson.ts
+++ b/src/helpers/fetchMetadataJson.ts
@@ -24,6 +24,8 @@ export const METADATA_FETCH_TIMEOUT_MS = 5000;
  *    (including cleartext `http`) are rejected before any network call.
  * 2. After the fetch resolves the final `response.url` is re-checked so a
  *    server that 3xx-redirects to a non-https scheme cannot bypass step 1.
+ *    If `response.url` is present but cannot be parsed we fail closed — we
+ *    can't confirm the scheme, so we can't confirm we weren't redirected.
  * 3. A 5-second AbortController-backed timeout bounds how long we wait.
  * 4. `Content-Length` is pre-checked — if the server advertises a body larger
  *    than MAX_METADATA_BYTES the request fails fast.
@@ -72,7 +74,9 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
 
     // Validate the *final* URL (after any redirects) is still https. The
     // input-URL check alone can be bypassed by a server that 3xx-redirects
-    // to a non-https scheme, which fetch follows by default.
+    // to a non-https scheme, which fetch follows by default. Fail closed if
+    // we can't parse response.url — we can't confirm the scheme, so we
+    // can't confirm we weren't redirected away.
     if (response.url) {
       let finalProtocol: string | null = null;
       try {
@@ -80,10 +84,12 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
       } catch {
         finalProtocol = null;
       }
-      if (finalProtocol !== null && finalProtocol !== "https:") {
-        await response.body?.cancel?.();
+      if (finalProtocol !== "https:") {
+        await response.body?.cancel?.().catch(() => {});
         throw new Error(
-          "fetchMetadataJson: redirect landed on a non-https scheme",
+          finalProtocol === null
+            ? "fetchMetadataJson: could not parse final response.url"
+            : "fetchMetadataJson: redirect landed on a non-https scheme",
         );
       }
     }

--- a/src/helpers/fetchMetadataJson.ts
+++ b/src/helpers/fetchMetadataJson.ts
@@ -22,20 +22,26 @@ export const METADATA_FETCH_TIMEOUT_MS = 5000;
  * 1. URL scheme is restricted to `https:` (parsed via `new URL`, so the
  *    check is case-insensitive and rejects malformed URLs). Other schemes
  *    (including cleartext `http`) are rejected before any network call.
- * 2. A 5-second AbortController-backed timeout bounds how long we wait.
- * 3. `Content-Length` is pre-checked — if the server advertises a body larger
+ * 2. After the fetch resolves the final `response.url` is re-checked so a
+ *    server that 3xx-redirects to a non-https scheme cannot bypass step 1.
+ * 3. A 5-second AbortController-backed timeout bounds how long we wait.
+ * 4. `Content-Length` is pre-checked — if the server advertises a body larger
  *    than MAX_METADATA_BYTES the request fails fast.
- * 4. The body is read via `response.body.getReader()` with a byte counter;
+ * 5. The body is read via `response.body.getReader()` with a byte counter;
  *    if accumulated bytes exceed MAX_METADATA_BYTES the reader is cancelled
  *    and the call fails. This keeps memory bounded even when
  *    `Content-Length` is absent or inaccurate.
- * 5. If `response.body.getReader` is unavailable in the current runtime, the
+ * 6. If `response.body.getReader` is unavailable in the current runtime, the
  *    helper falls back to `response.text()` followed by a byte-length check.
  *    In that fallback the body is fully buffered before the size check runs,
  *    so the only up-front bounds are the Content-Length pre-check (when the
  *    server advertises it) and the AbortController timeout; the post-download
  *    check is a secondary gate. React Native 0.81+ exposes `getReader`, so in
  *    practice the fallback path is rare.
+ *
+ * On any early-exit failure (redirect to non-https, non-OK status, oversized
+ * Content-Length) the response body is cancelled before throwing so streaming
+ * implementations don't continue downloading into a discarded response.
  */
 export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
   if (!url || typeof url !== "string") {
@@ -64,7 +70,26 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
   try {
     const response = await fetch(url, { signal: controller.signal });
 
+    // Validate the *final* URL (after any redirects) is still https. The
+    // input-URL check alone can be bypassed by a server that 3xx-redirects
+    // to a non-https scheme, which fetch follows by default.
+    if (response.url) {
+      let finalProtocol: string | null = null;
+      try {
+        finalProtocol = new URL(response.url).protocol;
+      } catch {
+        finalProtocol = null;
+      }
+      if (finalProtocol !== null && finalProtocol !== "https:") {
+        await response.body?.cancel?.();
+        throw new Error(
+          "fetchMetadataJson: redirect landed on a non-https scheme",
+        );
+      }
+    }
+
     if (!response.ok) {
+      await response.body?.cancel?.();
       throw new Error(
         `fetchMetadataJson: request failed with ${response.status} ${response.statusText}`,
       );
@@ -77,6 +102,7 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
         Number.isFinite(contentLength) &&
         contentLength > MAX_METADATA_BYTES
       ) {
+        await response.body?.cancel?.();
         throw new Error(
           `fetchMetadataJson: response too large (${contentLength} bytes, max ${MAX_METADATA_BYTES})`,
         );

--- a/src/helpers/fetchMetadataJson.ts
+++ b/src/helpers/fetchMetadataJson.ts
@@ -1,0 +1,122 @@
+import { Buffer } from "buffer";
+
+/**
+ * Maximum size (in bytes) of a metadata response body we read. Real NFT
+ * metadata JSON is typically well under 10 KB; 1 MB provides generous
+ * headroom while keeping memory usage bounded.
+ */
+export const MAX_METADATA_BYTES = 1024 * 1024;
+
+/**
+ * Hard timeout for a metadata fetch. If the request does not complete within
+ * this window the in-flight fetch is aborted via AbortController so slow or
+ * unreachable hosts do not leave work hanging.
+ */
+export const METADATA_FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Fetches and parses a JSON metadata document from a remote URL with
+ * sensible defaults for bounded, resilient reads.
+ *
+ * Behavior:
+ * 1. URL scheme is restricted to `https://`. Other schemes (including
+ *    cleartext `http`) are rejected before any network call.
+ * 2. A 5-second AbortController-backed timeout bounds how long we wait.
+ * 3. `Content-Length` is pre-checked — if the server advertises a body larger
+ *    than MAX_METADATA_BYTES the request fails fast.
+ * 4. The body is read via `response.body.getReader()` with a byte counter;
+ *    if accumulated bytes exceed MAX_METADATA_BYTES the reader is cancelled
+ *    and the call fails. This keeps memory bounded even when
+ *    `Content-Length` is absent or inaccurate.
+ * 5. If `response.body.getReader` is unavailable in the current runtime, the
+ *    helper falls back to `response.text()` with a post-download byte-length
+ *    check. The fallback remains bounded by the Content-Length pre-check and
+ *    the AbortController timeout.
+ */
+export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
+  if (!url || typeof url !== "string") {
+    throw new Error("fetchMetadataJson: url must be a non-empty string");
+  }
+
+  if (!url.startsWith("https://")) {
+    throw new Error(
+      "fetchMetadataJson: url scheme must be https — got a different scheme",
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    METADATA_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new Error(
+        `fetchMetadataJson: request failed with ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const contentLengthHeader = response.headers.get("content-length");
+    if (contentLengthHeader !== null) {
+      const contentLength = parseInt(contentLengthHeader, 10);
+      if (
+        Number.isFinite(contentLength) &&
+        contentLength > MAX_METADATA_BYTES
+      ) {
+        throw new Error(
+          `fetchMetadataJson: response too large (${contentLength} bytes, max ${MAX_METADATA_BYTES})`,
+        );
+      }
+    }
+
+    const reader = response.body?.getReader?.() as
+      | ReadableStreamDefaultReader<Uint8Array>
+      | undefined;
+    let text: string;
+
+    if (reader) {
+      const chunks: Uint8Array[] = [];
+      let totalBytes = 0;
+      let done = false;
+      // Sequential reads are inherent to streaming — we cannot parallelize.
+      /* eslint-disable no-await-in-loop */
+      while (!done) {
+        const chunk = await reader.read();
+        done = chunk.done;
+        if (chunk.value) {
+          totalBytes += chunk.value.byteLength;
+          if (totalBytes > MAX_METADATA_BYTES) {
+            await reader.cancel();
+            throw new Error(
+              `fetchMetadataJson: response too large (>${MAX_METADATA_BYTES} bytes)`,
+            );
+          }
+          chunks.push(chunk.value);
+        }
+      }
+      /* eslint-enable no-await-in-loop */
+      const merged = new Uint8Array(totalBytes);
+      let offset = 0;
+      chunks.forEach((chunk) => {
+        merged.set(chunk, offset);
+        offset += chunk.byteLength;
+      });
+      text = Buffer.from(merged).toString("utf-8");
+    } else {
+      text = await response.text();
+      const byteLength = Buffer.byteLength(text, "utf-8");
+      if (byteLength > MAX_METADATA_BYTES) {
+        throw new Error(
+          `fetchMetadataJson: response too large (${byteLength} bytes, max ${MAX_METADATA_BYTES})`,
+        );
+      }
+    }
+
+    return JSON.parse(text) as T;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/src/helpers/fetchMetadataJson.ts
+++ b/src/helpers/fetchMetadataJson.ts
@@ -19,8 +19,9 @@ export const METADATA_FETCH_TIMEOUT_MS = 5000;
  * sensible defaults for bounded, resilient reads.
  *
  * Behavior:
- * 1. URL scheme is restricted to `https://`. Other schemes (including
- *    cleartext `http`) are rejected before any network call.
+ * 1. URL scheme is restricted to `https:` (parsed via `new URL`, so the
+ *    check is case-insensitive and rejects malformed URLs). Other schemes
+ *    (including cleartext `http`) are rejected before any network call.
  * 2. A 5-second AbortController-backed timeout bounds how long we wait.
  * 3. `Content-Length` is pre-checked — if the server advertises a body larger
  *    than MAX_METADATA_BYTES the request fails fast.
@@ -29,16 +30,26 @@ export const METADATA_FETCH_TIMEOUT_MS = 5000;
  *    and the call fails. This keeps memory bounded even when
  *    `Content-Length` is absent or inaccurate.
  * 5. If `response.body.getReader` is unavailable in the current runtime, the
- *    helper falls back to `response.text()` with a post-download byte-length
- *    check. The fallback remains bounded by the Content-Length pre-check and
- *    the AbortController timeout.
+ *    helper falls back to `response.text()` followed by a byte-length check.
+ *    In that fallback the body is fully buffered before the size check runs,
+ *    so the only up-front bounds are the Content-Length pre-check (when the
+ *    server advertises it) and the AbortController timeout; the post-download
+ *    check is a secondary gate. React Native 0.81+ exposes `getReader`, so in
+ *    practice the fallback path is rare.
  */
 export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
   if (!url || typeof url !== "string") {
     throw new Error("fetchMetadataJson: url must be a non-empty string");
   }
 
-  if (!url.startsWith("https://")) {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error("fetchMetadataJson: url is not a valid URL");
+  }
+
+  if (parsedUrl.protocol !== "https:") {
     throw new Error(
       "fetchMetadataJson: url scheme must be https — got a different scheme",
     );


### PR DESCRIPTION
### What

Harden the collectible metadata fetch path with bounded, resilient reads.

- New helper `src/helpers/fetchMetadataJson.ts` that enforces three defaults when reading external JSON metadata:
  - `https://` only (rejects `http://`, `file://`, `data:`, `ftp://`, `javascript:`, etc. before any network call)
  - 5-second `AbortController`-backed timeout
  - 1 MB response-size cap via a `Content-Length` pre-check + a streaming body reader that cancels on overflow, with a `response.text()` + post-download byte-length fallback when `getReader` is unavailable
- `transformBackendCollections` in `src/helpers/collectibles.ts` now calls the helper instead of a bare `fetch(token_uri)` + `response.json()` pair. The existing per-collectible try/catch keeps producing a graceful placeholder record when a fetch fails.
- 21 new unit tests in `__tests__/helpers/fetchMetadataJson.test.ts` cover URL validation, response handling, both size-limit paths (Content-Length and streaming), the fallback path, and timeout behavior. Existing `transformBackendCollections` tests updated to mock the new helper rather than `global.fetch`.

### Why

The previous metadata fetch had no URL-scheme validation, no timeout, and no size limit. Collectible `token_uri` values come from on-chain data and we have no control over the remote host or the response size, so the fetch should be bounded defensively — similar to the pattern already used in `src/helpers/validateIconUrl.ts`. These changes give the metadata path the same kind of bounded, resilient behavior the rest of the codebase expects, and degrade gracefully to a placeholder collectible when a remote host is slow, unreachable, or returns something oversized.

### Known limitations

N/A

### Videos

https://github.com/user-attachments/assets/b1f3c499-7d67-480d-bfb0-9a000a51f672

https://github.com/user-attachments/assets/0e570fef-90a1-497f-bef0-ab721dec9f14

#### When metadata fetching fails

https://github.com/user-attachments/assets/83ee465a-4b17-41b5-8b45-31f55e715bfb

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)