### PR TITLE
Fix Android crash on activity restoration

### DIFF
--- a/android/app/src/main/java/com/freightermobile/MainActivity.kt
+++ b/android/app/src/main/java/com/freightermobile/MainActivity.kt
@@ -25,10 +25,13 @@ class MainActivity : ReactActivity() {
       DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
 
   /**
-   * react-native-screens package requires this override to properly work on Android devices.
+   * Pass null to super.onCreate to prevent Android from restoring react-native-screens
+   * fragments — they intentionally throw on restoration (process death, config change in
+   * background) and crash the app on relaunch.
+   * https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067
    */
   override fun onCreate(savedInstanceState: Bundle?) {
     RNBootSplash.init(this, R.style.BootTheme)
-    super.onCreate(savedInstanceState)
+    super.onCreate(null)
   }
 }


### PR DESCRIPTION
### What

In `MainActivity.onCreate`, pass `null` to `super.onCreate(...)` instead of forwarding `savedInstanceState`. This prevents Android from attempting to restore `react-native-screens` fragments from the saved state bundle.

Closes https://github.com/orgs/stellar/projects/58/views/2?pane=issue&itemId=179721892

### Why

#### The crash

Play Console > Crashes and ANRs has been reporting a top crash for months:

> `org.stellar.freighterwallet.MainActivity.onCreate` — `androidx.fragment.app.Fragment$InstantiationException`

Baseline (1.17.26): **406 events / 118 users**, ~20% of Android crashes. The label is misleading though — Android wraps the real exception. Sentry has the unwrapped trace ([FREIGHTER-MOBILE-4G](https://stellarorg.sentry.io/issues/FREIGHTER-MOBILE-4G)):

> `IllegalStateException: ScreenStack fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067 to properly configure your main activity.`

`react-native-screens` deliberately throws from `ScreenStackFragment`'s no-arg constructor (see [`ScreenStackFragment.kt:87-91`](https://github.com/software-mansion/react-native-screens/blob/main/android/src/main/java/com/swmansion/rnscreens/ScreenStackFragment.kt#L87-L91)). When Android tears down `MainActivity` (process death, OS reclaim, config change while backgrounded), it serializes the live screen fragments into `savedInstanceState`. On relaunch, `FragmentManager.restoreSaveStateInternal` calls the no-arg constructor → boom, every time. JS-side React Navigation state is what should drive screen reconstruction, not Android's fragment manager.

The fix here is the canonical workaround documented by the `react-native-screens` maintainer in the linked issue: pass `null` to `super.onCreate` so Android never tries to restore the fragments.

#### Why this was nearly invisible in Sentry

Play Console: 406 events / 118 users.
Sentry FREIGHTER-MOBILE-4G: 40 events / 8 users.

Sentry undercounts this category by ~10× because of how `@sentry/react-native` initializes today. We only call `Sentry.init()` from JS (in `src/config/sentryConfig.ts`); there is no native `SentryAndroid.init` in `MainApplication.onCreate`. Per Sentry's docs:

> "the SDK has a current limitation of not capturing native crashes that occur prior to the `init` method being called on the JS layer"

This crash *is* `MainActivity.onCreate` — strictly before the JS bridge boots, before the bundle evaluates, before `Sentry.init()` runs. So the native SDK isn't listening yet. Play Console captures it from the OS; Sentry doesn't.

### Known limitations

- Hard to reproduce locally without forcing process death. Real validation will come from Play Console crash rate on the release after this merges.
- The Sentry issue (FREIGHTER-MOBILE-4G) is intentionally **not** auto-resolved on merge — we'll resolve manually after confirming the Play Console crash rate drops on the next release. A scheduled remote agent will DM the author on May 11 with the verification checklist.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.