### PR TITLE
Filter Sentry noise

### DIFF
--- a/__tests__/components/screens/SwapScreen/useSwapTransaction.test.ts
+++ b/__tests__/components/screens/SwapScreen/useSwapTransaction.test.ts
@@ -1,0 +1,170 @@
+/* eslint-disable @fnando/consistent-import/consistent-import */
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useSwapTransaction } from "components/screens/SwapScreen/hooks/useSwapTransaction";
+import { NETWORKS } from "config/constants";
+import type { ActiveAccount } from "ducks/auth";
+
+const mockSignTransaction = jest.fn();
+const mockSubmitTransaction = jest.fn();
+const mockBuildSwapTransaction = jest.fn().mockResolvedValue("xdr");
+const mockShowToast = jest.fn();
+const mockTrackTransactionError = jest.fn();
+const mockTrackSwapSuccess = jest.fn();
+const mockScanTransaction = jest.fn().mockResolvedValue({});
+
+jest.mock("ducks/transactionBuilder", () => ({
+  useTransactionBuilderStore: Object.assign(
+    () => ({
+      buildSwapTransaction: mockBuildSwapTransaction,
+      signTransaction: mockSignTransaction,
+      submitTransaction: mockSubmitTransaction,
+    }),
+    {
+      getState: () => ({ error: "Submit error from store" }),
+    },
+  ),
+}));
+
+jest.mock("ducks/swapSettings", () => ({
+  useSwapSettingsStore: Object.assign(() => ({}), {
+    getState: () => ({
+      swapFee: "100",
+      swapTimeout: "30",
+      swapSlippage: "0.5",
+    }),
+  }),
+}));
+
+jest.mock("ducks/history", () => ({
+  useHistoryStore: () => ({ fetchAccountHistory: jest.fn() }),
+}));
+
+jest.mock("hooks/blockaid/useBlockaidTransaction", () => ({
+  useBlockaidTransaction: () => ({ scanTransaction: mockScanTransaction }),
+}));
+
+jest.mock("hooks/useAppTranslation", () => ({
+  __esModule: true,
+  default: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("providers/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock("services/analytics", () => ({
+  analytics: {
+    trackTransactionError: jest.fn((...args) =>
+      mockTrackTransactionError(...args),
+    ),
+    trackSwapSuccess: jest.fn((...args) => mockTrackSwapSuccess(...args)),
+  },
+}));
+
+const mockNavigation = {
+  reset: jest.fn(),
+} as unknown as Parameters<typeof useSwapTransaction>[0]["navigation"];
+
+const baseParams: Parameters<typeof useSwapTransaction>[0] = {
+  sourceAmount: "1",
+  sourceBalance: { tokenCode: "XLM" } as never,
+  destinationBalance: { tokenCode: "USDC" } as never,
+  pathResult: {
+    path: [],
+    destinationAmount: "1",
+    destinationAmountMin: "0.99",
+  } as never,
+  account: {
+    publicKey: "GA...",
+    privateKey: "SA...",
+  } as ActiveAccount,
+  network: NETWORKS.PUBLIC,
+  navigation: mockNavigation,
+};
+
+describe("useSwapTransaction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("executeSwap rejection contract", () => {
+    it("does NOT reject when submitTransaction returns null (failure)", async () => {
+      // submitTransaction returns null on failure - the hook reads the
+      // error from the store and throws inside the try, where the catch
+      // handles toast / analytics. The catch must NOT rethrow, otherwise
+      // SwapAmountScreen's fire-and-forget call site would surface an
+      // unhandled promise rejection at the global handler.
+      mockSignTransaction.mockReturnValue("signed-xdr");
+      mockSubmitTransaction.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useSwapTransaction(baseParams));
+
+      // Should resolve, not reject.
+      let didReject = false;
+      await act(async () => {
+        await result.current.executeSwap().catch(() => {
+          didReject = true;
+        });
+      });
+
+      expect(didReject).toBe(false);
+      // Side effects should still run despite no rethrow.
+      expect(mockTrackTransactionError).toHaveBeenCalledWith(
+        expect.objectContaining({ isSwap: true }),
+      );
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error" }),
+      );
+    });
+
+    it("does NOT reject when submitTransaction throws synchronously", async () => {
+      mockSignTransaction.mockReturnValue("signed-xdr");
+      mockSubmitTransaction.mockRejectedValue(new Error("Submit failed"));
+
+      const { result } = renderHook(() => useSwapTransaction(baseParams));
+
+      let didReject = false;
+      await act(async () => {
+        await result.current.executeSwap().catch(() => {
+          didReject = true;
+        });
+      });
+
+      expect(didReject).toBe(false);
+      expect(mockTrackTransactionError).toHaveBeenCalled();
+      expect(mockShowToast).toHaveBeenCalled();
+    });
+
+    it("does NOT reject when signTransaction returns null", async () => {
+      mockSignTransaction.mockReturnValue(null);
+
+      const { result } = renderHook(() => useSwapTransaction(baseParams));
+
+      let didReject = false;
+      await act(async () => {
+        await result.current.executeSwap().catch(() => {
+          didReject = true;
+        });
+      });
+
+      expect(didReject).toBe(false);
+      expect(mockShowToast).toHaveBeenCalled();
+    });
+
+    it("resolves successfully on a successful swap (sanity check)", async () => {
+      mockSignTransaction.mockReturnValue("signed-xdr");
+      mockSubmitTransaction.mockResolvedValue("tx-hash");
+
+      const { result } = renderHook(() => useSwapTransaction(baseParams));
+
+      await act(async () => {
+        await result.current.executeSwap();
+      });
+
+      expect(mockTrackSwapSuccess).toHaveBeenCalled();
+      expect(mockTrackTransactionError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @fnando/consistent-import/consistent-import */
+import * as Sentry from "@sentry/react-native";
+
+jest.mock("@sentry/react-native", () => ({
+  addBreadcrumb: jest.fn(),
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+jest.mock("helpers/isEnv", () => ({
+  isDev: false,
+  isE2ETest: false,
+}));
+
+// Bypass the global jest.mock("config/logger", ...) installed in
+// jest.setup.js so we can test the real adapter behavior.
+jest.unmock("config/logger");
+const {
+  logger,
+  initializeSentryLogger,
+  normalizeError,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+} = jest.requireActual("config/logger");
+
+const mockedSentry = Sentry as jest.Mocked<typeof Sentry>;
+
+describe("logger", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // The default adapter routes warn to console only - install the
+    // production adapter so warn reaches the Sentry path.
+    initializeSentryLogger();
+  });
+
+  describe("warn() Sentry severity", () => {
+    it("emits a Sentry breadcrumb instead of capturing a top-level message", () => {
+      logger.warn("ContextA", "something happened");
+
+      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith({
+        category: "ContextA",
+        message: "something happened",
+        level: "warning",
+        data: undefined,
+      });
+      expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it("attaches variadic args as breadcrumb data", () => {
+      logger.warn("ContextA", "something happened", { foo: "bar" }, 42);
+
+      // sanitizeLogData spreads the rest array into a numeric-keyed
+      // object - that's existing logger behavior we're documenting here,
+      // not redesigning. The args are still inspectable in the breadcrumb.
+      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "ContextA",
+          message: "something happened",
+          level: "warning",
+          data: { args: { 0: { foo: "bar" }, 1: 42 } },
+        }),
+      );
+    });
+
+    it("redacts known top-level PII keys (e.g. password) when args is a flat object", () => {
+      // sanitizeLogData only redacts at the top level of its input;
+      // because it spreads the rest array, the redactable keys are the
+      // numeric indices ("0", "1") not the inner object's keys. So
+      // password / publicKey nested inside an arg object are NOT
+      // redacted today. Document the limitation by passing a top-level
+      // string arg with a key that DOES match (top-level), via the args
+      // array spread becoming { "0": { ... } }.
+      //
+      // This test verifies the contract reaches addBreadcrumb intact -
+      // tightening the recursion is a separate concern.
+      logger.warn("ContextA", "something happened", { password: "secret" });
+
+      const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
+      // Existing behavior: the inner object's "password" survives.
+      expect(call.data).toEqual({
+        args: { 0: { password: "secret" } },
+      });
+    });
+  });
+
+  describe("error() Sentry severity", () => {
+    it("captures the error as a Sentry exception", () => {
+      const err = new Error("boom");
+
+      logger.error("ContextA", "operation failed", err);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(
+        err,
+        expect.objectContaining({ tags: { context: "ContextA" } }),
+      );
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it("normalizes non-Error values before capturing", () => {
+      logger.error("ContextA", "operation failed", "string error");
+
+      expect(mockedSentry.captureException).toHaveBeenCalledTimes(1);
+      const captured = mockedSentry.captureException.mock.calls[0][0];
+      expect(captured).toBeInstanceOf(Error);
+      expect((captured as Error).message).toBe("string error");
+    });
+  });
+
+  describe("info() / debug() Sentry severity", () => {
+    it("info() does NOT reach Sentry (no breadcrumb, no event)", () => {
+      logger.info("ContextA", "informational");
+
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+      expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
+      expect(mockedSentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it("debug() does NOT reach Sentry", () => {
+      logger.debug("ContextA", "debug detail");
+
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+      expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
+      expect(mockedSentry.captureException).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("normalizeError", () => {
+  it("returns the original Error instance unchanged", () => {
+    const err = new Error("boom");
+    expect(normalizeError(err)).toBe(err);
+  });
+
+  it("wraps strings in an Error with the same message", () => {
+    expect(normalizeError("plain string").message).toBe("plain string");
+  });
+
+  it("returns a generic Error for null / undefined", () => {
+    expect(normalizeError(null).message).toBe("An unknown error occurred");
+    expect(normalizeError(undefined).message).toBe("An unknown error occurred");
+  });
+
+  it("extracts the message from an axios-like error object", () => {
+    const apiError = { code: 500, message: "Network Error" };
+    const result = normalizeError(apiError);
+    expect(result.message).toContain("Network error 500");
+    expect(result.message).toContain("Network Error");
+  });
+});

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -19,6 +19,7 @@ const {
   logger,
   initializeSentryLogger,
   normalizeError,
+  sanitizeLogData,
   // eslint-disable-next-line @typescript-eslint/no-require-imports
 } = jest.requireActual("config/logger");
 
@@ -197,6 +198,36 @@ describe("logger", () => {
       expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
       expect(mockedSentry.captureException).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("sanitizeLogData depth cap", () => {
+  it("replaces values past the depth cap with a sentinel string (not the original reference)", () => {
+    // 9 levels of nesting - one past the depth cap of 8.
+    const deep = {
+      a: { b: { c: { d: { e: { f: { g: { h: { i: "leaf" } } } } } } } },
+    };
+
+    const sanitized = sanitizeLogData(deep) as { a: { b: { c: any } } };
+
+    // The path up to depth 8 is preserved, but the value at depth 8
+    // is the sentinel, not the original sub-object reference.
+    expect(typeof sanitized.a.b.c.d.e.f.g.h).toBe("string");
+    expect(sanitized.a.b.c.d.e.f.g.h).toBe("[MAX_DEPTH_EXCEEDED]");
+  });
+
+  it("does not let cyclic objects escape into the sanitized payload", () => {
+    // obj.self = obj - the classic cyclic structure that would crash
+    // JSON.stringify() and corrupt Sentry breadcrumbs / extras.
+    const obj: Record<string, unknown> = { foo: "bar" };
+    obj.self = obj;
+
+    const sanitized = sanitizeLogData(obj);
+
+    // Sentry will serialize the breadcrumb / extra payload via
+    // JSON.stringify - if a cycle escaped, this would throw with
+    // "Converting circular structure to JSON".
+    expect(() => JSON.stringify(sanitized)).not.toThrow();
   });
 });
 

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -79,7 +79,6 @@ describe("logger", () => {
     it("redacts PII keys nested inside variadic arg objects", () => {
       logger.warn("ContextA", "something happened", {
         password: "secret",
-        publicKey: "GA...",
         normalField: "ok",
       });
 
@@ -88,7 +87,54 @@ describe("logger", () => {
         args: [
           {
             password: "[REDACTED]",
-            publicKey: "GA...",
+            normalField: "ok",
+          },
+        ],
+      });
+    });
+
+    it("redacts publicKey (camelCase) and public_key (snake_case)", () => {
+      // publicKey isn't strictly secret, but the codebase gates it on
+      // the analytics opt-in (see buildSentryContext). Redact in logger
+      // payloads to extend that opt-out promise to breadcrumbs / extras.
+      // Backend payloads arrive snake_case, so both forms must redact.
+      logger.warn("ContextA", "something happened", {
+        publicKey: "GA_CAMEL",
+        public_key: "GA_SNAKE",
+        normalField: "ok",
+      });
+
+      const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
+      expect(call.data).toEqual({
+        args: [
+          {
+            publicKey: "[REDACTED]",
+            public_key: "[REDACTED]",
+            normalField: "ok",
+          },
+        ],
+      });
+    });
+
+    it("redacts other snake_case PII variants (account_id, private_key, etc.)", () => {
+      logger.warn("ContextA", "something happened", {
+        account_id: "GA...",
+        private_key: "S...",
+        secret_key: "S...",
+        api_key: "ak_...",
+        ip_address: "1.2.3.4",
+        normalField: "ok",
+      });
+
+      const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
+      expect(call.data).toEqual({
+        args: [
+          {
+            account_id: "[REDACTED]",
+            private_key: "[REDACTED]",
+            secret_key: "[REDACTED]",
+            api_key: "[REDACTED]",
+            ip_address: "[REDACTED]",
             normalField: "ok",
           },
         ],

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -141,6 +141,44 @@ describe("logger", () => {
       expect(captured).toBeInstanceOf(Error);
       expect((captured as Error).message).toBe("string error");
     });
+
+    it("forwards the caller's `message` arg into Sentry extras (not just console)", () => {
+      // The Sentry title comes from the Error.message (preserves
+      // grouping), but the caller's intent string ("operation failed")
+      // would otherwise be lost on the Sentry path. It's inspectable
+      // in the event extras now.
+      const err = new Error("boom");
+
+      logger.error("ContextA", "Failed at step 2 (token refresh)", err);
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(
+        err,
+        expect.objectContaining({
+          tags: { context: "ContextA" },
+          extra: expect.objectContaining({
+            message: "Failed at step 2 (token refresh)",
+          }),
+        }),
+      );
+    });
+
+    it("merges `message` and `args` into a single extras object", () => {
+      const err = new Error("boom");
+
+      logger.error("ContextA", "User-friendly description", err, {
+        userId: "x",
+      });
+
+      expect(mockedSentry.captureException).toHaveBeenCalledWith(
+        err,
+        expect.objectContaining({
+          extra: {
+            message: "User-friendly description",
+            args: [{ userId: "[REDACTED]" }],
+          },
+        }),
+      );
+    });
   });
 
   describe("info() / debug() Sentry severity", () => {

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -45,39 +45,77 @@ describe("logger", () => {
       expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
     });
 
-    it("attaches variadic args as breadcrumb data", () => {
+    it("attaches variadic args as breadcrumb data preserving array shape", () => {
       logger.warn("ContextA", "something happened", { foo: "bar" }, 42);
 
-      // sanitizeLogData spreads the rest array into a numeric-keyed
-      // object - that's existing logger behavior we're documenting here,
-      // not redesigning. The args are still inspectable in the breadcrumb.
       expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
         expect.objectContaining({
           category: "ContextA",
           message: "something happened",
           level: "warning",
-          data: { args: { 0: { foo: "bar" }, 1: 42 } },
+          data: { args: [{ foo: "bar" }, 42] },
         }),
       );
     });
 
-    it("redacts known top-level PII keys (e.g. password) when args is a flat object", () => {
-      // sanitizeLogData only redacts at the top level of its input;
-      // because it spreads the rest array, the redactable keys are the
-      // numeric indices ("0", "1") not the inner object's keys. So
-      // password / publicKey nested inside an arg object are NOT
-      // redacted today. Document the limitation by passing a top-level
-      // string arg with a key that DOES match (top-level), via the args
-      // array spread becoming { "0": { ... } }.
-      //
-      // This test verifies the contract reaches addBreadcrumb intact -
-      // tightening the recursion is a separate concern.
-      logger.warn("ContextA", "something happened", { password: "secret" });
+    it("redacts PII keys nested inside variadic arg objects", () => {
+      logger.warn("ContextA", "something happened", {
+        password: "secret",
+        publicKey: "GA...",
+        normalField: "ok",
+      });
 
       const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
-      // Existing behavior: the inner object's "password" survives.
       expect(call.data).toEqual({
-        args: { 0: { password: "secret" } },
+        args: [
+          {
+            password: "[REDACTED]",
+            publicKey: "GA...",
+            normalField: "ok",
+          },
+        ],
+      });
+    });
+
+    it("recurses into deeply nested objects to redact PII", () => {
+      logger.warn("ContextA", "something happened", {
+        outer: {
+          inner: {
+            mnemonic: "word word word",
+            other: "ok",
+          },
+        },
+      });
+
+      const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
+      expect(call.data).toEqual({
+        args: [
+          {
+            outer: {
+              inner: {
+                mnemonic: "[REDACTED]",
+                other: "ok",
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it("redacts PII inside arrays of objects (e.g. account list)", () => {
+      logger.warn("ContextA", "something happened", [
+        { id: "a", privateKey: "S1" },
+        { id: "b", privateKey: "S2" },
+      ]);
+
+      const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
+      expect(call.data).toEqual({
+        args: [
+          [
+            { id: "a", privateKey: "[REDACTED]" },
+            { id: "b", privateKey: "[REDACTED]" },
+          ],
+        ],
       });
     });
   });

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -300,4 +300,19 @@ describe("normalizeError", () => {
     expect(result.message).toContain("Network error 500");
     expect(result.message).toContain("Network Error");
   });
+
+  it("formats apiFactory's no-response ApiError (status: 0) as 'Network error 0:', not 'Network error undefined:'", () => {
+    // apiFactory throws ApiError with `status: 0` and
+    // `isNetworkError: true` when axios sees no response. The fallback
+    // chain in normalizeError must use `??` (not `||`) so the
+    // numeric 0 is preserved and the captured Error.message tells the
+    // truth about what failed.
+    const apiError = {
+      message: "Network Error",
+      status: 0,
+      isNetworkError: true,
+    };
+    const result = normalizeError(apiError);
+    expect(result.message).toBe("Network error 0: Network Error");
+  });
 });

--- a/__tests__/config/logger.test.ts
+++ b/__tests__/config/logger.test.ts
@@ -46,6 +46,23 @@ describe("logger", () => {
       expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
     });
 
+    it("preserves Error message and stack when an Error is passed as a variadic arg", () => {
+      // Regression: callers like `logger.warn(ctx, "Failed", err)` rely
+      // on the breadcrumb carrying err.message / err.stack. Without
+      // the Error special case in sanitizeLogData, the breadcrumb
+      // would ship `{ args: [{}] }` because Error fields are
+      // non-enumerable, silently dropping the diagnostic.
+      const err = new Error("token refresh failed");
+      logger.warn("AuthFlow", "step 2 failed", err);
+
+      const call = mockedSentry.addBreadcrumb.mock.calls[0][0];
+      const { args } = call.data as {
+        args: Array<{ message?: string; stack?: string }>;
+      };
+      expect(args[0].message).toBe("token refresh failed");
+      expect(typeof args[0].stack).toBe("string");
+    });
+
     it("attaches variadic args as breadcrumb data preserving array shape", () => {
       logger.warn("ContextA", "something happened", { foo: "bar" }, 42);
 
@@ -198,6 +215,37 @@ describe("logger", () => {
       expect(mockedSentry.captureMessage).not.toHaveBeenCalled();
       expect(mockedSentry.captureException).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("sanitizeLogData Error preservation", () => {
+  it("preserves message and stack from a bare Error (non-enumerable per spec)", () => {
+    const err = new Error("boom");
+
+    const sanitized = sanitizeLogData(err) as {
+      name: string;
+      message: string;
+      stack: string;
+    };
+
+    expect(sanitized.name).toBe("Error");
+    expect(sanitized.message).toBe("boom");
+    expect(typeof sanitized.stack).toBe("string");
+    expect(sanitized.stack).toContain("boom");
+  });
+
+  it("preserves Error fields when nested inside the variadic args array", () => {
+    // The actual logger.warn / logger.error path: callers pass an Error
+    // as a variadic arg, sanitizeLogData walks the args ARRAY, then
+    // reaches each Error. Must produce a useful object, not `{}`.
+    const err = new Error("nested boom");
+
+    const sanitized = sanitizeLogData([err, { ok: true }]) as Array<{
+      message?: string;
+    }>;
+
+    expect(sanitized[0].message).toBe("nested boom");
+    expect(sanitized[1]).toEqual({ ok: true });
   });
 });
 

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -426,21 +426,46 @@ describe("sentryConfig.beforeSend filters", () => {
         expect(owner).toBe("G***");
       });
 
-      it("does not throw on cyclic structures (depth-cap behavior)", () => {
-        // Defense: a cyclic value should not crash the scrubber.
-        // Sentry's serializer would also fail on cycles, but if
-        // anything ever passes one through to beforeSend we must not
-        // throw and drop the event entirely.
+      it("replaces cyclic substructures with a sentinel instead of returning the original reference", () => {
+        // At the depth cap the walker must return a sentinel string,
+        // not the original subtree, otherwise a cyclic ref escapes
+        // into event.extra (defense-in-depth even if Sentry's
+        // serializer would also handle cycles). The positive
+        // guarantee here is that the post-scrub event payload is
+        // JSON-serializable - no live cycles survived.
         const cyclic: Record<string, unknown> = { a: PUBLIC_KEY };
         cyclic.self = cyclic;
 
-        expect(() =>
-          runBeforeSendWith({
-            type: undefined,
-            exception: { values: [{ type: "Error", value: "boom" }] },
-            extra: { cyclic },
-          }),
-        ).not.toThrow();
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          extra: { cyclic },
+        }) as ErrorEvent;
+
+        expect(() => JSON.stringify(result?.extra)).not.toThrow();
+      });
+
+      it("replaces values past the depth cap with a sentinel string (so deep StrKeys cannot leak)", () => {
+        // The walker enters event.extra at depth 0; each property
+        // descent increments depth. With MAX_DEEP_SCRUB_DEPTH = 8,
+        // a value reached at depth 8 is replaced with the sentinel
+        // (not the original subtree).
+        const deep = {
+          a: { b: { c: { d: { e: { f: { g: { h: { i: PUBLIC_KEY } } } } } } } },
+        };
+
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          extra: { deep },
+        }) as ErrorEvent;
+
+        // The strongest leak guarantee: the original publicKey
+        // string must not appear ANYWHERE in the serialized payload.
+        // The depth cap clips the subtree before it can be walked
+        // for StrKey replacement.
+        expect(JSON.stringify(result?.extra)).not.toContain(PUBLIC_KEY);
+        expect(JSON.stringify(result?.extra)).toContain("[MAX_DEPTH_EXCEEDED]");
       });
     });
   });

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -6,8 +6,6 @@ import {
   initializeSentry,
   scrubStrKeys,
 } from "config/sentryConfig";
-import enTranslations from "i18n/locales/en/translations.json";
-import ptTranslations from "i18n/locales/pt/translations.json";
 
 jest.mock("@sentry/react-native", () => ({
   init: jest.fn(),
@@ -174,24 +172,6 @@ describe("sentryConfig.beforeSend filters", () => {
       const result = runBeforeSend(msg);
       expect(result).not.toBeNull();
       expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("PASSWORD_TYPO_MESSAGES stay in sync with i18n source", () => {
-    // Tripwire: if someone changes the user-facing copy in
-    // `translations.json` without also updating PASSWORD_TYPO_MESSAGES,
-    // the noise filter would silently stop matching and these typos
-    // would start landing in Sentry. Fail the build instead.
-    it("contains the English authStore.error.invalidPassword string", () => {
-      expect(PASSWORD_TYPO_MESSAGES).toContain(
-        enTranslations.authStore.error.invalidPassword,
-      );
-    });
-
-    it("contains the Portuguese authStore.error.invalidPassword string", () => {
-      expect(PASSWORD_TYPO_MESSAGES).toContain(
-        ptTranslations.authStore.error.invalidPassword,
-      );
     });
   });
 

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -326,5 +326,122 @@ describe("sentryConfig.beforeSend filters", () => {
         expect(result?.contexts?.appContext?.publicKey).toBe(PUBLIC_KEY);
       });
     });
+
+    describe("deep scrub: event.extra.args (recursive walk)", () => {
+      // Object-key redaction (PII_FIELDS_LOWER) catches known field
+      // names. The deep scrub catches StrKeys embedded in any string
+      // value, regardless of field name - the leak surface for
+      // backend payload shapes with `owner` / `from` / `recipient`.
+
+      it("scrubs StrKey nested inside event.extra.args (logger.error structured args)", () => {
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          extra: {
+            args: [{ owner: PUBLIC_KEY, otherField: "ok" }],
+          },
+        }) as ErrorEvent;
+
+        const args = (
+          result?.extra?.args as Array<{
+            owner?: string;
+            otherField?: string;
+          }>
+        )[0];
+        expect(args.owner).toBe("G***");
+        expect(args.otherField).toBe("ok");
+      });
+
+      it("scrubs StrKeys at depth (nested objects and arrays)", () => {
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          extra: {
+            payload: {
+              data: {
+                collections: [
+                  { collectibles: [{ owner: PUBLIC_KEY, name: "ok" }] },
+                ],
+              },
+            },
+          },
+        }) as ErrorEvent;
+
+        const { owner } = (
+          result?.extra?.payload as {
+            data: {
+              collections: Array<{ collectibles: Array<{ owner: string }> }>;
+            };
+          }
+        ).data.collections[0].collectibles[0];
+        expect(owner).toBe("G***");
+      });
+
+      it("preserves non-string types (numbers, booleans, null) in extras", () => {
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          extra: {
+            count: 42,
+            enabled: true,
+            ratio: null,
+            note: `account ${PUBLIC_KEY}`,
+          },
+        }) as ErrorEvent;
+
+        expect(result?.extra?.count).toBe(42);
+        expect(result?.extra?.enabled).toBe(true);
+        expect(result?.extra?.ratio).toBeNull();
+        expect(result?.extra?.note).toBe("account G***");
+      });
+
+      it("scrubs StrKeys inside breadcrumb.data (logger.warn args path)", () => {
+        // logger.warn ships args as breadcrumb data. A backend
+        // payload shape with `owner` would slip past sanitizeLogData's
+        // field-name redaction.
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          breadcrumbs: [
+            {
+              category: "fetchCollectibles",
+              message: "Backend error for collection",
+              level: "warning",
+              data: {
+                args: [
+                  {
+                    collection: { owner: PUBLIC_KEY, name: "Soroban Frogs" },
+                  },
+                ],
+              },
+            },
+          ],
+        }) as ErrorEvent;
+
+        const { owner } = (
+          result?.breadcrumbs?.[0].data?.args as Array<{
+            collection: { owner: string };
+          }>
+        )[0].collection;
+        expect(owner).toBe("G***");
+      });
+
+      it("does not throw on cyclic structures (depth-cap behavior)", () => {
+        // Defense: a cyclic value should not crash the scrubber.
+        // Sentry's serializer would also fail on cycles, but if
+        // anything ever passes one through to beforeSend we must not
+        // throw and drop the event entirely.
+        const cyclic: Record<string, unknown> = { a: PUBLIC_KEY };
+        cyclic.self = cyclic;
+
+        expect(() =>
+          runBeforeSendWith({
+            type: undefined,
+            exception: { values: [{ type: "Error", value: "boom" }] },
+            extra: { cyclic },
+          }),
+        ).not.toThrow();
+      });
+    });
   });
 });

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @fnando/consistent-import/consistent-import */
 import type { ErrorEvent } from "@sentry/core";
 import * as Sentry from "@sentry/react-native";
-import { PASSWORD_TYPO_MESSAGES, initializeSentry } from "config/sentryConfig";
+import {
+  PASSWORD_TYPO_MESSAGES,
+  initializeSentry,
+  scrubStrKeys,
+} from "config/sentryConfig";
 import enTranslations from "i18n/locales/en/translations.json";
 import ptTranslations from "i18n/locales/pt/translations.json";
 
@@ -57,6 +61,20 @@ const runBeforeSend = (message: string): ErrorEvent | null => {
   } as unknown as ErrorEvent;
   // The hint argument is unused by the filter logic; pass an empty obj.
   return initOpts.beforeSend(event, {}) as ErrorEvent | null;
+};
+
+/**
+ * Drive beforeSend with a fully-shaped synthetic event so we can
+ * assert scrub behavior on event.message, event.exception values,
+ * and event.extra.message simultaneously.
+ */
+const runBeforeSendWith = (event: Partial<ErrorEvent>): ErrorEvent | null => {
+  initializeSentry();
+  const initOpts = mockedSentry.init.mock.calls[0]?.[0];
+  if (!initOpts?.beforeSend) {
+    throw new Error("beforeSend not configured");
+  }
+  return initOpts.beforeSend(event as ErrorEvent, {}) as ErrorEvent | null;
 };
 
 describe("sentryConfig.beforeSend filters", () => {
@@ -185,6 +203,128 @@ describe("sentryConfig.beforeSend filters", () => {
       const result = runBeforeSend("Error: timeout of 15000ms exceeded");
       expect(result).not.toBeNull();
       expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("scrubStrKeys (Stellar StrKey identifier scrubber)", () => {
+    // Real-shape Stellar StrKey samples for the regex (G/S + 55 base32).
+    const PUBLIC_KEY = `G${"A".repeat(55)}`;
+    const PUBLIC_KEY_2 = `G${"Z".repeat(55)}`;
+    const SECRET_SEED = `S${"A".repeat(55)}`;
+
+    describe("unit: scrubStrKeys helper", () => {
+      it("replaces a publicKey with G***", () => {
+        expect(scrubStrKeys(`Account ${PUBLIC_KEY} not found`)).toBe(
+          "Account G*** not found",
+        );
+      });
+
+      it("replaces a secret seed with S*** (defense-in-depth)", () => {
+        // Secret seeds should NEVER reach this code path - they're meant
+        // to stay encrypted in the keychain. This is a last-line defense.
+        expect(scrubStrKeys(`Decryption failed for ${SECRET_SEED}`)).toBe(
+          "Decryption failed for S***",
+        );
+      });
+
+      it("replaces multiple StrKeys in the same string", () => {
+        expect(scrubStrKeys(`From ${PUBLIC_KEY} to ${PUBLIC_KEY_2}`)).toBe(
+          "From G*** to G***",
+        );
+      });
+
+      it("returns undefined for undefined input", () => {
+        expect(scrubStrKeys(undefined)).toBeUndefined();
+      });
+
+      it("returns the string unchanged when no StrKey is present", () => {
+        const msg = "Failed to fetch token details";
+        expect(scrubStrKeys(msg)).toBe(msg);
+      });
+
+      it("does NOT match wrong prefix (e.g. A-prefixed 56-char string)", () => {
+        const fake = `A${PUBLIC_KEY.slice(1)}`; // 56 chars, wrong prefix
+        expect(scrubStrKeys(`Foo ${fake} bar`)).toBe(`Foo ${fake} bar`);
+      });
+
+      it("does NOT match wrong length (54 or 57 chars with G prefix)", () => {
+        const tooShort = PUBLIC_KEY.slice(0, -1); // 55 chars
+        const tooLong = `${PUBLIC_KEY}A`; // 57 chars
+        expect(scrubStrKeys(`${tooShort} ${tooLong}`)).toBe(
+          `${tooShort} ${tooLong}`,
+        );
+      });
+
+      it("does NOT match a 56-char run embedded inside a longer alphanumeric string", () => {
+        // Word-boundary anchors prevent partial matches inside larger
+        // alphanumeric runs (e.g. URL slugs without separators).
+        const embedded = `XXX${PUBLIC_KEY}XXX`;
+        expect(scrubStrKeys(embedded)).toBe(embedded);
+      });
+
+      it("matches a StrKey embedded in URL-shaped paths (separators are non-word chars)", () => {
+        expect(
+          scrubStrKeys(
+            `https://horizon.stellar.org/accounts/${PUBLIC_KEY}/operations`,
+          ),
+        ).toBe("https://horizon.stellar.org/accounts/G***/operations");
+      });
+    });
+
+    describe("integration: beforeSend applies scrub to event surfaces", () => {
+      it("scrubs event.exception.values[].value", () => {
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: {
+            values: [
+              {
+                type: "Error",
+                value: `Failed for ${PUBLIC_KEY}`,
+              },
+            ],
+          },
+        }) as ErrorEvent;
+
+        expect(result?.exception?.values?.[0].value).toBe("Failed for G***");
+      });
+
+      it("scrubs event.message (captureMessage path)", () => {
+        const result = runBeforeSendWith({
+          type: undefined,
+          message: `Operation failed for account ${PUBLIC_KEY}`,
+        }) as ErrorEvent;
+
+        expect(result?.message).toBe("Operation failed for account G***");
+      });
+
+      it("scrubs event.extra.message (the logger.error message-into-extras path)", () => {
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          extra: {
+            message: `User-friendly description for ${PUBLIC_KEY}`,
+          },
+        }) as ErrorEvent;
+
+        expect(result?.extra?.message).toBe(
+          "User-friendly description for G***",
+        );
+      });
+
+      it("does NOT mutate event.contexts (opt-in users keep their unredacted publicKey for triage)", () => {
+        // The scrub targets raw message surfaces. The deliberate
+        // appContext.publicKey set by buildSentryContext is on a
+        // different field path and should be untouched.
+        const result = runBeforeSendWith({
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "boom" }] },
+          contexts: {
+            appContext: { publicKey: PUBLIC_KEY },
+          },
+        }) as ErrorEvent;
+
+        expect(result?.contexts?.appContext?.publicKey).toBe(PUBLIC_KEY);
+      });
     });
   });
 });

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @fnando/consistent-import/consistent-import */
 import type { ErrorEvent } from "@sentry/core";
 import * as Sentry from "@sentry/react-native";
-import { initializeSentry } from "config/sentryConfig";
+import { PASSWORD_TYPO_MESSAGES, initializeSentry } from "config/sentryConfig";
+import enTranslations from "i18n/locales/en/translations.json";
+import ptTranslations from "i18n/locales/pt/translations.json";
 
 jest.mock("@sentry/react-native", () => ({
   init: jest.fn(),
@@ -101,16 +103,26 @@ describe("sentryConfig.beforeSend filters", () => {
   });
 
   describe("breadcrumb-downgrade patterns (drop event, add breadcrumb)", () => {
-    it("downgrades 'Invalid password' to a breadcrumb", () => {
-      expect(
-        runBeforeSend("Error: Invalid password. Please try again."),
-      ).toBeNull();
-      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: "user-input-validation",
-          level: "info",
-        }),
-      );
+    it.each(PASSWORD_TYPO_MESSAGES.map((m) => [m]))(
+      "downgrades the user-typo password message %s to a breadcrumb",
+      (message) => {
+        expect(runBeforeSend(message)).toBeNull();
+        expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
+          expect.objectContaining({
+            category: "user-input-validation",
+            level: "info",
+          }),
+        );
+      },
+    );
+
+    it("does NOT drop the corruption signal 'Invalid password or corrupted data.'", () => {
+      // encryptPassword.ts throws this exact message when decryption
+      // fails - real signal of storage loss / data corruption, must
+      // not be swallowed by the user-typo filter.
+      const result = runBeforeSend("Invalid password or corrupted data.");
+      expect(result).not.toBeNull();
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
     });
 
     it("downgrades 'No stored password found for biometric authentication' to a breadcrumb", () => {
@@ -144,6 +156,24 @@ describe("sentryConfig.beforeSend filters", () => {
       const result = runBeforeSend(msg);
       expect(result).not.toBeNull();
       expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("PASSWORD_TYPO_MESSAGES stay in sync with i18n source", () => {
+    // Tripwire: if someone changes the user-facing copy in
+    // `translations.json` without also updating PASSWORD_TYPO_MESSAGES,
+    // the noise filter would silently stop matching and these typos
+    // would start landing in Sentry. Fail the build instead.
+    it("contains the English authStore.error.invalidPassword string", () => {
+      expect(PASSWORD_TYPO_MESSAGES).toContain(
+        enTranslations.authStore.error.invalidPassword,
+      );
+    });
+
+    it("contains the Portuguese authStore.error.invalidPassword string", () => {
+      expect(PASSWORD_TYPO_MESSAGES).toContain(
+        ptTranslations.authStore.error.invalidPassword,
+      );
     });
   });
 

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -1,0 +1,165 @@
+/* eslint-disable @fnando/consistent-import/consistent-import */
+import type { ErrorEvent } from "@sentry/core";
+import * as Sentry from "@sentry/react-native";
+import { initializeSentry } from "config/sentryConfig";
+
+jest.mock("@sentry/react-native", () => ({
+  init: jest.fn(),
+  setContext: jest.fn(),
+  setTag: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+
+jest.mock("helpers/isEnv", () => ({
+  isProd: false,
+  isE2ETest: false,
+}));
+
+jest.mock("react-native-device-info", () => ({
+  getVersion: jest.fn(() => "1.0.0"),
+  getBuildNumber: jest.fn(() => "1"),
+  getBundleId: jest.fn(() => "org.stellar.freighterwallet"),
+}));
+
+jest.mock("ducks/analytics", () => ({
+  useAnalyticsStore: { getState: () => ({ isEnabled: true }) },
+}));
+jest.mock("ducks/auth", () => ({
+  useAuthenticationStore: {
+    getState: () => ({ network: "PUBLIC", account: { publicKey: "GA..." } }),
+  },
+}));
+jest.mock("ducks/networkInfo", () => ({
+  useNetworkStore: {
+    getState: () => ({ connectionType: "wifi", effectiveType: "4g" }),
+  },
+}));
+
+const mockedSentry = Sentry as jest.Mocked<typeof Sentry>;
+
+/**
+ * Drive the configured beforeSend through a synthetic event whose
+ * exception value is `message`. Returns whatever beforeSend returns
+ * (the event object if passed through, null if dropped).
+ */
+const runBeforeSend = (message: string): ErrorEvent | null => {
+  // Capture the beforeSend callback from the Sentry.init invocation.
+  initializeSentry();
+  const initOpts = mockedSentry.init.mock.calls[0]?.[0];
+  if (!initOpts?.beforeSend) {
+    throw new Error("beforeSend not configured");
+  }
+  const event: ErrorEvent = {
+    type: undefined,
+    exception: { values: [{ type: "Error", value: message }] },
+  } as unknown as ErrorEvent;
+  // The hint argument is unused by the filter logic; pass an empty obj.
+  return initOpts.beforeSend(event, {}) as ErrorEvent | null;
+};
+
+describe("sentryConfig.beforeSend filters", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("dropped patterns (no Sentry event, no breadcrumb)", () => {
+    it.each([
+      ["Error: Missing or invalid. Record was recently deleted - request: 123"],
+      ["Error: Missing or invalid. Record was recently deleted - session: abc"],
+    ])("drops WalletConnect 'Record was recently deleted' (%s)", (msg) => {
+      expect(runBeforeSend(msg)).toBeNull();
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['Error Domain=com.apple.LocalAuthentication Code=-4 "Canceled"'],
+      ['Error Domain=com.apple.LocalAuthentication Code=-1003 "Timeout"'],
+      ['Error Domain=com.apple.LocalAuthentication Code=-1004 "Foreground"'],
+      ['Error Domain=com.apple.LocalAuthentication Code=6 "(null)"'],
+    ])("drops iOS LocalAuthentication cancellation %s", (msg) => {
+      expect(runBeforeSend(msg)).toBeNull();
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it("does NOT drop other LocalAuthentication codes (e.g. unknown new code)", () => {
+      // A future iOS version might introduce Code=-99 - we shouldn't
+      // silently swallow that; better to learn about it.
+      const result = runBeforeSend(
+        'Error Domain=com.apple.LocalAuthentication Code=-99 "Future code"',
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it.each([
+      ["Error: Fingerprint operation canceled."],
+      ["Error: Fingerprint operation cancelled."],
+      ["error: FINGERPRINT OPERATION CANCELLED"],
+    ])("drops Android biometric cancellations %s", (msg) => {
+      expect(runBeforeSend(msg)).toBeNull();
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("breadcrumb-downgrade patterns (drop event, add breadcrumb)", () => {
+    it("downgrades 'Invalid mnemonic' to a breadcrumb", () => {
+      expect(runBeforeSend("Error: Invalid mnemonic (see bip39)")).toBeNull();
+      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "user-input-validation",
+          level: "info",
+        }),
+      );
+    });
+
+    it("downgrades 'Invalid password' to a breadcrumb", () => {
+      expect(
+        runBeforeSend("Error: Invalid password. Please try again."),
+      ).toBeNull();
+      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "user-input-validation",
+          level: "info",
+        }),
+      );
+    });
+
+    it("downgrades 'No stored password found for biometric authentication' to a breadcrumb", () => {
+      expect(
+        runBeforeSend(
+          "Error: No stored password found for biometric authentication",
+        ),
+      ).toBeNull();
+      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: "biometric-state",
+          level: "info",
+        }),
+      );
+    });
+  });
+
+  describe("real errors pass through", () => {
+    it.each([
+      ["Error: Private key not found"],
+      ["TypeError: Cannot read property 'foo' of undefined"],
+      ["Error: Network error 504: Request failed with status code 504"],
+      ["Error: Failed to set key 0.123: User canceled the operation."],
+      ["Error: WalletConnect transaction request origin does not match"],
+    ])("does NOT filter real error %s", (msg) => {
+      const result = runBeforeSend(msg);
+      expect(result).not.toBeNull();
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("network timeouts (post-removal of the explicit filter)", () => {
+    // After removal of the timeout filter to preserve backend latency
+    // visibility, axios timeouts should pass through to Sentry as
+    // regular errors. This test pins that behavior.
+    it("does NOT filter 'timeout of 15000ms exceeded'", () => {
+      const result = runBeforeSend("Error: timeout of 15000ms exceeded");
+      expect(result).not.toBeNull();
+      expect(mockedSentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -110,7 +110,7 @@ describe("sentryConfig.beforeSend filters", () => {
         expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
           expect.objectContaining({
             category: "user-input-validation",
-            level: "info",
+            level: "warning",
           }),
         );
       },
@@ -134,7 +134,7 @@ describe("sentryConfig.beforeSend filters", () => {
       expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
         expect.objectContaining({
           category: "biometric-state",
-          level: "info",
+          level: "warning",
         }),
       );
     });

--- a/__tests__/config/sentryConfig.test.ts
+++ b/__tests__/config/sentryConfig.test.ts
@@ -101,16 +101,6 @@ describe("sentryConfig.beforeSend filters", () => {
   });
 
   describe("breadcrumb-downgrade patterns (drop event, add breadcrumb)", () => {
-    it("downgrades 'Invalid mnemonic' to a breadcrumb", () => {
-      expect(runBeforeSend("Error: Invalid mnemonic (see bip39)")).toBeNull();
-      expect(mockedSentry.addBreadcrumb).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: "user-input-validation",
-          level: "info",
-        }),
-      );
-    });
-
     it("downgrades 'Invalid password' to a breadcrumb", () => {
       expect(
         runBeforeSend("Error: Invalid password. Please try again."),
@@ -145,6 +135,11 @@ describe("sentryConfig.beforeSend filters", () => {
       ["Error: Network error 504: Request failed with status code 504"],
       ["Error: Failed to set key 0.123: User canceled the operation."],
       ["Error: WalletConnect transaction request origin does not match"],
+      // bip39's "Invalid mnemonic" - the verifyMnemonicPhrase path
+      // logs at warn (no Sentry event), so any "Invalid mnemonic"
+      // event reaching beforeSend is from a post-validation path
+      // (e.g. corrupted stored mnemonic) and is a real signal.
+      ["Invalid mnemonic"],
     ])("does NOT filter real error %s", (msg) => {
       const result = runBeforeSend(msg);
       expect(result).not.toBeNull();

--- a/__tests__/ducks/auth.test.ts
+++ b/__tests__/ducks/auth.test.ts
@@ -1297,11 +1297,17 @@ describe("auth duck", () => {
           });
         }
 
-        // Should log suspicious repeated failures after threshold
+        // Should log suspicious repeated failures after threshold.
+        // Stable Error message + variable count moved to extra args
+        // so events group as a single Sentry issue across counts.
         expect(logger.error).toHaveBeenCalledWith(
           "[getTemporaryStore]",
-          "Repeated failures detected",
-          expect.stringContaining("Multiple unauthorized access attempts"),
+          expect.stringContaining("Repeated decryption failures"),
+          expect.any(Error),
+          expect.objectContaining({
+            failureCount: expect.any(Number),
+            windowMs: expect.any(Number),
+          }),
         );
       });
 

--- a/__tests__/ducks/auth.test.ts
+++ b/__tests__/ducks/auth.test.ts
@@ -1306,7 +1306,7 @@ describe("auth duck", () => {
           expect.any(Error),
           expect.objectContaining({
             failureCount: expect.any(Number),
-            windowMs: expect.any(Number),
+            failureResetWindowMs: expect.any(Number),
           }),
         );
       });

--- a/__tests__/ducks/remoteConfig.test.ts
+++ b/__tests__/ducks/remoteConfig.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @fnando/consistent-import/consistent-import */
 import { act, renderHook } from "@testing-library/react-hooks";
+import { logger } from "config/logger";
+import { useNetworkStore } from "ducks/networkInfo";
 import { useRemoteConfigStore } from "ducks/remoteConfig";
 import { getExperimentClient } from "services/analytics/core";
 
@@ -19,6 +21,10 @@ jest.mock("config/logger", () => ({
     warn: jest.fn(),
     error: jest.fn(),
   },
+}));
+
+jest.mock("ducks/networkInfo", () => ({
+  useNetworkStore: { getState: jest.fn(() => ({ isOffline: false })) },
 }));
 
 jest.mock("helpers/device", () => ({
@@ -217,6 +223,50 @@ describe("remoteConfig duck", () => {
       expect(result.current.swap_enabled).toBe(false);
       expect(result.current.discover_enabled).toBe(false);
       expect(result.current.onramp_enabled).toBe(false);
+    });
+
+    it("logs as logger.warn when the device is offline (avoid hourly polling noise)", async () => {
+      (useNetworkStore.getState as jest.Mock).mockReturnValue({
+        isOffline: true,
+      });
+      const mockClient = createMockExperimentClient();
+      mockClient.fetch.mockRejectedValue(new Error("Network down"));
+      mockGetExperimentClient.mockReturnValue(mockClient);
+
+      const { result } = renderHook(() => useRemoteConfigStore());
+
+      await act(async () => {
+        await result.current.fetchFeatureFlags();
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        "remoteConfig.fetchFeatureFlags",
+        expect.stringContaining("offline"),
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("logs as logger.error when the device is online (real SDK / config / outage)", async () => {
+      (useNetworkStore.getState as jest.Mock).mockReturnValue({
+        isOffline: false,
+      });
+      const mockClient = createMockExperimentClient();
+      const realError = new Error("Amplitude SDK error");
+      mockClient.fetch.mockRejectedValue(realError);
+      mockGetExperimentClient.mockReturnValue(mockClient);
+
+      const { result } = renderHook(() => useRemoteConfigStore());
+
+      await act(async () => {
+        await result.current.fetchFeatureFlags();
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "remoteConfig.fetchFeatureFlags",
+        "Failed to fetch feature flags",
+        realError,
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it("should handle variant errors gracefully", async () => {

--- a/__tests__/ducks/remoteConfig.test.ts
+++ b/__tests__/ducks/remoteConfig.test.ts
@@ -242,6 +242,7 @@ describe("remoteConfig duck", () => {
       expect(logger.warn).toHaveBeenCalledWith(
         "remoteConfig.fetchFeatureFlags",
         expect.stringContaining("offline"),
+        expect.any(Error),
       );
       expect(logger.error).not.toHaveBeenCalled();
     });

--- a/__tests__/ducks/transactionBuilder.test.ts
+++ b/__tests__/ducks/transactionBuilder.test.ts
@@ -1,5 +1,6 @@
 import { act } from "@testing-library/react-hooks";
 import { NETWORKS } from "config/constants";
+import { logger } from "config/logger";
 import { useTransactionBuilderStore } from "ducks/transactionBuilder";
 import * as sorobanHelpers from "helpers/soroban";
 import * as stellarServices from "services/stellar";
@@ -314,6 +315,84 @@ describe("transactionBuilder Duck", () => {
     expect(state.isSubmitting).toBe(false);
     expect(state.transactionHash).toBeNull();
     expect(state.error).toBe(submitError.message);
+  });
+
+  describe("submitTransaction logger severity (Horizon error split)", () => {
+    beforeEach(() => {
+      act(() => {
+        store.setState({ signedTransactionXDR: mockSignedXDR });
+      });
+      // Treat the test errors as HorizonError shapes so the duck's branch
+      // can read .response.status off them.
+      (
+        stellarServices.isHorizonError as unknown as jest.Mock
+      ).mockImplementation(
+        (val: unknown) =>
+          typeof val === "object" &&
+          val !== null &&
+          "response" in val &&
+          typeof (val as { response: unknown }).response === "object",
+      );
+    });
+
+    it("demotes Horizon 4xx protocol rejections to warn (e.g. tx_bad_seq)", async () => {
+      const horizon4xxError = {
+        response: {
+          status: 400,
+          data: { extras: { result_codes: { transaction: "tx_bad_seq" } } },
+        },
+      };
+      (stellarServices.submitTx as jest.Mock).mockRejectedValue(
+        horizon4xxError,
+      );
+
+      await act(async () => {
+        await store.getState().submitTransaction({ network: mockNetwork });
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        "TransactionBuilderStore",
+        expect.stringContaining("Network rejected transaction (HTTP 400)"),
+        { transaction: "tx_bad_seq" },
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("keeps Horizon 5xx server errors as logger.error (e.g. submitted-then-overloaded)", async () => {
+      const horizon5xxError = {
+        response: { status: 504 },
+      };
+      (stellarServices.submitTx as jest.Mock).mockRejectedValue(
+        horizon5xxError,
+      );
+
+      await act(async () => {
+        await store.getState().submitTransaction({ network: mockNetwork });
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "TransactionBuilderStore",
+        expect.stringContaining("Failed to submit transaction"),
+        horizon5xxError,
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("keeps non-Horizon errors as logger.error (bad XDR, network unreachable, SDK exception)", async () => {
+      const sdkError = new Error("Bad XDR encoding");
+      (stellarServices.submitTx as jest.Mock).mockRejectedValue(sdkError);
+
+      await act(async () => {
+        await store.getState().submitTransaction({ network: mockNetwork });
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "TransactionBuilderStore",
+        expect.stringContaining("Failed to submit transaction"),
+        sdkError,
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
   });
 
   it("should reset the transaction state", () => {

--- a/__tests__/ducks/transactionBuilder.test.ts
+++ b/__tests__/ducks/transactionBuilder.test.ts
@@ -358,6 +358,33 @@ describe("transactionBuilder Duck", () => {
       expect(logger.error).not.toHaveBeenCalled();
     });
 
+    it("keeps Horizon 4xx WITHOUT result_codes as logger.error (operational failures, not user-correctable)", async () => {
+      // 4xx responses from Horizon / proxies that don't carry the
+      // protocol-rejection `result_codes` (rate limits, auth failures,
+      // generic gateway errors) are operational, not user-correctable
+      // - they need Sentry visibility, not the warn breadcrumb path.
+      const horizon4xxNoResultCodes = {
+        response: {
+          status: 429,
+          data: { detail: "Too many requests" },
+        },
+      };
+      (stellarServices.submitTx as jest.Mock).mockRejectedValue(
+        horizon4xxNoResultCodes,
+      );
+
+      await act(async () => {
+        await store.getState().submitTransaction({ network: mockNetwork });
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "TransactionBuilderStore",
+        expect.stringContaining("Failed to submit transaction"),
+        horizon4xxNoResultCodes,
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
     it("keeps Horizon 5xx server errors as logger.error (e.g. submitted-then-overloaded)", async () => {
       const horizon5xxError = {
         response: { status: 504 },

--- a/__tests__/helpers/browser.test.ts
+++ b/__tests__/helpers/browser.test.ts
@@ -265,7 +265,7 @@ describe("browser helpers", () => {
       const result = await clearAllCookies();
 
       expect(result).toBe(false);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         "clearAllCookies",
         "Cookie cleanup may have failed",
       );
@@ -313,7 +313,7 @@ describe("browser helpers", () => {
       const result = await clearAllWebViewData();
 
       expect(result).toBe(false);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         "clearAllWebViewData",
         "WebView data cleanup may have failed",
       );
@@ -326,7 +326,7 @@ describe("browser helpers", () => {
       const result = await clearAllWebViewData();
 
       expect(result).toBe(false);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect(mockLogger.info).toHaveBeenCalledWith(
         "clearAllWebViewData",
         "WebView data cleanup may have failed",
       );

--- a/__tests__/hooks/useSecureClipboard.test.tsx
+++ b/__tests__/hooks/useSecureClipboard.test.tsx
@@ -82,7 +82,7 @@ const mockNativeClearString =
     typeof SecureClipboardModule.clearString
   >;
 
-const mockLoggerWarn = logger.warn as jest.MockedFunction<typeof logger.warn>;
+const mockLoggerInfo = logger.info as jest.MockedFunction<typeof logger.info>;
 
 describe("useSecureClipboard", () => {
   beforeEach(() => {
@@ -177,7 +177,7 @@ describe("useSecureClipboard", () => {
 
     expect(mockNativeSetString).toHaveBeenCalledWith(text, 30000);
     expect(mockSetString).toHaveBeenCalledWith(text); // Should fallback to standard clipboard
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
       "SecureClipboardService.copyToClipboard",
       "Native module failed, falling back to standard clipboard",
       expect.any(Error),

--- a/__tests__/hooks/useSecureClipboard.test.tsx
+++ b/__tests__/hooks/useSecureClipboard.test.tsx
@@ -82,7 +82,7 @@ const mockNativeClearString =
     typeof SecureClipboardModule.clearString
   >;
 
-const mockLoggerInfo = logger.info as jest.MockedFunction<typeof logger.info>;
+const mockLoggerWarn = logger.warn as jest.MockedFunction<typeof logger.warn>;
 
 describe("useSecureClipboard", () => {
   beforeEach(() => {
@@ -177,7 +177,7 @@ describe("useSecureClipboard", () => {
 
     expect(mockNativeSetString).toHaveBeenCalledWith(text, 30000);
     expect(mockSetString).toHaveBeenCalledWith(text); // Should fallback to standard clipboard
-    expect(mockLoggerInfo).toHaveBeenCalledWith(
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
       "SecureClipboardService.copyToClipboard",
       "Native module failed, falling back to standard clipboard",
       expect.any(Error),

--- a/__tests__/services/apiFactory.test.ts
+++ b/__tests__/services/apiFactory.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @fnando/consistent-import/consistent-import */
+import { ApiError, isApiNetworkError } from "services/apiFactory";
+
+describe("apiFactory", () => {
+  describe("isApiNetworkError", () => {
+    it("matches an ApiError-shaped object with isNetworkError: true", () => {
+      const networkErr: ApiError = {
+        message: "Network Error",
+        status: 0,
+        isNetworkError: true,
+      };
+      expect(isApiNetworkError(networkErr)).toBe(true);
+    });
+
+    it("does NOT match an ApiError with isNetworkError: false (real backend response)", () => {
+      const realApiErr: ApiError = {
+        message: "Bad request",
+        status: 400,
+        isNetworkError: false,
+      };
+      expect(isApiNetworkError(realApiErr)).toBe(false);
+    });
+
+    it("does NOT match a regular Error instance", () => {
+      expect(isApiNetworkError(new Error("oops"))).toBe(false);
+    });
+
+    it("does NOT match a plain object missing isNetworkError", () => {
+      expect(isApiNetworkError({ message: "oops", status: 500 })).toBe(false);
+    });
+
+    it("does NOT match null / undefined / primitives", () => {
+      expect(isApiNetworkError(null)).toBe(false);
+      expect(isApiNetworkError(undefined)).toBe(false);
+      expect(isApiNetworkError("string")).toBe(false);
+      expect(isApiNetworkError(42)).toBe(false);
+    });
+
+    it("does NOT match objects with isNetworkError: false-y but not strictly true", () => {
+      // Guard against truthy but non-boolean values from third-party
+      // error shapes that happen to have an isNetworkError key.
+      expect(isApiNetworkError({ isNetworkError: 1 })).toBe(false);
+      expect(isApiNetworkError({ isNetworkError: "true" })).toBe(false);
+      expect(isApiNetworkError({ isNetworkError: undefined })).toBe(false);
+    });
+  });
+});

--- a/__tests__/services/apiFactory.test.ts
+++ b/__tests__/services/apiFactory.test.ts
@@ -36,10 +36,14 @@ describe("apiFactory", () => {
       }
     });
 
-    it("axios timeouts (no response) are treated as network errors (status: 0)", async () => {
-      // axios surfaces timeouts as `Error: timeout of Xms exceeded` with
-      // no `response` field - same shape as offline. Pin this so callers
-      // branching on isApiNetworkError pick up timeouts too.
+    it("axios timeouts (ECONNABORTED) are NOT treated as network errors", async () => {
+      // axios timeouts share the no-response shape with true connectivity
+      // failures, but they represent backend latency, not connectivity.
+      // The interceptor uses `error.code === "ECONNABORTED"` to carve
+      // them out so consumers branching on isApiNetworkError route
+      // timeouts to logger.error and preserve Sentry visibility for
+      // latency regressions (rather than silently demoting them to
+      // breadcrumbs alongside offline events).
       const timeoutAdapter: AxiosAdapter = () =>
         Promise.reject(
           Object.assign(new Error("timeout of 15000ms exceeded"), {
@@ -54,8 +58,9 @@ describe("apiFactory", () => {
       } catch (caught) {
         const apiError = caught as ApiError;
         expect(apiError.status).toBe(0);
-        expect(apiError.isNetworkError).toBe(true);
-        expect(isApiNetworkError(apiError)).toBe(true);
+        expect(apiError.message).toBe("timeout of 15000ms exceeded");
+        expect(apiError.isNetworkError).toBe(false);
+        expect(isApiNetworkError(apiError)).toBe(false);
       }
     });
 

--- a/__tests__/services/apiFactory.test.ts
+++ b/__tests__/services/apiFactory.test.ts
@@ -21,7 +21,10 @@ describe("apiFactory", () => {
       // with no `response` field on the error.
       const noResponseAdapter: AxiosAdapter = () =>
         Promise.reject(
-          Object.assign(new Error("Network Error"), { response: undefined }),
+          Object.assign(new Error("Network Error"), {
+            isAxiosError: true,
+            response: undefined,
+          }),
         );
 
       try {
@@ -47,6 +50,7 @@ describe("apiFactory", () => {
       const timeoutAdapter: AxiosAdapter = () =>
         Promise.reject(
           Object.assign(new Error("timeout of 15000ms exceeded"), {
+            isAxiosError: true,
             code: "ECONNABORTED",
             response: undefined,
           }),

--- a/__tests__/services/apiFactory.test.ts
+++ b/__tests__/services/apiFactory.test.ts
@@ -1,7 +1,90 @@
 /* eslint-disable @fnando/consistent-import/consistent-import */
-import { ApiError, isApiNetworkError } from "services/apiFactory";
+import { AxiosAdapter } from "axios";
+import {
+  ApiError,
+  createApiService,
+  isApiNetworkError,
+} from "services/apiFactory";
 
 describe("apiFactory", () => {
+  describe("response interceptor: error transformation contract", () => {
+    // Drives a real axios instance through the response interceptor with a
+    // custom adapter so we can assert the thrown ApiError shape that every
+    // caller in the codebase relies on (status, isNetworkError, data).
+    const driveAdapter = (adapter: AxiosAdapter) => {
+      const api = createApiService({ baseURL: "https://example.test" });
+      return api.get<unknown>("/path", { adapter });
+    };
+
+    it("no-response failures throw an ApiError with status: 0 and isNetworkError: true", async () => {
+      // Simulates offline / DNS / TLS / captive-portal: axios resolves
+      // with no `response` field on the error.
+      const noResponseAdapter: AxiosAdapter = () =>
+        Promise.reject(
+          Object.assign(new Error("Network Error"), { response: undefined }),
+        );
+
+      try {
+        await driveAdapter(noResponseAdapter);
+        fail("expected interceptor to throw");
+      } catch (caught) {
+        const apiError = caught as ApiError;
+        expect(apiError.status).toBe(0);
+        expect(apiError.isNetworkError).toBe(true);
+        expect(apiError.message).toBe("Network Error");
+        expect(isApiNetworkError(apiError)).toBe(true);
+      }
+    });
+
+    it("axios timeouts (no response) are treated as network errors (status: 0)", async () => {
+      // axios surfaces timeouts as `Error: timeout of Xms exceeded` with
+      // no `response` field - same shape as offline. Pin this so callers
+      // branching on isApiNetworkError pick up timeouts too.
+      const timeoutAdapter: AxiosAdapter = () =>
+        Promise.reject(
+          Object.assign(new Error("timeout of 15000ms exceeded"), {
+            code: "ECONNABORTED",
+            response: undefined,
+          }),
+        );
+
+      try {
+        await driveAdapter(timeoutAdapter);
+        fail("expected interceptor to throw");
+      } catch (caught) {
+        const apiError = caught as ApiError;
+        expect(apiError.status).toBe(0);
+        expect(apiError.isNetworkError).toBe(true);
+        expect(isApiNetworkError(apiError)).toBe(true);
+      }
+    });
+
+    it("backend response errors throw an ApiError preserving status + data, with isNetworkError: false", async () => {
+      // Real HTTP error responses (4xx/5xx) still need to surface as
+      // ApiError with the actual status + body so callers can branch.
+      const responseAdapter: AxiosAdapter = () =>
+        Promise.reject(
+          Object.assign(new Error("Request failed with status code 500"), {
+            response: {
+              status: 500,
+              data: { error: "boom" },
+            },
+          }),
+        );
+
+      try {
+        await driveAdapter(responseAdapter);
+        fail("expected interceptor to throw");
+      } catch (caught) {
+        const apiError = caught as ApiError;
+        expect(apiError.status).toBe(500);
+        expect(apiError.isNetworkError).toBe(false);
+        expect(apiError.data).toEqual({ error: "boom" });
+        expect(isApiNetworkError(apiError)).toBe(false);
+      }
+    });
+  });
+
   describe("isApiNetworkError", () => {
     it("matches an ApiError-shaped object with isNetworkError: true", () => {
       const networkErr: ApiError = {

--- a/__tests__/services/apiFactory.test.ts
+++ b/__tests__/services/apiFactory.test.ts
@@ -1,10 +1,20 @@
 /* eslint-disable @fnando/consistent-import/consistent-import */
 import { AxiosAdapter } from "axios";
+import { logger } from "config/logger";
 import {
   ApiError,
   createApiService,
   isApiNetworkError,
+  logApiError,
 } from "services/apiFactory";
+
+jest.mock("config/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  normalizeError: jest.fn((e) => e),
+}));
 
 describe("apiFactory", () => {
   describe("response interceptor: error transformation contract", () => {
@@ -134,6 +144,69 @@ describe("apiFactory", () => {
       expect(isApiNetworkError({ isNetworkError: 1 })).toBe(false);
       expect(isApiNetworkError({ isNetworkError: "true" })).toBe(false);
       expect(isApiNetworkError({ isNetworkError: undefined })).toBe(false);
+    });
+  });
+
+  describe("logApiError", () => {
+    const mockedLogger = logger as unknown as {
+      warn: jest.Mock;
+      error: jest.Mock;
+    };
+
+    beforeEach(() => {
+      mockedLogger.warn.mockClear();
+      mockedLogger.error.mockClear();
+    });
+
+    it("routes connectivity failures to logger.warn with the warn message", () => {
+      const networkError: ApiError = {
+        message: "Network Error",
+        status: 0,
+        isNetworkError: true,
+      };
+
+      logApiError("ctx", "warn-msg", "error-msg", networkError, { extra: 1 });
+
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        "ctx",
+        "warn-msg",
+        networkError,
+        { extra: 1 },
+      );
+      expect(mockedLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("routes real backend errors (isNetworkError: false) to logger.error with the error message", () => {
+      const backendError: ApiError = {
+        message: "Bad Request",
+        status: 400,
+        isNetworkError: false,
+        data: { result_codes: { transaction: "tx_bad_seq" } },
+      };
+
+      logApiError("ctx", "warn-msg", "error-msg", backendError);
+
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "ctx",
+        "error-msg",
+        backendError,
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("routes non-axios throws to logger.error (not misclassified as network)", () => {
+      // A bare Error has no isNetworkError flag; isApiNetworkError returns
+      // false, so logApiError should pick the error path.
+      const bareError = new Error("something blew up");
+
+      logApiError("ctx", "warn-msg", "error-msg", bareError);
+
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "ctx",
+        "error-msg",
+        bareError,
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/services/backend.test.ts
+++ b/__tests__/services/backend.test.ts
@@ -689,7 +689,13 @@ describe("Backend Service - fetchCollectibles severity split", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "backendApi.fetchCollectibles",
       expect.stringContaining("Invalid response shape"),
-      expect.objectContaining({ data: expect.anything() }),
+      // Args carry only the payload SHAPE (key names) - no values,
+      // so a malformed payload can't smuggle account IDs through
+      // breadcrumb data on opt-out users' Sentry events.
+      expect.objectContaining({
+        topLevelKeys: expect.any(Array),
+        innerKeys: expect.any(Array),
+      }),
     );
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(

--- a/__tests__/services/backend.test.ts
+++ b/__tests__/services/backend.test.ts
@@ -620,6 +620,7 @@ describe("Backend Service - fetchCollectibles severity split", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "backendApi.fetchCollectibles",
       expect.stringContaining("Network unreachable"),
+      networkError,
     );
     expect(errorSpy).not.toHaveBeenCalled();
   });

--- a/__tests__/services/backend.test.ts
+++ b/__tests__/services/backend.test.ts
@@ -1,20 +1,28 @@
 import { Networks, xdr } from "@stellar/stellar-sdk";
-import { NETWORK_URLS } from "config/constants";
+import { NETWORK_URLS, NETWORKS } from "config/constants";
+import { logger } from "config/logger";
 import {
+  fetchCollectibles,
   freighterBackendV1,
+  freighterBackendV2,
   simulateTransaction,
   submitTransaction,
   SimulateTransactionParams,
   SubmitTransactionBody,
 } from "services/backend";
 
-jest.mock("services/apiFactory", () => ({
-  createApiService: jest.fn(() => ({
-    get: jest.fn(),
-    post: jest.fn(),
-  })),
-  isRequestCanceled: jest.fn(),
-}));
+jest.mock("services/apiFactory", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const actual = jest.requireActual("services/apiFactory");
+  return {
+    ...actual,
+    createApiService: jest.fn(() => ({
+      get: jest.fn(),
+      post: jest.fn(),
+    })),
+    isRequestCanceled: jest.fn(),
+  };
+});
 
 jest.mock("config/logger", () => ({
   logger: {
@@ -570,5 +578,89 @@ describe("Backend Service - Transaction Operations", () => {
       expect(submitResult.successful).toBe(true);
       expect(mockPost).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe("Backend Service - fetchCollectibles severity split", () => {
+  let mockV2Post: jest.MockedFunction<any>;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  const params = {
+    owner: "GCMTT4N6CZ5CU7JTKDLVUCDK4JZVFQCRUVQJ7BMKYSJWCSIDG3BIW4PH",
+    contracts: [{ id: "C...", token_ids: ["abc"] }],
+    network: NETWORKS.PUBLIC,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockV2Post = freighterBackendV2.post as jest.MockedFunction<any>;
+    warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("logs warn (not error) on connectivity failures from apiFactory", async () => {
+    // apiFactory throws a plain ApiError object on no-response failures
+    // (offline, DNS, TLS, captive portal). isApiNetworkError matches that
+    // shape, so the catch should demote to logger.warn.
+    const networkError = {
+      message: "Network Error",
+      status: 0,
+      isNetworkError: true,
+    };
+    mockV2Post.mockRejectedValue(networkError);
+
+    await expect(fetchCollectibles(params)).rejects.toEqual(networkError);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "backendApi.fetchCollectibles",
+      expect.stringContaining("Network unreachable"),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs error on backend response errors (4xx/5xx)", async () => {
+    const backendError = {
+      message: "Internal Server Error",
+      status: 500,
+      isNetworkError: false,
+    };
+    mockV2Post.mockRejectedValue(backendError);
+
+    await expect(fetchCollectibles(params)).rejects.toEqual(backendError);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "backendApi.fetchCollectibles",
+      "Error fetching collectibles",
+      backendError,
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs error on malformed response (data.collections missing)", async () => {
+    // Server returned 200 but the payload is missing the expected
+    // collections field. This is a contract violation, not a
+    // connectivity failure - keep it as logger.error.
+    mockV2Post.mockResolvedValue({
+      data: { data: {} },
+      status: 200,
+      statusText: "OK",
+    });
+
+    await expect(fetchCollectibles(params)).rejects.toThrow(
+      "Invalid response from server",
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "backendApi.fetchCollectibles",
+      "Invalid response from server",
+      expect.any(Object),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/backend.test.ts
+++ b/__tests__/services/backend.test.ts
@@ -624,6 +624,31 @@ describe("Backend Service - fetchCollectibles severity split", () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
+  it("logs error (NOT warn) on axios timeouts so latency regressions stay visible in Sentry", async () => {
+    // apiFactory carves timeouts out of the isNetworkError bucket
+    // (status: 0, isNetworkError: false, message: "timeout of ...").
+    // A timeout is backend latency, not connectivity, so the
+    // fetchCollectibles catch must take the error branch - not the
+    // warn branch shared with offline events. Without this carve-out
+    // we'd silently demote slow/hung backends and lose Sentry signal
+    // for latency regressions.
+    const timeoutError = {
+      message: "timeout of 15000ms exceeded",
+      status: 0,
+      isNetworkError: false,
+    };
+    mockV2Post.mockRejectedValue(timeoutError);
+
+    await expect(fetchCollectibles(params)).rejects.toEqual(timeoutError);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "backendApi.fetchCollectibles",
+      "Error fetching collectibles",
+      timeoutError,
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it("logs error on backend response errors (4xx/5xx)", async () => {
     const backendError = {
       message: "Internal Server Error",

--- a/__tests__/services/backend.test.ts
+++ b/__tests__/services/backend.test.ts
@@ -642,10 +642,14 @@ describe("Backend Service - fetchCollectibles severity split", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("logs error on malformed response (data.collections missing)", async () => {
+  it("logs malformed response (data.collections missing) exactly once", async () => {
     // Server returned 200 but the payload is missing the expected
     // collections field. This is a contract violation, not a
-    // connectivity failure - keep it as logger.error.
+    // connectivity failure. Inner shape mismatch should ship as a
+    // warn breadcrumb (with the raw payload for inspection); the
+    // outer catch fires a single logger.error for the thrown Error.
+    // Earlier this path produced TWO Sentry events for one bad
+    // payload (inner logger.error + catch logger.error).
     mockV2Post.mockResolvedValue({
       data: { data: {} },
       status: 200,
@@ -656,11 +660,16 @@ describe("Backend Service - fetchCollectibles severity split", () => {
       "Invalid response from server",
     );
 
+    expect(warnSpy).toHaveBeenCalledWith(
+      "backendApi.fetchCollectibles",
+      expect.stringContaining("Invalid response shape"),
+      expect.objectContaining({ data: expect.anything() }),
+    );
+    expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(
       "backendApi.fetchCollectibles",
-      "Invalid response from server",
-      expect.any(Object),
+      "Error fetching collectibles",
+      expect.any(Error),
     );
-    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/storage/secureStorage.test.ts
+++ b/__tests__/services/storage/secureStorage.test.ts
@@ -69,6 +69,30 @@ describe("secureStorage interaction-not-allowed branching", () => {
       );
       expect(mockedLogger.error).not.toHaveBeenCalled();
     });
+
+    it("getItem: matches interaction-not-allowed when the rejection is a plain object (not an Error instance)", async () => {
+      // RN's bridge wraps native rejections in Error instances on the
+      // current version, but the predicate intentionally accepts any
+      // object with the matching `message` so a future bridge change
+      // (or vendor patch) that ships a plain `{ code, message }` shape
+      // still routes errSecInteractionNotAllowed to the warn path.
+      const plainObjectRejection = {
+        code: "-25308",
+        message: "User interaction is not allowed.",
+      };
+      (mockedKeychain.getGenericPassword as jest.Mock).mockRejectedValue(
+        plainObjectRejection,
+      );
+
+      const result = await storage.getItem("k");
+
+      expect(result).toBe(false);
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        "secureStorage.getItem",
+        expect.stringContaining("Keychain read blocked"),
+      );
+      expect(mockedLogger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe("write paths (always logger.error - auth-critical / security-relevant)", () => {

--- a/__tests__/services/storage/secureStorage.test.ts
+++ b/__tests__/services/storage/secureStorage.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @fnando/consistent-import/consistent-import */
+import { logger } from "config/logger";
+import * as Keychain from "react-native-keychain";
+import { createSecureStorage } from "services/storage/secureStorage";
+
+jest.mock("react-native-keychain");
+jest.mock("react-native-biometrics", () =>
+  jest.fn().mockImplementation(() => ({
+    simplePrompt: jest.fn().mockResolvedValue({ success: true }),
+  })),
+);
+
+const mockedKeychain = Keychain as jest.Mocked<typeof Keychain>;
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+const INTERACTION_ERR = new Error("User interaction is not allowed.");
+
+describe("secureStorage interaction-not-allowed branching", () => {
+  const storage = createSecureStorage("test_service");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("read paths (warn for background-restricted reads)", () => {
+    it("getItem: demotes errSecInteractionNotAllowed to logger.warn", async () => {
+      (mockedKeychain.getGenericPassword as jest.Mock).mockRejectedValue(
+        INTERACTION_ERR,
+      );
+
+      const result = await storage.getItem("k");
+
+      expect(result).toBe(false);
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        "secureStorage.getItem",
+        expect.stringContaining("Keychain read blocked"),
+      );
+      expect(mockedLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("getItem: real failures (not interaction-not-allowed) stay logger.error", async () => {
+      const realErr = new Error("Decryption failed: ...");
+      (mockedKeychain.getGenericPassword as jest.Mock).mockRejectedValue(
+        realErr,
+      );
+
+      const result = await storage.getItem("k");
+
+      expect(result).toBe(false);
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "secureStorage.getItem",
+        expect.stringContaining("Error retrieving"),
+        realErr,
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("checkIfExists: demotes errSecInteractionNotAllowed to logger.warn", async () => {
+      (mockedKeychain.hasGenericPassword as jest.Mock).mockRejectedValue(
+        INTERACTION_ERR,
+      );
+
+      const result = await storage.checkIfExists("k");
+
+      expect(result).toBe(false);
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        "secureStorage.checkIfExists",
+        expect.stringContaining("Keychain check blocked"),
+      );
+      expect(mockedLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("write paths (always logger.error - auth-critical / security-relevant)", () => {
+    it("setItem: keeps errSecInteractionNotAllowed as logger.error", async () => {
+      (mockedKeychain.setGenericPassword as jest.Mock).mockRejectedValue(
+        INTERACTION_ERR,
+      );
+
+      await expect(storage.setItem("k", "v")).rejects.toThrow(
+        "Failed to store item in keychain",
+      );
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "secureStorage.setItem",
+        expect.stringContaining("Error storing"),
+        INTERACTION_ERR,
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("remove: keeps errSecInteractionNotAllowed as logger.error", async () => {
+      (mockedKeychain.resetGenericPassword as jest.Mock).mockRejectedValue(
+        INTERACTION_ERR,
+      );
+
+      // remove() doesn't throw (cleanup failures shouldn't block flow)
+      await storage.remove("k");
+
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "secureStorage.remove",
+        expect.stringContaining("Error removing"),
+        INTERACTION_ERR,
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("clear: keeps errSecInteractionNotAllowed as logger.error", async () => {
+      (
+        mockedKeychain.getAllGenericPasswordServices as jest.Mock
+      ).mockResolvedValue(["test_service_a"]);
+      (mockedKeychain.resetGenericPassword as jest.Mock).mockRejectedValue(
+        INTERACTION_ERR,
+      );
+
+      // clear() doesn't throw (logout proceeds even on cleanup failure)
+      await storage.clear();
+
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "secureStorage.clear",
+        expect.stringContaining("Error clearing"),
+        INTERACTION_ERR,
+      );
+      expect(mockedLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services/verified-token-lists.test.ts
+++ b/__tests__/services/verified-token-lists.test.ts
@@ -22,7 +22,11 @@ describe("Verified Token Lists", () => {
     expect(verifiedTokens).toEqual(MOCK_TOKEN_LIST_RESPONSE.assets);
   });
 
-  it("logs an error when fetching a list fails", async () => {
+  it("logs an error with the URL as a structured arg (not interpolated into the message)", async () => {
+    // The URL must NOT be in the message string - interpolating it
+    // would fragment Sentry grouping into one issue per token-list
+    // URL. It belongs in the args extras, where Sentry can show it
+    // per-event without splitting the issue.
     const error = new Error("Network error");
     (mockApiService.get as jest.Mock).mockRejectedValue(error);
 
@@ -36,8 +40,9 @@ describe("Verified Token Lists", () => {
     expect(verifiedAssets).toEqual([]);
     expect(loggerSpy).toHaveBeenCalledWith(
       "fetchVerifiedTokens",
-      expect.stringContaining("Error retrieving verified tokens"),
+      "Error retrieving verified tokens from token list",
       error,
+      { url: "mock://uri" },
     );
 
     loggerSpy.mockRestore();
@@ -48,7 +53,7 @@ describe("Verified Token Lists", () => {
     // axios sees no response - offline, DNS, TLS, captive portal, etc.
     // The catch in fetchVerifiedTokens should branch on isApiNetworkError
     // and demote to logger.warn so we don't generate Sentry errors for
-    // every offline user.
+    // every offline user. URL goes in the args extras, not the message.
     const networkError = {
       message: "Network Error",
       status: 0,
@@ -67,7 +72,8 @@ describe("Verified Token Lists", () => {
     expect(verifiedAssets).toEqual([]);
     expect(warnSpy).toHaveBeenCalledWith(
       "fetchVerifiedTokens",
-      expect.stringContaining("Network unreachable"),
+      "Network unreachable for token list",
+      { url: "mock://uri" },
     );
     expect(errorSpy).not.toHaveBeenCalled();
 

--- a/__tests__/services/verified-token-lists.test.ts
+++ b/__tests__/services/verified-token-lists.test.ts
@@ -42,4 +42,36 @@ describe("Verified Token Lists", () => {
 
     loggerSpy.mockRestore();
   });
+
+  it("logs a warning (not error) when the failure is a connectivity error from apiFactory", async () => {
+    // apiFactory throws a plain ApiError object (not an Error instance) when
+    // axios sees no response - offline, DNS, TLS, captive portal, etc.
+    // The catch in fetchVerifiedTokens should branch on isApiNetworkError
+    // and demote to logger.warn so we don't generate Sentry errors for
+    // every offline user.
+    const networkError = {
+      message: "Network Error",
+      status: 0,
+      isNetworkError: true,
+    };
+    (mockApiService.get as jest.Mock).mockRejectedValue(networkError);
+
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+
+    const verifiedAssets = await fetchVerifiedTokens({
+      tokenListsApiServices: { [NETWORKS.TESTNET]: [mockApiService] },
+      network: NETWORKS.TESTNET,
+    });
+
+    expect(verifiedAssets).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "fetchVerifiedTokens",
+      expect.stringContaining("Network unreachable"),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });

--- a/__tests__/services/verified-token-lists.test.ts
+++ b/__tests__/services/verified-token-lists.test.ts
@@ -73,6 +73,7 @@ describe("Verified Token Lists", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "fetchVerifiedTokens",
       "Network unreachable for token list",
+      networkError,
       { url: "mock://uri" },
     );
     expect(errorSpy).not.toHaveBeenCalled();

--- a/docs/best-practices/error-handling.md
+++ b/docs/best-practices/error-handling.md
@@ -169,22 +169,135 @@ hasRespondedRef.current = true;
 await rejectSessionRequest({ sessionRequest, message });
 ```
 
-## Sentry Integration
+## Logger severity
 
-Sentry receives normalized errors automatically when you call `logger.error()` —
-the logger normalizes via `normalizeError()` and forwards internally. You don't
-need to call Sentry yourself.
+Each level has different Sentry behavior. Pick the one that matches the
+failure's actionability — the goal is that **anything that reaches Sentry as a
+top-level event is something an engineer should look at**.
+
+| Level            | Sentry behavior                                                                     | Use for                                                                                                  |
+| ---------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `logger.error()` | Top-level Sentry issue (`captureException`). Counts against quota. Pages on alerts. | Real bugs and load-bearing failures that need engineering action.                                        |
+| `logger.warn()`  | Sentry breadcrumb. Ships only attached to a real captured event. Zero quota cost.   | Expected-but-noteworthy conditions that provide forensic context if something downstream goes wrong.     |
+| `logger.info()`  | Console only. Never reaches Sentry.                                                 | Routine operational signal useful for local dev. Also use to protect the breadcrumb buffer in hot loops. |
+| `logger.debug()` | Console only.                                                                       | Verbose diagnostic during development.                                                                   |
+
+### Choosing the level
+
+Ask three questions in order:
+
+1. **Is this a real bug or load-bearing failure?** → `error`. Examples: 5xx
+   backend response, malformed payload, keychain write failure, feature-flag
+   fetch failure when the device is online, systemic outage detected via an
+   aggregate signal (e.g. every item in a batch fetch returned an error).
+2. **Is this expected but worth keeping as forensic context if a downstream
+   event captures?** → `warn`. Examples: connectivity failures (offline, DNS,
+   TLS), 4xx Horizon protocol rejections, keychain read blocked because the app
+   was backgrounded, pre-flight informational scan failure.
+3. **Is this routine, high-volume, or only useful in local dev?** → `info` /
+   `debug`. Examples: per-token failures inside a many-token loop (where one
+   breadcrumb per token would blow the ~100/session buffer), hash-key TTL
+   expiration, debug observations.
+
+### Patterns established in this codebase
+
+| Failure                                               | Level                                   | Why                                                                                                    |
+| ----------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Connectivity (offline, DNS, TLS, captive portal)      | `warn`                                  | Self-resolves; not actionable. Branch on `isApiNetworkError` from `services/apiFactory`.               |
+| Axios timeout (`ECONNABORTED`)                        | `error`                                 | Backend latency regression — carved out of `isApiNetworkError` so it stays visible.                    |
+| Backend 5xx                                           | `error`                                 | Real outage.                                                                                           |
+| Horizon 4xx protocol rejection                        | `warn`                                  | User-correctable (`tx_bad_seq`, `op_underfunded`). User toast + analytics handle the user-facing side. |
+| Keychain WRITE / REMOVE / CLEAR                       | `error`                                 | Security-relevant; silent failure could leave stale credentials.                                       |
+| Keychain READ blocked (`errSecInteractionNotAllowed`) | `warn`                                  | Expected when app is backgrounded or device is locked.                                                 |
+| Per-item failure inside a hot loop                    | `info`                                  | Volume control — breadcrumb buffer cap is ~100/session.                                                |
+| Per-collection failure (aggregate)                    | `warn` per-item + `error` when ALL fail | Surface systemic outage as one event; keep per-item context as breadcrumbs.                            |
+| User-typo validation failure                          | `warn` at source                        | Not a bug; expected user input. Some are also filtered in `beforeSend`.                                |
+| Auth state guard ("Attempted access in LOCKED state") | `warn`                                  | Recoverable; security-relevant signal but not actionable.                                              |
+| Hash-key TTL expiration                               | `info`                                  | Expected lifecycle event.                                                                              |
+
+### Logger anti-patterns
+
+**Don't interpolate identifiers into the log message string.** PublicKeys,
+WalletConnect topics, account IDs, etc. bypass `sanitizeLogData` (which only
+walks object keys, not message text) and ship verbatim. Use structured args
+instead so the sanitizer can redact PII fields:
+
+```tsx
+// Wrong: identifier embedded in message; bypasses redaction
+logger.error("ctx", `Failed for publicKey ${publicKey}`, error);
+
+// Right: identifier in structured args; publicKey is in PII_FIELDS_LOWER
+logger.error("ctx", "Failed for account", error, { publicKey });
+```
+
+For values that aren't strict PII but shouldn't ship in full (WalletConnect
+session topics, opaque correlation IDs), truncate inline:
+
+```tsx
+logger.error("ctx", `Failed. topic: ${topic.slice(0, 8)}...`, error);
+```
+
+**Don't pass a non-Error as the third arg to `logger.error()`.** That slot is
+the captured-exception. A plain object like `{ count: 5 }` gets wrapped into a
+generic Error whose message embeds the count value, fragmenting Sentry's issue
+grouping into one issue per distinct value:
+
+```tsx
+// Wrong: { count } as captured exception → fragments by count
+logger.error("ctx", "All collections failed", { count });
+
+// Right: stable Error for grouping, structured context in args
+logger.error(
+  "ctx",
+  "All collections failed",
+  new Error("All collections failed"),
+  { count },
+);
+```
+
+**Don't double-log on a single failure.** A `logger.error` inside a `try`
+followed by another `logger.error` in the surrounding `catch` produces two
+Sentry events for one failure:
+
+```tsx
+// Wrong: 2 Sentry events for 1 bad payload
+try {
+  if (malformed) {
+    logger.error("ctx", "Invalid response", data);
+    throw new Error("Invalid response");
+  }
+} catch (err) {
+  logger.error("ctx", "Failed", err); // ← duplicates the inner log
+}
+
+// Right: warn for inner context (breadcrumb only), error only in the catch
+try {
+  if (malformed) {
+    logger.warn("ctx", "Invalid response", { data });
+    throw new Error("Invalid response");
+  }
+} catch (err) {
+  logger.error("ctx", "Failed", err);
+}
+```
+
+**Don't wrap every catch in `logger.error`.** Many catches are routine lifecycle
+(offline, biometric cancelled, hash key expired) — those want `warn` or `info`.
+`error` is for failures that need engineering action.
 
 ## Rules
 
-- **Never** use empty catch blocks. Always handle or log the error.
-- **Never** silently swallow errors. At minimum, log with `logger.error()`.
-- **Never** show generic "Something went wrong" without additional context.
-  Include what operation failed.
+- **Avoid** silently swallowing errors (including empty catch blocks). Default
+  to logging at the appropriate severity (see the table above) — `info` for
+  routine lifecycle, `warn` for forensic context, `error` for failures that need
+  engineering action.
+- **Avoid** generic "Something went wrong" messages. Include what operation
+  failed unless surfacing the underlying detail would expose internals or
+  confuse the user.
 - **Never** use `Alert.alert()` — surface errors via toasts and confirmations
   via bottom sheets.
 - **Never** call `Sentry.captureException()` directly — go through
   `logger.error()` so the context tag and normalization are consistent.
-- **Be selective about what reaches Sentry.** Validation failures, user
-  cancellations, and expected network failures (timeouts, offline) are noise.
-  Reserve Sentry for unexpected errors and bugs that need engineering action.
+- **Be selective about what reaches Sentry.** Anything that reaches Sentry as a
+  top-level event should be actionable. Use the severity table above; default to
+  `warn` if you're unsure (forensic context without quota cost).

--- a/docs/best-practices/error-handling.md
+++ b/docs/best-practices/error-handling.md
@@ -175,12 +175,12 @@ Each level has different Sentry behavior. Pick the one that matches the
 failure's actionability — the goal is that **anything that reaches Sentry as a
 top-level event is something an engineer should look at**.
 
-| Level            | Sentry behavior                                                                     | Use for                                                                                                  |
-| ---------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `logger.error()` | Top-level Sentry issue (`captureException`). Counts against quota. Pages on alerts. | Real bugs and load-bearing failures that need engineering action.                                        |
-| `logger.warn()`  | Sentry breadcrumb. Ships only attached to a real captured event. Zero quota cost.   | Expected-but-noteworthy conditions that provide forensic context if something downstream goes wrong.     |
-| `logger.info()`  | Console only. Never reaches Sentry.                                                 | Routine operational signal useful for local dev. Also use to protect the breadcrumb buffer in hot loops. |
-| `logger.debug()` | Console only.                                                                       | Verbose diagnostic during development.                                                                   |
+| Level            | Sentry behavior                                                                                        | Use for                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `logger.error()` | Top-level Sentry issue (`captureException`). Counts against quota. Pages on alerts.                    | Real bugs and load-bearing failures that need engineering action.                                        |
+| `logger.warn()`  | Sentry breadcrumb. Ships only attached to a real captured event. Zero quota cost.                      | Expected-but-noteworthy conditions that provide forensic context if something downstream goes wrong.     |
+| `logger.info()`  | Dev-only console output. **No-op in production builds** (the production Sentry adapter discards them). | Routine operational signal useful for local dev. Also use to protect the breadcrumb buffer in hot loops. |
+| `logger.debug()` | Dev-only console output. **No-op in production builds.**                                               | Verbose diagnostic during development.                                                                   |
 
 ### Choosing the level
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -139,6 +139,8 @@ jest.mock("config/logger", () => ({
     warn: jest.fn(),
     debug: jest.fn(),
   },
+  MAX_RECURSIVE_DEPTH: 8,
+  MAX_DEPTH_SENTINEL: "[MAX_DEPTH_EXCEEDED]",
 }));
 
 jest.mock("react-native-scrypt", () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -41,11 +41,15 @@ export const App = (): React.JSX.Element => {
     const initSentry = async () => {
       initializeSentry();
 
+      // Switch the logger to its Sentry-aware adapter before any
+      // subsequent async work. Otherwise warn / error calls fired
+      // during getUserId / setUser run on the default consoleAdapter
+      // and produce no breadcrumb or captured event in production.
+      initializeSentryLogger();
+
       const userId = await getUserId();
 
       Sentry.setUser({ id: userId });
-
-      initializeSentryLogger();
     };
 
     initSentry();

--- a/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
+++ b/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
@@ -65,7 +65,8 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
       try {
         webViewInstance.clearCache?.(false); // false = preserve cookies
       } catch (error) {
-        logger.warn("WebViewContainer", "Failed to clear WebView cache", error);
+        // Best-effort cleanup, not actionable for downstream errors.
+        logger.info("WebViewContainer", "Failed to clear WebView cache", error);
       }
     };
 
@@ -117,7 +118,10 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
             webViewInstance.clearCache?.(true); // true = clear everything including cookies
             webViewInstance.clearHistory?.();
           } catch (error) {
-            logger.warn(
+            // Disposal race - same family as the screenshot capture
+            // failures (the WebView may have already been unmounted).
+            // Not actionable for downstream errors.
+            logger.info(
               "WebViewContainer",
               `Failed to dispose WebView for tab ${tabId}`,
               error,

--- a/src/components/screens/SignTransactionDetails/components/Operations.tsx
+++ b/src/components/screens/SignTransactionDetails/components/Operations.tsx
@@ -101,11 +101,10 @@ const RenderOperationByType = ({ operation }: { operation: Operation }) => {
     // still proceeds with sign. Wrap to avoid an unhandled promise rejection
     // bubbling to the global handler (mechanism=onunhandledrejection).
     scanOperationTokens().catch((error) => {
-      logger.warn(
-        "Operations",
-        "Pre-flight token scan failed",
-        error instanceof Error ? error.message : String(error),
-      );
+      // Pass the Error through directly - sanitizeLogData extracts
+      // name/message/stack so the breadcrumb keeps the full
+      // diagnostic instead of just the message string.
+      logger.warn("Operations", "Pre-flight token scan failed", error);
     });
   }, [type, networkDetails.network, operation]);
 
@@ -1087,11 +1086,10 @@ const RenderOperationArgsByType = ({ operation }: { operation: Operation }) => {
     // still proceeds with sign. Wrap to avoid an unhandled promise rejection
     // bubbling to the global handler (mechanism=onunhandledrejection).
     scanOperationTokens().catch((error) => {
-      logger.warn(
-        "Operations",
-        "Pre-flight token scan failed",
-        error instanceof Error ? error.message : String(error),
-      );
+      // Pass the Error through directly - sanitizeLogData extracts
+      // name/message/stack so the breadcrumb keeps the full
+      // diagnostic instead of just the message string.
+      logger.warn("Operations", "Pre-flight token scan failed", error);
     });
   }, [type, networkDetails.network, operation]);
 

--- a/src/components/screens/SignTransactionDetails/components/Operations.tsx
+++ b/src/components/screens/SignTransactionDetails/components/Operations.tsx
@@ -21,6 +21,7 @@ import {
   OPERATION_TYPES,
   VISUAL_DELAY_MS,
 } from "config/constants";
+import { logger } from "config/logger";
 import { useAuthenticationStore } from "ducks/auth";
 import { formatTokenForDisplay, formatFiatAmount } from "helpers/formatAmount";
 import { getCreateContractArgs } from "helpers/soroban";
@@ -96,7 +97,16 @@ const RenderOperationByType = ({ operation }: { operation: Operation }) => {
       }
     };
 
-    scanOperationTokens();
+    // Pre-flight informational scan: failures are non-fatal and the user
+    // still proceeds with sign. Wrap to avoid an unhandled promise rejection
+    // bubbling to the global handler (mechanism=onunhandledrejection).
+    scanOperationTokens().catch((error) => {
+      logger.warn(
+        "Operations",
+        "Pre-flight token scan failed",
+        error instanceof Error ? error.message : String(error),
+      );
+    });
   }, [type, networkDetails.network, operation]);
 
   switch (type) {
@@ -1073,7 +1083,16 @@ const RenderOperationArgsByType = ({ operation }: { operation: Operation }) => {
       }
     };
 
-    scanOperationTokens();
+    // Pre-flight informational scan: failures are non-fatal and the user
+    // still proceeds with sign. Wrap to avoid an unhandled promise rejection
+    // bubbling to the global handler (mechanism=onunhandledrejection).
+    scanOperationTokens().catch((error) => {
+      logger.warn(
+        "Operations",
+        "Pre-flight token scan failed",
+        error instanceof Error ? error.message : String(error),
+      );
+    });
   }, [type, networkDetails.network, operation]);
 
   switch (type) {

--- a/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
+++ b/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
@@ -188,7 +188,11 @@ export const useSwapTransaction = ({
         duration: 0,
       });
 
-      throw error;
+      // Don't rethrow - the catch fully handles the failure (toast + analytics
+      // + isProcessing reset), and SwapAmountScreen calls executeSwap()
+      // fire-and-forget without a .catch(). Rethrowing here would just
+      // produce an unhandled promise rejection at the global handler -
+      // exactly the kind of extra Sentry issue this PR is removing.
     }
   }, [
     account,

--- a/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
+++ b/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
@@ -164,9 +164,12 @@ export const useSwapTransaction = ({
     } catch (error) {
       setIsProcessing(false);
       // The inner submitTransaction / signTransaction in transactionBuilder
-      // already log the underlying failure to Sentry, so don't logger.error
-      // again here - re-logging would create duplicate Sentry events for
-      // each swap failure.
+      // is the single source of truth for logging submit failures
+      // (4xx Horizon rejections → warn breadcrumb, 5xx + non-Horizon
+      // errors → logger.error). Re-logging here would either produce
+      // duplicate Sentry events (5xx and SDK errors) or pollute
+      // breadcrumbs (4xx). The user-visible toast and analytics call
+      // below are the right places to react to the failure here.
 
       analytics.trackTransactionError({
         error: error instanceof Error ? error.message : String(error),

--- a/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
+++ b/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
@@ -163,13 +163,10 @@ export const useSwapTransaction = ({
       });
     } catch (error) {
       setIsProcessing(false);
-      // The inner submitTransaction / signTransaction in transactionBuilder
-      // is the single source of truth for logging submit failures
-      // (4xx Horizon rejections → warn breadcrumb, 5xx + non-Horizon
-      // errors → logger.error). Re-logging here would either produce
-      // duplicate Sentry events (5xx and SDK errors) or pollute
-      // breadcrumbs (4xx). The user-visible toast and analytics call
-      // below are the right places to react to the failure here.
+      // transactionBuilder.submitTransaction logs submit failures at
+      // the appropriate severity (4xx-with-result_codes → warn
+      // breadcrumb, everything else → logger.error). Re-logging here
+      // would either duplicate Sentry events or pollute breadcrumbs.
 
       analytics.trackTransactionError({
         error: error instanceof Error ? error.message : String(error),

--- a/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
+++ b/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
@@ -163,12 +163,12 @@ export const useSwapTransaction = ({
       });
     } catch (error) {
       setIsProcessing(false);
-      logger.error("SwapTransaction", "Swap failed", error);
-
-      // Debug: Log the actual error object and message
-      if (error instanceof Error) {
-        logger.error("SwapTransaction", "Error message:", error.message);
-      }
+      // No logger.error here — the inner submitTransaction / signTransaction
+      // already log the underlying failure (Horizon protocol rejections are
+      // demoted to warn there, real bugs surface as error). Re-logging here
+      // produced two extra Sentry groups per swap failure
+      // (FREIGHTER-MOBILE-RQ swap re-throw + FREIGHTER-MOBILE-RW debug log
+      // tripping the string branch of normalizeError).
 
       analytics.trackTransactionError({
         error: error instanceof Error ? error.message : String(error),

--- a/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
+++ b/src/components/screens/SwapScreen/hooks/useSwapTransaction.ts
@@ -163,12 +163,10 @@ export const useSwapTransaction = ({
       });
     } catch (error) {
       setIsProcessing(false);
-      // No logger.error here — the inner submitTransaction / signTransaction
-      // already log the underlying failure (Horizon protocol rejections are
-      // demoted to warn there, real bugs surface as error). Re-logging here
-      // produced two extra Sentry groups per swap failure
-      // (FREIGHTER-MOBILE-RQ swap re-throw + FREIGHTER-MOBILE-RW debug log
-      // tripping the string branch of normalizeError).
+      // The inner submitTransaction / signTransaction in transactionBuilder
+      // already log the underlying failure to Sentry, so don't logger.error
+      // again here - re-logging would create duplicate Sentry events for
+      // each swap failure.
 
       analytics.trackTransactionError({
         error: error instanceof Error ? error.message : String(error),
@@ -188,11 +186,10 @@ export const useSwapTransaction = ({
         duration: 0,
       });
 
-      // Don't rethrow - the catch fully handles the failure (toast + analytics
-      // + isProcessing reset), and SwapAmountScreen calls executeSwap()
-      // fire-and-forget without a .catch(). Rethrowing here would just
-      // produce an unhandled promise rejection at the global handler -
-      // exactly the kind of extra Sentry issue this PR is removing.
+      // Don't rethrow - this catch is the terminal handler (toast,
+      // analytics, isProcessing reset) and the only caller invokes
+      // executeSwap() fire-and-forget. Rethrowing would surface as an
+      // unhandled promise rejection at the global handler.
     }
   }, [
     account,

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -114,7 +114,10 @@ export const normalizeError = (error: unknown): Error => {
   // Network errors (fetch, axios, etc.)
   if ("code" in error || "status" in error || "statusCode" in error) {
     const errorObj = error as Record<string, unknown>;
-    const code = errorObj.code || errorObj.status || errorObj.statusCode;
+    // Use `??` so a numeric `status: 0` (apiFactory's "no response"
+    // sentinel) flows through as "Network error 0: ..." rather than
+    // falling through to undefined.
+    const code = errorObj.code ?? errorObj.status ?? errorObj.statusCode;
     const message =
       errorObj.message || errorObj.error || "Network request failed";
 

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -360,19 +360,36 @@ class Logger {
 export const logger = Logger.getInstance();
 
 // Common PII / secret fields to redact from logged payloads. Match
-// case-insensitively. Keep this list conservative - it's safer to
+// case-insensitively against the literal lowercased key. The list
+// includes both camelCase (frontend-shaped) and snake_case
+// (backend-shaped) variants since payloads from the Freighter
+// backend / Horizon arrive snake_case and would slip past a
+// camelCase-only list. Keep this conservative - it's safer to
 // over-redact than to leak.
+//
+// publicKey is included because, while Stellar public keys are not
+// strictly secret, this codebase deliberately gates them on the
+// analytics opt-in (see buildSentryContext in sentryConfig.ts).
+// Redacting them in logger payloads keeps that opt-out promise on
+// breadcrumbs and event extras as well as the appContext block.
 const PII_FIELDS_LOWER = [
   "email",
   "phone",
   "address",
   "name",
   "firstName",
+  "first_name",
   "lastName",
+  "last_name",
   "username",
   "userId",
+  "user_id",
   "accountId",
+  "account_id",
+  "publicKey",
+  "public_key",
   "privateKey",
+  "private_key",
   "seed",
   "mnemonic",
   "password",
@@ -381,16 +398,21 @@ const PII_FIELDS_LOWER = [
   "session",
   "ip",
   "ipAddress",
+  "ip_address",
   "location",
   "coordinates",
   "auth",
   "key",
   "apiKey",
+  "api_key",
   "secret",
   "secretKey",
+  "secret_key",
   "recovery",
   "recoveryPhrase",
+  "recovery_phrase",
   "mnemonicPhrase",
+  "mnemonic_phrase",
 ].map((f) => f.toLowerCase());
 
 const MAX_SANITIZE_DEPTH = 8;

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -460,10 +460,18 @@ const sentryAdapter: LoggerAdapter = {
     }
     const normalizedError = normalizeError(error);
 
-    // capture the error with context and sanitized extra data
+    // Include the caller-supplied `message` in the event extras so the
+    // intent isn't lost - Sentry's issue title still comes from the
+    // Error's own message (preserves grouping), but the message arg is
+    // inspectable in the event payload alongside any extra args.
+    const extra: Record<string, unknown> = { message };
+    if (args.length > 0) {
+      extra.args = sanitizeLogData(args);
+    }
+
     Sentry.captureException(normalizedError, {
       tags: { context },
-      extra: args.length > 0 ? { args: sanitizeLogData(args) } : undefined,
+      extra,
     });
   },
 };

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -385,6 +385,7 @@ const PII_FIELDS_LOWER = [
   "coordinates",
   "auth",
   "key",
+  "apiKey",
   "secret",
   "secretKey",
   "recovery",

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -390,6 +390,7 @@ const PII_FIELDS_LOWER = [
 ].map((f) => f.toLowerCase());
 
 const MAX_SANITIZE_DEPTH = 8;
+const MAX_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
 
 /**
  * Sanitize data to redact potential PII before sending to Sentry.
@@ -399,12 +400,14 @@ const MAX_SANITIZE_DEPTH = 8;
  * logger forwards a variadic argument list whose items contain
  * objects). Values are otherwise preserved.
  *
- * Bounded recursion (depth-limited) protects against malformed or
- * cyclic input structures.
+ * At the depth cap, return a sentinel string rather than the
+ * original reference so cyclic structures (e.g. obj.self = obj)
+ * can't escape into Sentry serialization and crash the breadcrumb
+ * payload.
  */
 export const sanitizeLogData = (data: unknown, depth = 0): unknown => {
   if (depth >= MAX_SANITIZE_DEPTH) {
-    return data;
+    return MAX_DEPTH_SENTINEL;
   }
 
   if (Array.isArray(data)) {

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -415,8 +415,14 @@ const PII_FIELDS_LOWER = [
   "mnemonic_phrase",
 ].map((f) => f.toLowerCase());
 
-const MAX_SANITIZE_DEPTH = 8;
-const MAX_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
+/**
+ * Shared depth cap for recursive structured-data walks (sanitization here
+ * and StrKey scrubbing in `sentryConfig.deepScrubStrKeys`). Both walks need
+ * to stop at the same point: deep enough to cover realistic payloads, but
+ * shallow enough that cyclic structures cannot escape into Sentry.
+ */
+export const MAX_RECURSIVE_DEPTH = 8;
+export const MAX_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
 
 /**
  * Sanitize data to redact potential PII before sending to Sentry.
@@ -432,7 +438,7 @@ const MAX_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
  * payload.
  */
 export const sanitizeLogData = (data: unknown, depth = 0): unknown => {
-  if (depth >= MAX_SANITIZE_DEPTH) {
+  if (depth >= MAX_RECURSIVE_DEPTH) {
     return MAX_DEPTH_SENTINEL;
   }
 

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -416,13 +416,21 @@ export const sanitizeLogData = (data: unknown): unknown => {
 const sentryAdapter: LoggerAdapter = {
   debug: () => {},
   info: () => {},
-  warn: (context: string, message: string) => {
+  warn: (context: string, message: string, ...args: unknown[]) => {
     // Skip Sentry during e2e tests
     if (isE2ETest) {
       return;
     }
-    // capture a message for warning level
-    Sentry.captureMessage(`[${context}] ${message}`, "warning");
+    // Add as a breadcrumb so the warning is attached to any subsequent
+    // captured event without creating its own top-level Sentry issue.
+    // Breadcrumbs sit in an in-memory ring buffer (default 100) and are
+    // only sent when an error/message is captured — no extra quota cost.
+    Sentry.addBreadcrumb({
+      category: context,
+      message,
+      level: "warning",
+      data: args.length > 0 ? { args: sanitizeLogData(args) } : undefined,
+    });
   },
   error: (
     context: string,

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -410,6 +410,18 @@ export const sanitizeLogData = (data: unknown, depth = 0): unknown => {
     return MAX_DEPTH_SENTINEL;
   }
 
+  // Error instances need explicit handling - `name`, `message`, and
+  // `stack` are non-enumerable per spec, so a generic `Object.entries`
+  // walk would drop them and produce `{}`. That silently strips the
+  // diagnostic detail every time a caller passes an error as a warn arg.
+  if (data instanceof Error) {
+    return {
+      name: data.name,
+      message: data.message,
+      stack: data.stack,
+    };
+  }
+
   if (Array.isArray(data)) {
     return data.map((item) => sanitizeLogData(item, depth + 1));
   }

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -356,57 +356,73 @@ class Logger {
  */
 export const logger = Logger.getInstance();
 
+// Common PII / secret fields to redact from logged payloads. Match
+// case-insensitively. Keep this list conservative - it's safer to
+// over-redact than to leak.
+const PII_FIELDS_LOWER = [
+  "email",
+  "phone",
+  "address",
+  "name",
+  "firstName",
+  "lastName",
+  "username",
+  "userId",
+  "accountId",
+  "privateKey",
+  "seed",
+  "mnemonic",
+  "password",
+  "token",
+  "jwt",
+  "session",
+  "ip",
+  "ipAddress",
+  "location",
+  "coordinates",
+  "auth",
+  "key",
+  "secret",
+  "secretKey",
+  "recovery",
+  "recoveryPhrase",
+  "mnemonicPhrase",
+].map((f) => f.toLowerCase());
+
+const MAX_SANITIZE_DEPTH = 8;
+
 /**
- * Sanitize data to remove potential PII before sending to Sentry
- * Add or remove fields on the list if necessary
+ * Sanitize data to redact potential PII before sending to Sentry.
+ *
+ * Recurses into nested objects and arrays so a key like `password`
+ * is redacted no matter how deep it is in the payload (e.g. when
+ * logger forwards a variadic argument list whose items contain
+ * objects). Values are otherwise preserved.
+ *
+ * Bounded recursion (depth-limited) protects against malformed or
+ * cyclic input structures.
  */
-export const sanitizeLogData = (data: unknown): unknown => {
+export const sanitizeLogData = (data: unknown, depth = 0): unknown => {
+  if (depth >= MAX_SANITIZE_DEPTH) {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((item) => sanitizeLogData(item, depth + 1));
+  }
+
   if (!data || typeof data !== "object") {
     return data;
   }
 
-  const sanitized = { ...(data as Record<string, unknown>) };
-
-  // Remove common PII fields
-  const piiFields = [
-    "email",
-    "phone",
-    "address",
-    "name",
-    "firstName",
-    "lastName",
-    "username",
-    "userId",
-    "accountId",
-    "privateKey",
-    "seed",
-    "mnemonic",
-    "password",
-    "token",
-    "jwt",
-    "session",
-    "ip",
-    "ipAddress",
-    "location",
-    "coordinates",
-    "auth",
-    "key",
-    "secret",
-    "secretKey",
-    "recovery",
-    "recoveryPhrase",
-    "mnemonicPhrase",
-  ];
-
-  const sanitizedKeys = Object.keys(sanitized);
-  const piiFieldsLower = piiFields.map((field) => field.toLowerCase());
-
-  sanitizedKeys.forEach((key) => {
-    if (piiFieldsLower.includes(key.toLowerCase())) {
+  const sanitized: Record<string, unknown> = {};
+  Object.entries(data as Record<string, unknown>).forEach(([key, value]) => {
+    if (PII_FIELDS_LOWER.includes(key.toLowerCase())) {
       sanitized[key] = "[REDACTED]";
+    } else {
+      sanitized[key] = sanitizeLogData(value, depth + 1);
     }
   });
-
   return sanitized;
 };
 

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -60,11 +60,11 @@ export const PASSWORD_TYPO_MESSAGES = [
  * length. The pattern is anchored on word boundaries so a 56-char
  * substring inside a longer alphanumeric run does not match.
  *
- * Anything matching this pattern is scrubbed from event message
- * surfaces in `beforeSend` (event.message, exception values,
- * extras.message) so identifiers that get interpolated into log
- * messages or embedded in thrown Error.message strings cannot
- * leak verbatim to Sentry.
+ * Anything matching this pattern is scrubbed in `beforeSend` from
+ * event.message, exception values, and recursively from the entire
+ * `event.extra` subtree and breadcrumb data — so identifiers that
+ * get interpolated into log messages or embedded in thrown
+ * Error.message strings cannot leak verbatim to Sentry.
  *
  * Object-key redaction (sanitizeLogData with PII_FIELDS_LOWER)
  * handles structured payloads. This pattern handles raw strings

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -187,7 +187,7 @@ export const initializeSentry = (): void => {
         Sentry.addBreadcrumb({
           category: "user-input-validation",
           message: noiseMessage,
-          level: "info",
+          level: "warning",
         });
         return null;
       }
@@ -204,7 +204,7 @@ export const initializeSentry = (): void => {
         Sentry.addBreadcrumb({
           category: "biometric-state",
           message: noiseMessage,
-          level: "info",
+          level: "warning",
         });
         return null;
       }

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -170,17 +170,6 @@ export const initializeSentry = (): void => {
         return null;
       }
 
-      // Mobile network timeouts - expected on poor connections
-      // (FREIGHTER-MOBILE-BM and similar).
-      if (/timeout of \d+ms exceeded/.test(noiseMessage)) {
-        Sentry.addBreadcrumb({
-          category: "network-timeout",
-          message: noiseMessage,
-          level: "info",
-        });
-        return null;
-      }
-
       // Recoverable biometric state mismatch - the user enabled
       // biometrics but the keychain entry is missing (e.g. cleared by
       // OS, app reinstall). User can re-enter password and re-enable

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -117,6 +117,90 @@ export const initializeSentry = (): void => {
     appHangTimeoutInterval: 5,
 
     beforeSend(event) {
+      // Drop / downgrade known-noise patterns at the gate before any PII
+      // scrubbing or context updates. Keep this list small and specific —
+      // each entry should describe a known noise source documented in
+      // #814's noise-filter analysis. Source-level fixes are preferred
+      // over filtering here; these are the residual patterns that we
+      // can't easily fix at the source (third-party libraries, native
+      // events, user-initiated cancellations).
+      const noiseMessage =
+        event.message || event.exception?.values?.[0]?.value || "";
+
+      // ---- Drop entirely (no diagnostic value) ----
+
+      // WalletConnect session lifecycle - the SDK throws when looking up
+      // a record that has just been cleaned up. Normal lifecycle, not a
+      // bug (FREIGHTER-MOBILE-DM / 2Q / FM, ~14K events).
+      if (noiseMessage.includes("Record was recently deleted")) return null;
+
+      // User-initiated biometric / auth cancellations on iOS. The user
+      // pressed Cancel, switched away, the system invalidated the prompt,
+      // or retry-limit hit. Not bugs (FREIGHTER-MOBILE-14 / FA / BZ / HS /
+      // T8 / TQ / T1, ~370 events).
+      if (
+        noiseMessage.includes("com.apple.LocalAuthentication") &&
+        /Code=(-4|-1003|-1004|6)\b/.test(noiseMessage)
+      ) {
+        return null;
+      }
+
+      // Android biometric cancellations. Same family, different vendor
+      // wording (FREIGHTER-MOBILE-AW / MR / MM / MB / TR, ~50 events).
+      if (/Fingerprint operation canc(elled|eled)/i.test(noiseMessage)) {
+        return null;
+      }
+      if (noiseMessage.includes("지문 인식 작업이 취소되었습니다")) {
+        return null;
+      }
+
+      // ---- Downgrade to breadcrumb (keep for context, no new issue) ----
+      // Sentry has no built-in "convert event to breadcrumb" - we add a
+      // breadcrumb for any subsequent event in the same session and drop
+      // the current one.
+
+      // User typed a wrong mnemonic / password - handled errors from user
+      // input, not bugs (FREIGHTER-MOBILE-Q / 3H, ~5K events).
+      if (
+        noiseMessage.includes("Invalid mnemonic") ||
+        noiseMessage.includes("Invalid password")
+      ) {
+        Sentry.addBreadcrumb({
+          category: "user-input-validation",
+          message: noiseMessage,
+          level: "info",
+        });
+        return null;
+      }
+
+      // Mobile network timeouts - expected on poor connections
+      // (FREIGHTER-MOBILE-BM and similar).
+      if (/timeout of \d+ms exceeded/.test(noiseMessage)) {
+        Sentry.addBreadcrumb({
+          category: "network-timeout",
+          message: noiseMessage,
+          level: "info",
+        });
+        return null;
+      }
+
+      // Recoverable biometric state mismatch - the user enabled
+      // biometrics but the keychain entry is missing (e.g. cleared by
+      // OS, app reinstall). User can re-enter password and re-enable
+      // (FREIGHTER-MOBILE-13, ~1K events).
+      if (
+        noiseMessage.includes(
+          "No stored password found for biometric authentication",
+        )
+      ) {
+        Sentry.addBreadcrumb({
+          category: "biometric-state",
+          message: noiseMessage,
+          level: "info",
+        });
+        return null;
+      }
+
       // Update context on each event to ensure freshness
       Sentry.setContext("appContext", buildSentryContext());
 

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -152,12 +152,12 @@ export const initializeSentry = (): void => {
       // breadcrumb for any subsequent event in the same session and drop
       // the current one.
 
-      // User typed a wrong mnemonic / password - handled errors from
-      // user input, not bugs.
-      if (
-        noiseMessage.includes("Invalid mnemonic") ||
-        noiseMessage.includes("Invalid password")
-      ) {
+      // User typed a wrong password - handled error from user input,
+      // not a bug. The mnemonic case is handled at source
+      // (verifyMnemonicPhrase logs at warn), so any "Invalid mnemonic"
+      // event reaching here is from a post-validation path (e.g.
+      // corrupted stored mnemonic) and should pass through.
+      if (noiseMessage.includes("Invalid password")) {
         Sentry.addBreadcrumb({
           category: "user-input-validation",
           message: noiseMessage,

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -28,6 +28,33 @@ export const SENTRY_CONFIG = {
 } as const;
 
 /**
+ * User-typo password messages we downgrade in `beforeSend`.
+ *
+ * A cleaner long-term fix would be at source: `useAuthenticationStore.signIn`
+ * (`ducks/auth.ts`) rethrows on wrong-password and the LockScreen caller
+ * is fire-and-forget, so the rejection ends up at Sentry's global
+ * handler. Removing that rethrow (or having LockScreen catch it) would
+ * stop the events from ever reaching Sentry. We don't do that here
+ * because changing the action's throw contract risks affecting other
+ * auth flows (biometric login, settings password gates, re-auth) and
+ * wants its own focused review. This filter is a contained workaround
+ * until the long-term fix is implemented.
+ *
+ * Kept as exact strings (not substrings) because a substring match on
+ * "Invalid password" would also catch "Invalid password or corrupted
+ * data." from `helpers/encryptPassword.ts`, which is a real corruption
+ * signal, not a user typo.
+ *
+ * The corresponding `sentryConfig.test.ts` block asserts these stay in
+ * sync with the i18n source so a copy change in `translations.json`
+ * will trip the test rather than silently disabling the filter.
+ */
+export const PASSWORD_TYPO_MESSAGES = [
+  "Invalid password. Please try again.",
+  "Senha inválida. Por favor, tente novamente.",
+];
+
+/**
  * Builds common context data for Sentry events (similar to analytics).
  *
  * When analytics are enabled: Full context including connectivity info and public key
@@ -152,12 +179,11 @@ export const initializeSentry = (): void => {
       // breadcrumb for any subsequent event in the same session and drop
       // the current one.
 
-      // User typed a wrong password - handled error from user input,
-      // not a bug. The mnemonic case is handled at source
-      // (verifyMnemonicPhrase logs at warn), so any "Invalid mnemonic"
-      // event reaching here is from a post-validation path (e.g.
-      // corrupted stored mnemonic) and should pass through.
-      if (noiseMessage.includes("Invalid password")) {
+      // User typed a wrong password - see PASSWORD_TYPO_MESSAGES above
+      // for the source-fix tradeoff. Match against exact strings to
+      // avoid catching neighbouring messages like "Invalid password or
+      // corrupted data." (a real corruption signal).
+      if (PASSWORD_TYPO_MESSAGES.includes(noiseMessage)) {
         Sentry.addBreadcrumb({
           category: "user-input-validation",
           message: noiseMessage,

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -30,6 +30,19 @@ export const SENTRY_CONFIG = {
 } as const;
 
 /**
+ * Centralized registry of breadcrumb categories used by `Sentry.addBreadcrumb`
+ * call sites in this file.
+ *
+ * Note: the `sentryAdapter.warn` path in `logger.ts` uses the caller-supplied
+ * `context` argument as the breadcrumb category and is intentionally not
+ * enumerated here (callers can pick any module-scoped name).
+ */
+export const SENTRY_BREADCRUMB_CATEGORIES = {
+  USER_INPUT_VALIDATION: "user-input-validation",
+  BIOMETRIC_STATE: "biometric-state",
+} as const;
+
+/**
  * User-typo password messages we downgrade in `beforeSend`.
  *
  * A cleaner long-term fix would be at source: `useAuthenticationStore.signIn`
@@ -244,7 +257,7 @@ export const initializeSentry = (): void => {
       // corrupted data." (a real corruption signal).
       if (PASSWORD_TYPO_MESSAGES.includes(noiseMessage)) {
         Sentry.addBreadcrumb({
-          category: "user-input-validation",
+          category: SENTRY_BREADCRUMB_CATEGORIES.USER_INPUT_VALIDATION,
           message: noiseMessage,
           level: "warning",
         });
@@ -261,7 +274,7 @@ export const initializeSentry = (): void => {
         )
       ) {
         Sentry.addBreadcrumb({
-          category: "biometric-state",
+          category: SENTRY_BREADCRUMB_CATEGORIES.BIOMETRIC_STATE,
           message: noiseMessage,
           level: "warning",
         });

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -81,6 +81,39 @@ const STELLAR_STRKEY_PATTERN = /\b[GS][A-Z2-7]{55}\b/g;
 export const scrubStrKeys = (s: string | undefined): string | undefined =>
   s?.replace(STELLAR_STRKEY_PATTERN, (match) => `${match[0]}***`);
 
+const MAX_DEEP_SCRUB_DEPTH = 8;
+
+/**
+ * Recursively walk a structured value and scrub Stellar StrKeys from
+ * every string descendant. Used to defend against StrKeys embedded in
+ * structured payloads (event.extra.args, breadcrumb data) where field
+ * names alone can't predict every leak surface — e.g. a backend
+ * response with `owner` / `from` / `recipient` fields holding
+ * account IDs.
+ *
+ * Bounded recursion (depth cap) protects against malformed or
+ * cyclic input.
+ */
+const deepScrubStrKeys = (data: unknown, depth = 0): unknown => {
+  if (depth >= MAX_DEEP_SCRUB_DEPTH) {
+    return data;
+  }
+  if (typeof data === "string") {
+    return scrubStrKeys(data);
+  }
+  if (Array.isArray(data)) {
+    return data.map((item) => deepScrubStrKeys(item, depth + 1));
+  }
+  if (data && typeof data === "object") {
+    const out: Record<string, unknown> = {};
+    Object.entries(data as Record<string, unknown>).forEach(([k, v]) => {
+      out[k] = deepScrubStrKeys(v, depth + 1);
+    });
+    return out;
+  }
+  return data;
+};
+
 /**
  * Builds common context data for Sentry events (similar to analytics).
  *
@@ -260,7 +293,7 @@ export const initializeSentry = (): void => {
       // may have been interpolated into log messages or embedded in
       // thrown Error.message strings (libraries we don't control,
       // future regressions in our own code). Object-key redaction
-      // already covers structured payloads; this catches the raw
+      // already covers known PII fields; this catches the raw
       // string surfaces it can't reach.
       if (typeof event.message === "string") {
         // eslint-disable-next-line no-param-reassign
@@ -270,10 +303,21 @@ export const initializeSentry = (): void => {
         // eslint-disable-next-line no-param-reassign
         v.value = scrubStrKeys(v.value);
       });
-      if (event.extra && typeof event.extra.message === "string") {
+      // Deep-scrub structured payloads: event.extra (logger.error
+      // extras) and breadcrumb data (logger.warn args). Catches
+      // StrKeys nested in fields that aren't in PII_FIELDS_LOWER -
+      // e.g. backend response shapes with `owner` / `from` /
+      // `recipient` holding account IDs.
+      if (event.extra) {
         // eslint-disable-next-line no-param-reassign
-        event.extra.message = scrubStrKeys(event.extra.message);
+        event.extra = deepScrubStrKeys(event.extra) as Record<string, unknown>;
       }
+      event.breadcrumbs?.forEach((bc) => {
+        if (bc.data) {
+          // eslint-disable-next-line no-param-reassign
+          bc.data = deepScrubStrKeys(bc.data) as Record<string, unknown>;
+        }
+      });
 
       return event;
     },

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -146,11 +146,8 @@ export const initializeSentry = (): void => {
       }
 
       // Android biometric cancellations. Same family, different vendor
-      // wording (FREIGHTER-MOBILE-AW / MR / MM / MB / TR, ~50 events).
+      // wording (FREIGHTER-MOBILE-AW / MR / MM / MB, ~50 events).
       if (/Fingerprint operation canc(elled|eled)/i.test(noiseMessage)) {
-        return null;
-      }
-      if (noiseMessage.includes("지문 인식 작업이 취소되었습니다")) {
         return null;
       }
 

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -55,6 +55,33 @@ export const PASSWORD_TYPO_MESSAGES = [
 ];
 
 /**
+ * Stellar StrKey identifiers (publicKeys `G...` and secret seeds
+ * `S...`) are base32-encoded with a fixed prefix and exact 56-char
+ * length. The pattern is anchored on word boundaries so a 56-char
+ * substring inside a longer alphanumeric run does not match.
+ *
+ * Anything matching this pattern is scrubbed from event message
+ * surfaces in `beforeSend` (event.message, exception values,
+ * extras.message) so identifiers that get interpolated into log
+ * messages or embedded in thrown Error.message strings cannot
+ * leak verbatim to Sentry.
+ *
+ * Object-key redaction (sanitizeLogData with PII_FIELDS_LOWER)
+ * handles structured payloads. This pattern handles raw strings
+ * the key-based redactor can't reach.
+ */
+const STELLAR_STRKEY_PATTERN = /\b[GS][A-Z2-7]{55}\b/g;
+
+/**
+ * Replace any embedded Stellar StrKey with a short prefix sentinel
+ * ("G***" / "S***"). Preserves the prefix so triage can still
+ * distinguish a publicKey leak from a secret-seed leak (the latter
+ * is a critical bug — secrets should never reach this code path).
+ */
+export const scrubStrKeys = (s: string | undefined): string | undefined =>
+  s?.replace(STELLAR_STRKEY_PATTERN, (match) => `${match[0]}***`);
+
+/**
  * Builds common context data for Sentry events (similar to analytics).
  *
  * When analytics are enabled: Full context including connectivity info and public key
@@ -227,6 +254,25 @@ export const initializeSentry = (): void => {
 
         // eslint-disable-next-line no-param-reassign
         event.contexts.appContext = minimalContext;
+      }
+
+      // Defense-in-depth scrub for Stellar StrKey identifiers that
+      // may have been interpolated into log messages or embedded in
+      // thrown Error.message strings (libraries we don't control,
+      // future regressions in our own code). Object-key redaction
+      // already covers structured payloads; this catches the raw
+      // string surfaces it can't reach.
+      if (typeof event.message === "string") {
+        // eslint-disable-next-line no-param-reassign
+        event.message = scrubStrKeys(event.message);
+      }
+      event.exception?.values?.forEach((v) => {
+        // eslint-disable-next-line no-param-reassign
+        v.value = scrubStrKeys(v.value);
+      });
+      if (event.extra && typeof event.extra.message === "string") {
+        // eslint-disable-next-line no-param-reassign
+        event.extra.message = scrubStrKeys(event.extra.message);
       }
 
       return event;

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -107,37 +107,33 @@ export const initializeSentry = (): void => {
     // Performance monitoring - equivalent to browserTracingIntegration
     tracesSampleRate: 1.0,
 
-    // iOS-only main-thread monitor. Default is 2 seconds, which catches
-    // a lot of natural transition stalls (clipboard reads via
+    // iOS-only main-thread monitor. The default of 2 seconds catches a
+    // lot of natural transition stalls (clipboard reads via
     // RNCClipboard.getString, GPU shader compilation on cold start,
     // Fabric mount work) that aren't actionable bugs in our code.
-    // 5 seconds keeps the genuinely-bad hangs visible while dropping
-    // the bulk of the noise (FREIGHTER-MOBILE-4A / Q5 / TF / T7,
-    // ~244 events / ~65 users).
+    // 5 seconds keeps the genuinely-bad hangs visible while skipping
+    // those routine stalls.
     appHangTimeoutInterval: 5,
 
     beforeSend(event) {
-      // Drop / downgrade known-noise patterns at the gate before any PII
-      // scrubbing or context updates. Keep this list small and specific —
-      // each entry should describe a known noise source documented in
-      // #814's noise-filter analysis. Source-level fixes are preferred
-      // over filtering here; these are the residual patterns that we
-      // can't easily fix at the source (third-party libraries, native
-      // events, user-initiated cancellations).
+      // Drop or downgrade known-noise patterns before any PII scrubbing
+      // or context updates. Each entry should describe a noise source
+      // we've seen in production (third-party SDK quirks, native auth
+      // cancellations, user-typed validation failures). Prefer fixing
+      // at the source over adding entries here.
       const noiseMessage =
         event.message || event.exception?.values?.[0]?.value || "";
 
       // ---- Drop entirely (no diagnostic value) ----
 
-      // WalletConnect session lifecycle - the SDK throws when looking up
+      // WalletConnect session lifecycle: the SDK throws when looking up
       // a record that has just been cleaned up. Normal lifecycle, not a
-      // bug (FREIGHTER-MOBILE-DM / 2Q / FM, ~14K events).
+      // bug.
       if (noiseMessage.includes("Record was recently deleted")) return null;
 
       // User-initiated biometric / auth cancellations on iOS. The user
       // pressed Cancel, switched away, the system invalidated the prompt,
-      // or retry-limit hit. Not bugs (FREIGHTER-MOBILE-14 / FA / BZ / HS /
-      // T8 / TQ / T1, ~370 events).
+      // or retry-limit hit. Not bugs.
       if (
         noiseMessage.includes("com.apple.LocalAuthentication") &&
         /Code=(-4|-1003|-1004|6)\b/.test(noiseMessage)
@@ -145,19 +141,19 @@ export const initializeSentry = (): void => {
         return null;
       }
 
-      // Android biometric cancellations. Same family, different vendor
-      // wording (FREIGHTER-MOBILE-AW / MR / MM / MB, ~50 events).
+      // Android biometric cancellations - same family, different vendor
+      // wording.
       if (/Fingerprint operation canc(elled|eled)/i.test(noiseMessage)) {
         return null;
       }
 
       // ---- Downgrade to breadcrumb (keep for context, no new issue) ----
-      // Sentry has no built-in "convert event to breadcrumb" - we add a
+      // Sentry has no built-in "convert event to breadcrumb" so we add a
       // breadcrumb for any subsequent event in the same session and drop
       // the current one.
 
-      // User typed a wrong mnemonic / password - handled errors from user
-      // input, not bugs (FREIGHTER-MOBILE-Q / 3H, ~5K events).
+      // User typed a wrong mnemonic / password - handled errors from
+      // user input, not bugs.
       if (
         noiseMessage.includes("Invalid mnemonic") ||
         noiseMessage.includes("Invalid password")
@@ -170,10 +166,10 @@ export const initializeSentry = (): void => {
         return null;
       }
 
-      // Recoverable biometric state mismatch - the user enabled
+      // Recoverable biometric state mismatch: the user enabled
       // biometrics but the keychain entry is missing (e.g. cleared by
-      // OS, app reinstall). User can re-enter password and re-enable
-      // (FREIGHTER-MOBILE-13, ~1K events).
+      // OS, app reinstall). User can re-enter their password and
+      // re-enable biometrics, so this is recoverable.
       if (
         noiseMessage.includes(
           "No stored password found for biometric authentication",

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -107,6 +107,15 @@ export const initializeSentry = (): void => {
     // Performance monitoring - equivalent to browserTracingIntegration
     tracesSampleRate: 1.0,
 
+    // iOS-only main-thread monitor. Default is 2 seconds, which catches
+    // a lot of natural transition stalls (clipboard reads via
+    // RNCClipboard.getString, GPU shader compilation on cold start,
+    // Fabric mount work) that aren't actionable bugs in our code.
+    // 5 seconds keeps the genuinely-bad hangs visible while dropping
+    // the bulk of the noise (FREIGHTER-MOBILE-4A / Q5 / TF / T7,
+    // ~244 events / ~65 users).
+    appHangTimeoutInterval: 5,
+
     beforeSend(event) {
       // Update context on each event to ensure freshness
       Sentry.setContext("appContext", buildSentryContext());

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -82,6 +82,7 @@ export const scrubStrKeys = (s: string | undefined): string | undefined =>
   s?.replace(STELLAR_STRKEY_PATTERN, (match) => `${match[0]}***`);
 
 const MAX_DEEP_SCRUB_DEPTH = 8;
+const DEEP_SCRUB_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
 
 /**
  * Recursively walk a structured value and scrub Stellar StrKeys from
@@ -91,12 +92,13 @@ const MAX_DEEP_SCRUB_DEPTH = 8;
  * response with `owner` / `from` / `recipient` fields holding
  * account IDs.
  *
- * Bounded recursion (depth cap) protects against malformed or
- * cyclic input.
+ * At the depth cap, return a sentinel string instead of the original
+ * subtree so cyclic structures cannot escape into the Sentry payload
+ * and StrKeys nested past the cap cannot leak unscrubbed.
  */
 const deepScrubStrKeys = (data: unknown, depth = 0): unknown => {
   if (depth >= MAX_DEEP_SCRUB_DEPTH) {
-    return data;
+    return DEEP_SCRUB_DEPTH_SENTINEL;
   }
   if (typeof data === "string") {
     return scrubStrKeys(data);

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react-native";
 import { EnvConfig } from "config/envConfig";
+import { MAX_DEPTH_SENTINEL, MAX_RECURSIVE_DEPTH } from "config/logger";
 import { useAnalyticsStore } from "ducks/analytics";
 import { useAuthenticationStore } from "ducks/auth";
 import { useNetworkStore } from "ducks/networkInfo";
@@ -91,9 +92,6 @@ const STELLAR_STRKEY_PATTERN = /\b[GS][A-Z2-7]{55}\b/g;
 export const scrubStrKeys = (s: string | undefined): string | undefined =>
   s?.replace(STELLAR_STRKEY_PATTERN, (match) => `${match[0]}***`);
 
-const MAX_DEEP_SCRUB_DEPTH = 8;
-const DEEP_SCRUB_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
-
 /**
  * Recursively walk a structured value and scrub Stellar StrKeys from
  * every string descendant. Used to defend against StrKeys embedded in
@@ -107,8 +105,8 @@ const DEEP_SCRUB_DEPTH_SENTINEL = "[MAX_DEPTH_EXCEEDED]";
  * and StrKeys nested past the cap cannot leak unscrubbed.
  */
 const deepScrubStrKeys = (data: unknown, depth = 0): unknown => {
-  if (depth >= MAX_DEEP_SCRUB_DEPTH) {
-    return DEEP_SCRUB_DEPTH_SENTINEL;
+  if (depth >= MAX_RECURSIVE_DEPTH) {
+    return MAX_DEPTH_SENTINEL;
   }
   if (typeof data === "string") {
     return scrubStrKeys(data);

--- a/src/config/sentryConfig.ts
+++ b/src/config/sentryConfig.ts
@@ -4,6 +4,8 @@ import { useAnalyticsStore } from "ducks/analytics";
 import { useAuthenticationStore } from "ducks/auth";
 import { useNetworkStore } from "ducks/networkInfo";
 import { isProd, isE2ETest } from "helpers/isEnv";
+import enTranslations from "i18n/locales/en/translations.json";
+import ptTranslations from "i18n/locales/pt/translations.json";
 import { Platform } from "react-native";
 import {
   getVersion,
@@ -40,18 +42,13 @@ export const SENTRY_CONFIG = {
  * wants its own focused review. This filter is a contained workaround
  * until the long-term fix is implemented.
  *
- * Kept as exact strings (not substrings) because a substring match on
- * "Invalid password" would also catch "Invalid password or corrupted
- * data." from `helpers/encryptPassword.ts`, which is a real corruption
- * signal, not a user typo.
- *
- * The corresponding `sentryConfig.test.ts` block asserts these stay in
- * sync with the i18n source so a copy change in `translations.json`
- * will trip the test rather than silently disabling the filter.
+ * Sourced from i18n translation files so a copy change in
+ * `translations.json` automatically updates this filter — no separate
+ * sync step.
  */
 export const PASSWORD_TYPO_MESSAGES = [
-  "Invalid password. Please try again.",
-  "Senha inválida. Por favor, tente novamente.",
+  enTranslations.authStore.error.invalidPassword,
+  ptTranslations.authStore.error.invalidPassword,
 ];
 
 /**

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -1321,13 +1321,10 @@ const signIn = async ({
   if (!account) {
     // Keychain has a key for activeAccountId but the AsyncStorage
     // ACCOUNT_LIST doesn't have a matching entry - keychain/AsyncStorage
-    // drift. The next 4 lines recover by recreating the account from the
+    // drift. The next lines recover by recreating the account from the
     // loaded key. Worth a breadcrumb (warn) so we have visibility if the
     // recovery itself ever fails downstream, but not an error since
     // the user-visible flow keeps working.
-    //
-    // NOTE: a related drift bug where ACTIVE_ACCOUNT_ID itself is missing
-    // (FREIGHTER-MOBILE-6Z) is tracked in #851 - it is NOT fixed here.
     logger.warn(
       "signIn",
       "Active account ID missing from account list, recreating from keychain key",

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -666,7 +666,7 @@ const getTemporaryStore = async (
         new Error("Repeated decryption failures detected"),
         {
           failureCount: getTemporaryStoreFailureCount,
-          windowMs: FAILURE_RESET_WINDOW_MS,
+          failureResetWindowMs: FAILURE_RESET_WINDOW_MS,
         },
       );
     }

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -655,10 +655,19 @@ const getTemporaryStore = async (
     lastFailureTimestamp = now;
 
     if (getTemporaryStoreFailureCount >= SUSPICIOUS_FAILURE_THRESHOLD) {
+      // Pass a real Error with a stable message so all events group as
+      // a single Sentry issue. The variable failure count and window
+      // go into extra args (Sentry's "extra" payload) for diagnostics
+      // - inlining them into the message would interpolate the count
+      // into the title and split the group on every distinct count.
       logger.error(
         "[getTemporaryStore]",
-        "Repeated failures detected",
-        `Multiple unauthorized access attempts (${getTemporaryStoreFailureCount}) within ${FAILURE_RESET_WINDOW_MS}ms`,
+        "Repeated decryption failures detected within failure window",
+        new Error("Repeated decryption failures detected"),
+        {
+          failureCount: getTemporaryStoreFailureCount,
+          windowMs: FAILURE_RESET_WINDOW_MS,
+        },
       );
     }
     clearDerivedKeyCache();

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -618,10 +618,10 @@ const getTemporaryStore = async (
       // fully completed when the new account write begins, leaving
       // a brief window where authStatus + hashKey are present but
       // TEMPORARY_STORE has been removed and not yet rewritten. Rare
-      // in practice (~1 in 10 fresh creations during testing) and
-      // self-resolves on the next read, so we keep the log at error
-      // (downstream callers swallow the null silently) to monitor in
-      // case it starts happening more than expected.
+      // in practice and self-resolves on the next read, so we keep
+      // the log at error (downstream callers swallow the null
+      // silently) to monitor in case it starts happening more than
+      // expected.
       logger.error(
         "[getTemporaryStore]",
         "Temporary store missing in active session",

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -561,8 +561,22 @@ const SUSPICIOUS_FAILURE_THRESHOLD = 3; // Log warning after 3 failures
  * @param {AuthStatus} authStatus - Current auth status to validate before decryption
  * @returns {Promise<TemporaryStore | null>} The decrypted temporary store or null if retrieval failed
  */
+/**
+ * Options for `getTemporaryStore`.
+ *
+ * `allowMissing`: caller expects the store may legitimately not exist
+ * (e.g. running mid-signup, BEFORE the new store has been written).
+ * Suppresses the "missing in active session" error log for that case.
+ * Default false — real corruption signals on the unlock / decrypt
+ * paths still fire `logger.error`.
+ */
+type GetTemporaryStoreOptions = {
+  allowMissing?: boolean;
+};
+
 const getTemporaryStore = async (
   authStatus: AuthStatus,
+  { allowMissing = false }: GetTemporaryStoreOptions = {},
 ): Promise<TemporaryStore | null> => {
   try {
     // Security check: Only allow decryption if user can actually access the data
@@ -613,19 +627,32 @@ const getTemporaryStore = async (
       SENSITIVE_STORAGE_KEYS.TEMPORARY_STORE,
     );
     if (!temporaryStore) {
-      // Fires transiently during fresh-account creation: the signup
-      // flow wipes prior account state but persisted authStatus +
-      // hashKey can be momentarily out of sync with the cleared
-      // temporary store. Real corruption signals still leave a
-      // breadcrumb on any downstream captured event - the user gets
-      // bounced to the lock screen and the auth-failure path fires
-      // its own logger calls. Warn preserves that visibility without
-      // firing one top-level Sentry event per signup.
-      logger.warn(
-        "[getTemporaryStore]",
-        "Temporary store data not found for an active session - possible storage corruption",
-        new Error("Temporary store missing in active session"),
-      );
+      if (allowMissing) {
+        // Caller legitimately expects the store may not exist (e.g.
+        // mid-signup, before the new store is written). Emit a warn
+        // breadcrumb so the missing-store state is still visible on
+        // any downstream captured event for forensic context, but
+        // don't fire a top-level Sentry event. Pass the authStatus
+        // as a structured arg so triage can tell whether the caller
+        // was in AUTHENTICATED or LOCKED at the moment.
+        logger.warn(
+          "[getTemporaryStore]",
+          "Temporary store not found (caller opted into allowMissing)",
+          { authStatus },
+        );
+      } else {
+        // Real corruption signal on the unlock / decrypt paths:
+        // hashKey is valid but the encrypted store is gone. The
+        // downstream callers (getActiveAccount, fetchActiveAccount,
+        // initBiometricPassword) treat the null return as a hard
+        // failure but do NOT fire their own Sentry event — without
+        // this log the regression would disappear silently.
+        logger.error(
+          "[getTemporaryStore]",
+          "Temporary store data not found for an active session - possible storage corruption",
+          new Error("Temporary store missing in active session"),
+        );
+      }
 
       return null;
     }
@@ -1073,8 +1100,13 @@ const verifyAndCreateExistingAccountsOnNetwork = async (
   password: string,
   authStatus: AuthStatus,
 ): Promise<void> => {
-  // Check what accounts we already have locally before hitting the network
-  const temporaryStore = await getTemporaryStore(authStatus);
+  // Check what accounts we already have locally before hitting the network.
+  // The signup path arrives here mid-flow (clearAllData has wiped the
+  // previous store and the new one hasn't been written yet), so a missing
+  // store is expected control flow - opt out of the corruption log.
+  const temporaryStore = await getTemporaryStore(authStatus, {
+    allowMissing: true,
+  });
   const existingAccounts = await getAllAccounts();
 
   // Get public keys from temporary store

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -561,22 +561,8 @@ const SUSPICIOUS_FAILURE_THRESHOLD = 3; // Log warning after 3 failures
  * @param {AuthStatus} authStatus - Current auth status to validate before decryption
  * @returns {Promise<TemporaryStore | null>} The decrypted temporary store or null if retrieval failed
  */
-/**
- * Options for `getTemporaryStore`.
- *
- * `allowMissing`: caller expects the store may legitimately not exist
- * (e.g. running mid-signup, BEFORE the new store has been written).
- * Suppresses the "missing in active session" error log for that case.
- * Default false — real corruption signals on the unlock / decrypt
- * paths still fire `logger.error`.
- */
-type GetTemporaryStoreOptions = {
-  allowMissing?: boolean;
-};
-
 const getTemporaryStore = async (
   authStatus: AuthStatus,
-  { allowMissing = false }: GetTemporaryStoreOptions = {},
 ): Promise<TemporaryStore | null> => {
   try {
     // Security check: Only allow decryption if user can actually access the data
@@ -627,32 +613,20 @@ const getTemporaryStore = async (
       SENSITIVE_STORAGE_KEYS.TEMPORARY_STORE,
     );
     if (!temporaryStore) {
-      if (allowMissing) {
-        // Caller legitimately expects the store may not exist (e.g.
-        // mid-signup, before the new store is written). Emit a warn
-        // breadcrumb so the missing-store state is still visible on
-        // any downstream captured event for forensic context, but
-        // don't fire a top-level Sentry event. Pass the authStatus
-        // as a structured arg so triage can tell whether the caller
-        // was in AUTHENTICATED or LOCKED at the moment.
-        logger.warn(
-          "[getTemporaryStore]",
-          "Temporary store not found (caller opted into allowMissing)",
-          { authStatus },
-        );
-      } else {
-        // Real corruption signal on the unlock / decrypt paths:
-        // hashKey is valid but the encrypted store is gone. The
-        // downstream callers (getActiveAccount, fetchActiveAccount,
-        // initBiometricPassword) treat the null return as a hard
-        // failure but do NOT fire their own Sentry event — without
-        // this log the regression would disappear silently.
-        logger.error(
-          "[getTemporaryStore]",
-          "Temporary store data not found for an active session - possible storage corruption",
-          new Error("Temporary store missing in active session"),
-        );
-      }
+      // Can fire transiently during the delete-account → create-new-
+      // account flow: the previous account's cleanup may not have
+      // fully completed when the new account write begins, leaving
+      // a brief window where authStatus + hashKey are present but
+      // TEMPORARY_STORE has been removed and not yet rewritten. Rare
+      // in practice (~1 in 10 fresh creations during testing) and
+      // self-resolves on the next read, so we keep the log at error
+      // (downstream callers swallow the null silently) to monitor in
+      // case it starts happening more than expected.
+      logger.error(
+        "[getTemporaryStore]",
+        "Temporary store missing in active session",
+        new Error("Temporary store missing in active session"),
+      );
 
       return null;
     }
@@ -1100,13 +1074,8 @@ const verifyAndCreateExistingAccountsOnNetwork = async (
   password: string,
   authStatus: AuthStatus,
 ): Promise<void> => {
-  // Check what accounts we already have locally before hitting the network.
-  // The signup path arrives here mid-flow (clearAllData has wiped the
-  // previous store and the new one hasn't been written yet), so a missing
-  // store is expected control flow - opt out of the corruption log.
-  const temporaryStore = await getTemporaryStore(authStatus, {
-    allowMissing: true,
-  });
+  // Check what accounts we already have locally before hitting the network
+  const temporaryStore = await getTemporaryStore(authStatus);
   const existingAccounts = await getAllAccounts();
 
   // Get public keys from temporary store

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -587,21 +587,21 @@ const getTemporaryStore = async (
     const hashKey = await getHashKey();
 
     if (!hashKey) {
-      logger.error(
+      // No hashKey means the user is locked / has never signed in.
+      // This is the expected unauthenticated state, not an error -
+      // the caller checks for null and prompts the user to unlock.
+      logger.info(
         "[getTemporaryStore]",
         "Hash key not found - user must sign in",
-        undefined,
       );
 
       return null;
     }
 
     if (isHashKeyExpired(hashKey)) {
-      logger.error(
-        "[getTemporaryStore]",
-        "Hash key has expired, access denied",
-        undefined,
-      );
+      // Hash key TTL expired - the security policy is forcing
+      // re-authentication. Expected lifecycle behavior.
+      logger.info("[getTemporaryStore]", "Hash key has expired, access denied");
 
       return null;
     }
@@ -609,11 +609,9 @@ const getTemporaryStore = async (
       SENSITIVE_STORAGE_KEYS.TEMPORARY_STORE,
     );
     if (!temporaryStore) {
-      logger.error(
-        "[getTemporaryStore]",
-        "Temporary store data not found",
-        undefined,
-      );
+      // No in-memory unlocked-wallet cache means the user is locked -
+      // expected on cold start before they enter their password.
+      logger.info("[getTemporaryStore]", "Temporary store data not found");
 
       return null;
     }
@@ -1321,7 +1319,19 @@ const signIn = async ({
   let account = accountList.find((a) => a.id === activeAccountId);
 
   if (!account) {
-    logger.error("signIn", "Account not found in account list", null);
+    // Keychain has a key for activeAccountId but the AsyncStorage
+    // ACCOUNT_LIST doesn't have a matching entry - keychain/AsyncStorage
+    // drift. The next 4 lines recover by recreating the account from the
+    // loaded key. Worth a breadcrumb (warn) so we have visibility if the
+    // recovery itself ever fails downstream, but not an error since
+    // the user-visible flow keeps working.
+    //
+    // NOTE: a related drift bug where ACTIVE_ACCOUNT_ID itself is missing
+    // (FREIGHTER-MOBILE-6Z) is tracked in #851 - it is NOT fixed here.
+    logger.warn(
+      "signIn",
+      "Active account ID missing from account list, recreating from keychain key",
+    );
 
     account = {
       id: loadedKey.id,

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -1930,7 +1930,12 @@ export const useAuthenticationStore = create<AuthStore>()((set, get) => ({
       StellarHDWallet.fromMnemonic(mnemonicPhrase);
       return true;
     } catch (error) {
-      logger.error("verifyMnemonicPhrase", "Invalid mnemonic phrase", error);
+      // User-typed mnemonic validation. Invalid input here is the
+      // expected failure mode (this is the verify step), not a bug -
+      // the caller displays the error via the store's `error` field.
+      // Emit only a breadcrumb so the diagnostic is preserved if a
+      // downstream auth event captures it.
+      logger.warn("verifyMnemonicPhrase", "Invalid mnemonic phrase", error);
       set({
         error: t("authStore.error.invalidMnemonicPhrase"),
       });

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -594,7 +594,7 @@ const getTemporaryStore = async (
       // treat as a hard auth failure.
       logger.error(
         "[getTemporaryStore]",
-        "Hash key missing for an active session - possible storage corruption",
+        "Hash key missing in active session",
         new Error("Hash key missing in active session"),
       );
 
@@ -603,9 +603,11 @@ const getTemporaryStore = async (
 
     if (isHashKeyExpired(hashKey)) {
       // Hash key TTL expired - the security policy is forcing
-      // re-authentication. Expected lifecycle behavior; the security
-      // check at the top normally catches this transition.
-      logger.info("[getTemporaryStore]", "Hash key has expired, access denied");
+      // re-authentication. Expected lifecycle, normally caught by
+      // the security check at the top. Warn so the breadcrumb is
+      // available for debugging if it ever fires off the expected
+      // path; fires at most once per session, no buffer concern.
+      logger.warn("[getTemporaryStore]", "Hash key has expired, access denied");
 
       return null;
     }

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -587,12 +587,15 @@ const getTemporaryStore = async (
     const hashKey = await getHashKey();
 
     if (!hashKey) {
-      // No hashKey means the user is locked / has never signed in.
-      // This is the expected unauthenticated state, not an error -
-      // the caller checks for null and prompts the user to unlock.
-      logger.info(
+      // The security check above already filters NOT_AUTHENTICATED, so
+      // we're in AUTHENTICATED or LOCKED state - both should carry a
+      // valid hashKey. Missing here indicates storage corruption /
+      // keychain ↔ AsyncStorage drift, which downstream callers will
+      // treat as a hard auth failure.
+      logger.error(
         "[getTemporaryStore]",
-        "Hash key not found - user must sign in",
+        "Hash key missing for an active session - possible storage corruption",
+        new Error("Hash key missing in active session"),
       );
 
       return null;
@@ -600,7 +603,8 @@ const getTemporaryStore = async (
 
     if (isHashKeyExpired(hashKey)) {
       // Hash key TTL expired - the security policy is forcing
-      // re-authentication. Expected lifecycle behavior.
+      // re-authentication. Expected lifecycle behavior; the security
+      // check at the top normally catches this transition.
       logger.info("[getTemporaryStore]", "Hash key has expired, access denied");
 
       return null;
@@ -609,9 +613,16 @@ const getTemporaryStore = async (
       SENSITIVE_STORAGE_KEYS.TEMPORARY_STORE,
     );
     if (!temporaryStore) {
-      // No in-memory unlocked-wallet cache means the user is locked -
-      // expected on cold start before they enter their password.
-      logger.info("[getTemporaryStore]", "Temporary store data not found");
+      // We have a valid hashKey but the encrypted temporary store is
+      // gone - real storage corruption, not the normal locked state
+      // (the security check above already filtered NOT_AUTHENTICATED).
+      // Downstream callers throw on null, so surface this so the
+      // regression doesn't disappear from Sentry.
+      logger.error(
+        "[getTemporaryStore]",
+        "Temporary store data not found for an active session - possible storage corruption",
+        new Error("Temporary store missing in active session"),
+      );
 
       return null;
     }

--- a/src/ducks/auth.ts
+++ b/src/ducks/auth.ts
@@ -613,12 +613,15 @@ const getTemporaryStore = async (
       SENSITIVE_STORAGE_KEYS.TEMPORARY_STORE,
     );
     if (!temporaryStore) {
-      // We have a valid hashKey but the encrypted temporary store is
-      // gone - real storage corruption, not the normal locked state
-      // (the security check above already filtered NOT_AUTHENTICATED).
-      // Downstream callers throw on null, so surface this so the
-      // regression doesn't disappear from Sentry.
-      logger.error(
+      // Fires transiently during fresh-account creation: the signup
+      // flow wipes prior account state but persisted authStatus +
+      // hashKey can be momentarily out of sync with the cleared
+      // temporary store. Real corruption signals still leave a
+      // breadcrumb on any downstream captured event - the user gets
+      // bounced to the lock screen and the auth-failure path fires
+      // its own logger calls. Warn preserves that visibility without
+      // firing one top-level Sentry event per signup.
+      logger.warn(
         "[getTemporaryStore]",
         "Temporary store data not found for an active session - possible storage corruption",
         new Error("Temporary store missing in active session"),

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -375,9 +375,15 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
         // outage signal - per-collection breadcrumbs below give the
         // forensic detail.
         if (errorCollections.length === collections.length) {
+          // Pass an Error as the third arg (the captured-exception slot)
+          // so Sentry's grouping uses the stable Error.message. Putting
+          // `{ count }` directly in that slot would normalize to a
+          // generic Error embedding the count, fragmenting the outage
+          // into one issue per collection count.
           logger.error(
             "fetchCollectibles",
             "All collections returned backend errors",
+            new Error("All collections returned backend errors"),
             { count: collections.length },
           );
         }

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -368,26 +368,10 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
         (collection) => "error" in collection,
       );
       if (errorCollections.length > 0) {
-        // If every collection in the fetch came back as an error, that's
-        // a likely systemic backend regression (metadata service down,
-        // parser bug, gateway outage) and the gallery would otherwise
-        // render empty silently. Surface a single Sentry event for the
-        // outage signal - per-collection breadcrumbs below give the
-        // forensic detail.
-        if (errorCollections.length === collections.length) {
-          // Pass an Error as the third arg (the captured-exception slot)
-          // so Sentry's grouping uses the stable Error.message. Putting
-          // `{ count }` directly in that slot would normalize to a
-          // generic Error embedding the count, fragmenting the outage
-          // into one issue per collection count.
-          logger.error(
-            "fetchCollectibles",
-            "All collections returned backend errors",
-            new Error("All collections returned backend errors"),
-            { count: collections.length },
-          );
-        }
-
+        // Per-collection breadcrumbs first - Sentry breadcrumbs only
+        // attach to events captured AFTER them, so emitting these
+        // before any aggregate logger.error below ensures the
+        // breadcrumb chain shows up on the captured event.
         errorCollections.forEach((errorCollection) => {
           const { error } = errorCollection;
           const tokenErrors = Array.isArray(error.tokens) ? error.tokens : [];
@@ -402,7 +386,7 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
           //
           // Always emit a per-collection breadcrumb so the collection
           // address is captured on any downstream Sentry event - including
-          // the all-failed aggregate above. Without this, an outage where
+          // the all-failed aggregate below. Without this, an outage where
           // every collection fails via the per-token shape would surface
           // only the aggregate event with no breadcrumb chain showing
           // which collections were affected.
@@ -415,8 +399,8 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
           // Per-token failures stay at info: a single collection can have
           // hundreds of tokens, and emitting one breadcrumb per token
           // would blow the Sentry breadcrumb buffer (~100/session cap)
-          // for galleries with widespread metadata issues. Console-only
-          // diagnostic for local dev.
+          // for galleries with widespread metadata issues. Dev-only
+          // console output (no-op in production).
           tokenErrors.forEach((token) => {
             logger.info(
               "fetchCollectibles",
@@ -424,6 +408,40 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
             );
           });
         });
+
+        // If every collection in the fetch came back as a REAL error,
+        // that's a likely systemic backend regression (metadata service
+        // down, parser bug, gateway outage). Filter out the backend's
+        // expected empty-collection signal so the aggregate doesn't
+        // fire on the routine empty-gallery path: the backend always
+        // tries hardcoded MP contracts, and a user who owns no MP NFTs
+        // sees every collection come back with "No collectibles
+        // available for this collection.", which is not an outage.
+        // Case-insensitive match in case the backend ever shifts
+        // casing on the prefix.
+        const EMPTY_COLLECTION_PATTERN = /no collectibles available/i;
+        const realFailureCollections = errorCollections.filter(
+          (errorCollection) =>
+            !EMPTY_COLLECTION_PATTERN.test(
+              errorCollection.error.error_message ?? "",
+            ),
+        );
+        if (
+          realFailureCollections.length === collections.length &&
+          collections.length > 0
+        ) {
+          // Pass an Error as the third arg (the captured-exception slot)
+          // so Sentry's grouping uses the stable Error.message. Putting
+          // `{ count }` directly in that slot would normalize to a
+          // generic Error embedding the count, fragmenting the outage
+          // into one issue per collection count.
+          logger.error(
+            "fetchCollectibles",
+            "All collections returned backend errors",
+            new Error("All collections returned backend errors"),
+            { count: collections.length },
+          );
+        }
       }
 
       // Filter collections that are owned by the publicKey

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -390,6 +390,7 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
 
         errorCollections.forEach((errorCollection) => {
           const { error } = errorCollection;
+          const tokenErrors = Array.isArray(error.tokens) ? error.tokens : [];
 
           // Backend-supplied per-collection / per-token errors are part of
           // the API contract — they fire for expected conditions (empty
@@ -399,29 +400,29 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
           // for that one item), and the backend already has visibility
           // into the upstream failure.
           //
+          // Always emit a per-collection breadcrumb so the collection
+          // address is captured on any downstream Sentry event - including
+          // the all-failed aggregate above. Without this, an outage where
+          // every collection fails via the per-token shape would surface
+          // only the aggregate event with no breadcrumb chain showing
+          // which collections were affected.
+          logger.warn("fetchCollectibles", "Backend error for collection", {
+            collectionAddress: error.collection_address,
+            errorMessage: error.error_message,
+            tokenErrorCount: tokenErrors.length,
+          });
+
           // Per-token failures stay at info: a single collection can have
           // hundreds of tokens, and emitting one breadcrumb per token
-          // would blow the Sentry breadcrumb buffer (capped at ~100/session)
-          // for galleries with widespread metadata issues. Per-collection
-          // failures emit at warn so the breadcrumb chain on a captured
-          // event has the collection-level failure pattern.
-          if (
-            error.tokens &&
-            Array.isArray(error.tokens) &&
-            error.tokens.length > 0
-          ) {
-            error.tokens.forEach((token) => {
-              logger.info(
-                "fetchCollectibles",
-                `Error in token ${token.token_id} of collection ${error.collection_address}: ${token.error_message}`,
-              );
-            });
-          } else {
-            logger.warn("fetchCollectibles", "Backend error for collection", {
-              collectionAddress: error.collection_address,
-              errorMessage: error.error_message,
-            });
-          }
+          // would blow the Sentry breadcrumb buffer (~100/session cap)
+          // for galleries with widespread metadata issues. Console-only
+          // diagnostic for local dev.
+          tokenErrors.forEach((token) => {
+            logger.info(
+              "fetchCollectibles",
+              `Error in token ${token.token_id} of collection ${error.collection_address}: ${token.error_message}`,
+            );
+          });
         });
       }
 

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -368,6 +368,20 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
         (collection) => "error" in collection,
       );
       if (errorCollections.length > 0) {
+        // If every collection in the fetch came back as an error, that's
+        // a likely systemic backend regression (metadata service down,
+        // parser bug, gateway outage) and the gallery would otherwise
+        // render empty silently. Surface a single Sentry event for the
+        // outage signal - per-collection breadcrumbs below give the
+        // forensic detail.
+        if (errorCollections.length === collections.length) {
+          logger.error(
+            "fetchCollectibles",
+            "All collections returned backend errors",
+            { count: collections.length },
+          );
+        }
+
         errorCollections.forEach((errorCollection) => {
           const { error } = errorCollection;
 
@@ -377,8 +391,14 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
           // out for individual NFT metadata, malformed token URIs, etc.).
           // The user-visible behavior is graceful (no thumbnail or traits
           // for that one item), and the backend already has visibility
-          // into the upstream failure. Logging them as Sentry errors just
-          // floods the dashboard. Use info so they stay local-only.
+          // into the upstream failure.
+          //
+          // Per-token failures stay at info: a single collection can have
+          // hundreds of tokens, and emitting one breadcrumb per token
+          // would blow the Sentry breadcrumb buffer (capped at ~100/session)
+          // for galleries with widespread metadata issues. Per-collection
+          // failures emit at warn so the breadcrumb chain on a captured
+          // event has the collection-level failure pattern.
           if (
             error.tokens &&
             Array.isArray(error.tokens) &&
@@ -391,10 +411,10 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
               );
             });
           } else {
-            logger.info(
-              "fetchCollectibles",
-              `Error in collection ${error.collection_address}: ${error.error_message}`,
-            );
+            logger.warn("fetchCollectibles", "Backend error for collection", {
+              collectionAddress: error.collection_address,
+              errorMessage: error.error_message,
+            });
           }
         });
       }

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -1,4 +1,3 @@
-import { EnvConfig } from "config/envConfig";
 import { logger } from "config/logger";
 import {
   retrieveCollectiblesContracts,
@@ -372,37 +371,29 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
         errorCollections.forEach((errorCollection) => {
           const { error } = errorCollection;
 
-          const isMPCollection = EnvConfig.MP_COLLECTIONS_ADDRESSES.includes(
-            error.collection_address,
-          );
-          const isNoCollectiblesAvailableError = error.error_message
-            ?.toLowerCase()
-            .includes("no collectibles available for this collection");
-
-          // Let's prevent flooding Sentry with "No collectibles available for this collection."
-          // errors since the backend has a few hardcoded collection contracts which errors for
-          // most users since they are not owners of collectibles on those contracts.
-          const isMPNoCollectiblesAvailableError =
-            isMPCollection && isNoCollectiblesAvailableError;
-
-          // Let's silently log the backend errors so we keep track of it on Sentry
+          // Backend-supplied per-collection / per-token errors are part of
+          // the API contract — they fire for expected conditions (empty
+          // collections on hardcoded MP contracts, IPFS gateways timing
+          // out for individual NFT metadata, malformed token URIs, etc.).
+          // The user-visible behavior is graceful (no thumbnail or traits
+          // for that one item), and the backend already has visibility
+          // into the upstream failure. Logging them as Sentry errors just
+          // floods the dashboard. Use info so they stay local-only.
           if (
             error.tokens &&
             Array.isArray(error.tokens) &&
             error.tokens.length > 0
           ) {
             error.tokens.forEach((token) => {
-              logger.error(
+              logger.info(
                 "fetchCollectibles",
-                `Error in token ${token.token_id} of collection ${error.collection_address}`,
-                token.error_message,
+                `Error in token ${token.token_id} of collection ${error.collection_address}: ${token.error_message}`,
               );
             });
-          } else if (!isMPNoCollectiblesAvailableError) {
-            logger.error(
+          } else {
+            logger.info(
               "fetchCollectibles",
-              `Error in collection ${error.collection_address}`,
-              error.error_message,
+              `Error in collection ${error.collection_address}: ${error.error_message}`,
             );
           }
         });

--- a/src/ducks/collectibles.ts
+++ b/src/ducks/collectibles.ts
@@ -375,15 +375,15 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
           const isMPCollection = EnvConfig.MP_COLLECTIONS_ADDRESSES.includes(
             error.collection_address,
           );
-          const isNoCollectblesFetchedError = error.error_message?.includes(
-            "no collectibles fetched for contract",
-          );
+          const isNoCollectiblesAvailableError = error.error_message
+            ?.toLowerCase()
+            .includes("no collectibles available for this collection");
 
-          // Let's prevent flooding Sentry with "no collectibles fetched for contract" errors
-          // since the backend has a few hardcoded collection contracts which errors for most
-          // users since they are not owners of collectibles on those contracts.
-          const isMPNoCollectblesFetchedError =
-            isMPCollection && isNoCollectblesFetchedError;
+          // Let's prevent flooding Sentry with "No collectibles available for this collection."
+          // errors since the backend has a few hardcoded collection contracts which errors for
+          // most users since they are not owners of collectibles on those contracts.
+          const isMPNoCollectiblesAvailableError =
+            isMPCollection && isNoCollectiblesAvailableError;
 
           // Let's silently log the backend errors so we keep track of it on Sentry
           if (
@@ -398,7 +398,7 @@ export const useCollectiblesStore = create<CollectiblesState>((set, get) => ({
                 token.error_message,
               );
             });
-          } else if (!isMPNoCollectblesFetchedError) {
+          } else if (!isMPNoCollectiblesAvailableError) {
             logger.error(
               "fetchCollectibles",
               `Error in collection ${error.collection_address}`,

--- a/src/ducks/history.ts
+++ b/src/ducks/history.ts
@@ -190,7 +190,9 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
   fetchAccountHistory: async (params) => {
     try {
       if (!params.publicKey) {
-        logger.warn("fetchAccountHistory", "No public key provided");
+        // Pre-call guardrail; caller has already returned early or
+        // shown an empty state. Not error-adjacent.
+        logger.info("fetchAccountHistory", "No public key provided");
         return;
       }
 

--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -1,4 +1,5 @@
 import { logger } from "config/logger";
+import { useNetworkStore } from "ducks/networkInfo";
 import { isAndroid } from "helpers/device";
 import { isE2ETest } from "helpers/isEnv";
 import { getBundleId, getVersion } from "react-native-device-info";
@@ -183,16 +184,26 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
       // Mark as initialized after successful fetch
       set({ isInitialized: true });
     } catch (error) {
-      // Feature flags are load-bearing for runtime behavior - if the
-      // fetch fails the app silently falls back to defaults, which can
-      // mask broken backend config or token-list outages. Surface as
-      // error so we have visibility when behavior anomalies trace back
-      // to a stale flag set.
-      logger.error(
-        "remoteConfig.fetchFeatureFlags",
-        "Failed to fetch feature flags",
-        error,
-      );
+      // Feature flags are load-bearing for runtime behavior - we want
+      // visibility on real SDK / backend / config failures - but the
+      // poll runs hourly, so reporting every transient connectivity
+      // loss as an error would generate exactly the noise pattern we
+      // are trying to remove. Split: device offline → warn breadcrumb
+      // (not actionable, self-resolves when connectivity returns); any
+      // other failure → logger.error (real SDK / config / outage).
+      const { isOffline } = useNetworkStore.getState();
+      if (isOffline) {
+        logger.warn(
+          "remoteConfig.fetchFeatureFlags",
+          "Failed to fetch feature flags (device offline)",
+        );
+      } else {
+        logger.error(
+          "remoteConfig.fetchFeatureFlags",
+          "Failed to fetch feature flags",
+          error,
+        );
+      }
 
       // Mark as initialized even on error to prevent infinite loading
       set({ isInitialized: true });

--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -196,6 +196,7 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
         logger.warn(
           "remoteConfig.fetchFeatureFlags",
           "Failed to fetch feature flags (device offline)",
+          error,
         );
       } else {
         logger.error(

--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -183,7 +183,12 @@ export const useRemoteConfigStore = create<RemoteConfigState>()((set, get) => ({
       // Mark as initialized after successful fetch
       set({ isInitialized: true });
     } catch (error) {
-      logger.warn(
+      // Feature flags are load-bearing for runtime behavior - if the
+      // fetch fails the app silently falls back to defaults, which can
+      // mask broken backend config or token-list outages. Surface as
+      // error so we have visibility when behavior anomalies trace back
+      // to a stale flag set.
+      logger.error(
         "remoteConfig.fetchFeatureFlags",
         "Failed to fetch feature flags",
         error,

--- a/src/ducks/transactionBuilder.ts
+++ b/src/ducks/transactionBuilder.ts
@@ -12,7 +12,7 @@ import { isContractId } from "helpers/soroban";
 import { isMuxedAccount } from "helpers/stellar";
 import { t } from "i18next";
 import { SimulationTransactionType } from "services/analytics/types";
-import { signTransaction, submitTx } from "services/stellar";
+import { isHorizonError, signTransaction, submitTx } from "services/stellar";
 import {
   buildPaymentTransaction,
   buildSendCollectibleTransaction,
@@ -572,11 +572,41 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
         return hash;
       } catch (error) {
         const errorMessage = extractErrorMessage(error);
-        logger.error(
-          "TransactionBuilderStore",
-          "Failed to submit transaction",
-          error,
-        );
+
+        // Horizon protocol rejections (HTTP 4xx with a result_codes body —
+        // tx_bad_seq, tx_insufficient_balance, op_underfunded,
+        // op_under_dest_min, etc.) are expected, handled failures, not bugs.
+        // The user already sees a toast with the underlying message and
+        // analytics.trackTransactionError records the failure. Demote to
+        // warn so they appear as breadcrumb context without creating
+        // top-level Sentry issues (FREIGHTER-MOBILE-1B, ~1.5K events).
+        // Real submit-time bugs (bad XDR encoding, network unreachable,
+        // SDK exceptions) still surface as logger.error.
+        if (isHorizonError(error)) {
+          const horizonStatus = error.response.status;
+          // result_codes (tx_bad_seq, op_under_dest_min, etc.) live on
+          // error.response.data.extras.result_codes from the underlying
+          // Horizon SDK error, but the project's narrow HorizonError
+          // type guard only exposes status. Pull through the data
+          // optionally without widening the type guard.
+          /* eslint-disable @typescript-eslint/no-explicit-any */
+          /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+          const resultCodes = (error.response as any).data?.extras
+            ?.result_codes;
+          /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+          /* eslint-enable @typescript-eslint/no-explicit-any */
+          logger.warn(
+            "TransactionBuilderStore",
+            `Network rejected transaction (HTTP ${horizonStatus})`,
+            resultCodes,
+          );
+        } else {
+          logger.error(
+            "TransactionBuilderStore",
+            "Failed to submit transaction",
+            error,
+          );
+        }
 
         // Only set error state if this submit request is still current.
         // Prevents stale submit error from affecting newer transaction flows.

--- a/src/ducks/transactionBuilder.ts
+++ b/src/ducks/transactionBuilder.ts
@@ -580,10 +580,20 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
         // analytics.trackTransactionError records the failure. Demote to
         // warn so they appear as breadcrumb context without creating
         // top-level Sentry issues (FREIGHTER-MOBILE-1B, ~1.5K events).
-        // Real submit-time bugs (bad XDR encoding, network unreachable,
-        // SDK exceptions) still surface as logger.error.
-        if (isHorizonError(error)) {
-          const horizonStatus = error.response.status;
+        //
+        // ONLY 4xx is demoted. Horizon 5xx (server overload, outages —
+        // submitTx already retries 504 a few times before bubbling)
+        // remains a logger.error so we keep visibility on real Horizon
+        // problems. Submit-time bugs that aren't HorizonError shape
+        // (bad XDR encoding, network unreachable, SDK exceptions) also
+        // stay as logger.error.
+        const isHorizonProtocolRejection =
+          isHorizonError(error) &&
+          error.response.status >= 400 &&
+          error.response.status < 500;
+        if (isHorizonProtocolRejection) {
+          const horizonStatus = (error as { response: { status: number } })
+            .response.status;
           // result_codes (tx_bad_seq, op_under_dest_min, etc.) live on
           // error.response.data.extras.result_codes from the underlying
           // Horizon SDK error, but the project's narrow HorizonError
@@ -591,7 +601,7 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
           // optionally without widening the type guard.
           /* eslint-disable @typescript-eslint/no-explicit-any */
           /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-          const resultCodes = (error.response as any).data?.extras
+          const resultCodes = (error as any).response.data?.extras
             ?.result_codes;
           /* eslint-enable @typescript-eslint/no-unsafe-member-access */
           /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/ducks/transactionBuilder.ts
+++ b/src/ducks/transactionBuilder.ts
@@ -573,15 +573,15 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
       } catch (error) {
         const errorMessage = extractErrorMessage(error);
 
-        // Horizon protocol rejections (HTTP 4xx with a result_codes body —
-        // tx_bad_seq, tx_insufficient_balance, op_underfunded,
-        // op_under_dest_min, etc.) are expected, handled failures, not bugs.
-        // The user already sees a toast with the underlying message and
-        // analytics.trackTransactionError records the failure. Demote to
-        // warn so they appear as breadcrumb context without creating
-        // top-level Sentry issues (FREIGHTER-MOBILE-1B, ~1.5K events).
+        // Horizon protocol rejections (HTTP 4xx with a result_codes
+        // body - tx_bad_seq, tx_insufficient_balance, op_underfunded,
+        // op_under_dest_min, etc.) are expected, handled failures, not
+        // bugs. The user already sees a toast with the underlying
+        // message and analytics.trackTransactionError records the
+        // failure. Demote to warn so these stay as breadcrumb context
+        // without creating Sentry issues.
         //
-        // ONLY 4xx is demoted. Horizon 5xx (server overload, outages —
+        // ONLY 4xx is demoted. Horizon 5xx (server overload, outages -
         // submitTx already retries 504 a few times before bubbling)
         // remains a logger.error so we keep visibility on real Horizon
         // problems. Submit-time bugs that aren't HorizonError shape

--- a/src/ducks/transactionBuilder.ts
+++ b/src/ducks/transactionBuilder.ts
@@ -573,25 +573,18 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
       } catch (error) {
         const errorMessage = extractErrorMessage(error);
 
-        // Horizon protocol rejections (HTTP 4xx with a result_codes
-        // body - tx_bad_seq, tx_insufficient_balance, op_underfunded,
-        // op_under_dest_min, etc.) are expected, handled failures, not
-        // bugs. The user already sees a toast with the underlying
-        // message and analytics.trackTransactionError records the
-        // failure. Demote to warn so these stay as breadcrumb context
-        // without creating Sentry issues.
+        // Demote ONLY user-correctable Horizon protocol rejections
+        // (HTTP 4xx with `result_codes` populated — tx_bad_seq,
+        // op_underfunded, op_under_dest_min, etc.). The user sees a
+        // toast and analytics.trackTransactionError fires, so a
+        // breadcrumb is enough.
         //
-        // ONLY 4xx is demoted. Horizon 5xx (server overload, outages -
-        // submitTx already retries 504 a few times before bubbling)
-        // remains a logger.error so we keep visibility on real Horizon
-        // problems. Submit-time bugs that aren't HorizonError shape
-        // (bad XDR encoding, network unreachable, SDK exceptions) also
-        // stay as logger.error.
-        // Demote ONLY user-correctable protocol rejections (HTTP 4xx
-        // with `result_codes` populated — tx_bad_seq, op_underfunded,
-        // op_under_dest_min, etc.). 4xx WITHOUT result_codes are
-        // operational failures (403/429/proxy, generic auth) that we
-        // want to keep visible in Sentry as logger.error.
+        // 4xx WITHOUT result_codes are operational failures
+        // (403/429/proxy, generic auth) and stay as logger.error.
+        // 5xx (server overload, outages — submitTx already retries
+        // 504 before bubbling) and non-Horizon errors (bad XDR,
+        // network unreachable, SDK exceptions) also stay as
+        // logger.error.
         //
         // result_codes lives on `error.response.data.extras.result_codes`
         // from the underlying Horizon SDK error, but the project's

--- a/src/ducks/transactionBuilder.ts
+++ b/src/ducks/transactionBuilder.ts
@@ -587,28 +587,33 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
         // problems. Submit-time bugs that aren't HorizonError shape
         // (bad XDR encoding, network unreachable, SDK exceptions) also
         // stay as logger.error.
-        const isHorizonProtocolRejection =
+        // Demote ONLY user-correctable protocol rejections (HTTP 4xx
+        // with `result_codes` populated — tx_bad_seq, op_underfunded,
+        // op_under_dest_min, etc.). 4xx WITHOUT result_codes are
+        // operational failures (403/429/proxy, generic auth) that we
+        // want to keep visible in Sentry as logger.error.
+        //
+        // result_codes lives on `error.response.data.extras.result_codes`
+        // from the underlying Horizon SDK error, but the project's
+        // narrow HorizonError type guard only exposes status. Pull
+        // through the data optionally without widening the type guard.
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+        const horizon4xxResultCodes =
           isHorizonError(error) &&
           error.response.status >= 400 &&
-          error.response.status < 500;
-        if (isHorizonProtocolRejection) {
+          error.response.status < 500
+            ? (error as any).response.data?.extras?.result_codes
+            : undefined;
+        /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+        if (horizon4xxResultCodes) {
           const horizonStatus = (error as { response: { status: number } })
             .response.status;
-          // result_codes (tx_bad_seq, op_under_dest_min, etc.) live on
-          // error.response.data.extras.result_codes from the underlying
-          // Horizon SDK error, but the project's narrow HorizonError
-          // type guard only exposes status. Pull through the data
-          // optionally without widening the type guard.
-          /* eslint-disable @typescript-eslint/no-explicit-any */
-          /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-          const resultCodes = (error as any).response.data?.extras
-            ?.result_codes;
-          /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-          /* eslint-enable @typescript-eslint/no-explicit-any */
           logger.warn(
             "TransactionBuilderStore",
             `Network rejected transaction (HTTP ${horizonStatus})`,
-            resultCodes,
+            horizon4xxResultCodes,
           );
         } else {
           logger.error(

--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -138,7 +138,10 @@ export const clearAllCookies = async (): Promise<boolean> => {
     if (result) {
       logger.debug("clearAllCookies", "All cookies cleared successfully");
     } else {
-      logger.warn("clearAllCookies", "Cookie cleanup may have failed");
+      // Best-effort cleanup - the "may have failed" wording reflects
+      // CookieManager's fuzzy success signal. Not actionable as a
+      // breadcrumb for downstream errors.
+      logger.info("clearAllCookies", "Cookie cleanup may have failed");
     }
 
     return result;
@@ -170,7 +173,8 @@ export const clearAllWebViewData = async (): Promise<boolean> => {
         "WebView data cleanup completed successfully",
       );
     } else {
-      logger.warn(
+      // Best-effort cleanup - same shape as clearAllCookies above.
+      logger.info(
         "clearAllWebViewData",
         "WebView data cleanup may have failed",
       );

--- a/src/helpers/keyManager/ReactNativeKeychainFacade.ts
+++ b/src/helpers/keyManager/ReactNativeKeychainFacade.ts
@@ -84,7 +84,10 @@ export class ReactNativeKeychainFacade {
     } catch (error) {
       logger.error(
         "ReactNativeKeychainKeyStore.getKey",
-        `Error getting key ${id}:`,
+        // Truncate the keychain id - it's a per-account correlation
+        // token and shouldn't ship verbatim. Prefix is enough for
+        // intra-session log correlation.
+        `Error getting key ${id.slice(0, 8)}...:`,
         error,
       );
 
@@ -120,7 +123,8 @@ export class ReactNativeKeychainFacade {
     } catch (error) {
       logger.error(
         "ReactNativeKeychainKeyStore.removeKey",
-        `Error removing key ${id}:`,
+        // Truncate the keychain id - same reasoning as getKey above.
+        `Error removing key ${id.slice(0, 8)}...:`,
         error,
       );
       // Don't throw here, as the key might not exist

--- a/src/helpers/screenshots.ts
+++ b/src/helpers/screenshots.ts
@@ -300,19 +300,18 @@ export const captureTabScreenshot = async ({
     // Browser-tab thumbnails are a non-essential UX nicety. The capture
     // can fail for a few reasons that are all environmental races, not
     // bugs in our code:
-    //   - "Failed to capture view snapshot" (FREIGHTER-MOBILE-2V) — the
-    //     bitmap render fails, usually because of low memory or
-    //     hardware-accelerated WebView surfaces.
-    //   - "No view found with reactTag: NNNN" (FREIGHTER-MOBILE-7K) —
-    //     the React Native view was already unmounted by the time native
-    //     code looked it up (tab disposal, navigation away mid-capture).
-    //   - "drawViewHierarchyInRect was not successful"
-    //     (FREIGHTER-MOBILE-84) — iOS-specific variant for offscreen /
-    //     mid-transition views.
-    // When the capture fails, the tab switcher just falls back to
-    // favicon/URL — already graceful. Use info so this stays local-only
-    // and doesn't take up a Sentry breadcrumb slot for an unrelated error
-    // later in the session.
+    //   - "Failed to capture view snapshot" - the bitmap render fails,
+    //     usually because of low memory or hardware-accelerated
+    //     WebView surfaces.
+    //   - "No view found with reactTag: NNNN" - the React Native view
+    //     was already unmounted by the time native code looked it up
+    //     (tab disposal, navigation away mid-capture).
+    //   - iOS "drawViewHierarchyInRect was not successful" - iOS
+    //     variant of the same condition for offscreen / mid-transition
+    //     views.
+    // When capture fails, the tab switcher falls back to favicon/URL.
+    // Use info so this stays local-only and doesn't take up a Sentry
+    // breadcrumb slot for an unrelated error later in the session.
     logger.info(
       source,
       `Failed to capture screenshot for tab ${tabId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/helpers/screenshots.ts
+++ b/src/helpers/screenshots.ts
@@ -297,7 +297,26 @@ export const captureTabScreenshot = async ({
       }
     }
   } catch (error) {
-    logger.error(source, "Failed to capture screenshot:", error);
+    // Browser-tab thumbnails are a non-essential UX nicety. The capture
+    // can fail for a few reasons that are all environmental races, not
+    // bugs in our code:
+    //   - "Failed to capture view snapshot" (FREIGHTER-MOBILE-2V) — the
+    //     bitmap render fails, usually because of low memory or
+    //     hardware-accelerated WebView surfaces.
+    //   - "No view found with reactTag: NNNN" (FREIGHTER-MOBILE-7K) —
+    //     the React Native view was already unmounted by the time native
+    //     code looked it up (tab disposal, navigation away mid-capture).
+    //   - "drawViewHierarchyInRect was not successful"
+    //     (FREIGHTER-MOBILE-84) — iOS-specific variant for offscreen /
+    //     mid-transition views.
+    // When the capture fails, the tab switcher just falls back to
+    // favicon/URL — already graceful. Use info so this stays local-only
+    // and doesn't take up a Sentry breadcrumb slot for an unrelated error
+    // later in the session.
+    logger.info(
+      source,
+      `Failed to capture screenshot for tab ${tabId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   } finally {
     // Clear OpenCV buffers
     // otherwise it will cause a memory leak

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -685,7 +685,10 @@ export const disconnectSession = async (topic: string): Promise<void> => {
   } catch (error) {
     logger.error(
       "disconnectSession",
-      `Failed to disconnect session. topic: ${topic}`,
+      // Truncate the WC topic - it's a session-scoped token, not
+      // useful in full and unnecessary to ship verbatim to Sentry.
+      // Prefix is enough for cross-log correlation within a session.
+      `Failed to disconnect session. topic: ${topic.slice(0, 8)}...`,
       error,
     );
   }
@@ -733,11 +736,15 @@ export const disconnectAllSessions = async (
       "All sessions disconnected successfully",
     );
   } catch (error) {
-    // Let's not block the user from logging out if this fails
+    // Let's not block the user from logging out if this fails.
+    // publicKey goes through the args extras so sanitizeLogData can
+    // redact it for opt-out users (interpolating it into the message
+    // would bypass the redactor and ship it to Sentry verbatim).
     logger.error(
       "disconnectAllSessions",
-      `Failed to disconnect all sessions. publicKey: ${publicKey}, network: ${network}`,
+      "Failed to disconnect all sessions",
       error,
+      { publicKey, network },
     );
   }
 };

--- a/src/hooks/useDeviceStorage.ts
+++ b/src/hooks/useDeviceStorage.ts
@@ -42,7 +42,8 @@ const getImageExtensionFromUrl = (imageUrl: string): string => {
       }
     }
   } catch (error) {
-    logger.warn("DeviceStorage", "Failed to extract extension from URL", {
+    // Utility edge case with a "jpg" fallback - not actionable.
+    logger.info("DeviceStorage", "Failed to extract extension from URL", {
       imageUrl,
       error,
     });

--- a/src/hooks/useTokenDetails.tsx
+++ b/src/hooks/useTokenDetails.tsx
@@ -56,9 +56,11 @@ const useTokenDetails = ({
           });
         }
       } catch (error) {
-        // UI display fallback in place; unlikely to correlate with
-        // downstream errors.
-        logger.info("useTokenDetails", "Failed to fetch token details", error);
+        // UI display falls back to the basic token info, so this
+        // doesn't block the user. Log as error anyway so escalating
+        // gives us visibility if the contract-spec / token-details
+        // fetch layer ever starts failing.
+        logger.error("useTokenDetails", "Failed to fetch token details", error);
       }
     };
 

--- a/src/hooks/useTokenDetails.tsx
+++ b/src/hooks/useTokenDetails.tsx
@@ -58,7 +58,7 @@ const useTokenDetails = ({
       } catch (error) {
         // UI display fallback in place; unlikely to correlate with
         // downstream errors.
-        logger.info("Failed to fetch token details:", String(error));
+        logger.info("useTokenDetails", "Failed to fetch token details", error);
       }
     };
 

--- a/src/hooks/useTokenDetails.tsx
+++ b/src/hooks/useTokenDetails.tsx
@@ -56,7 +56,9 @@ const useTokenDetails = ({
           });
         }
       } catch (error) {
-        logger.warn("Failed to fetch token details:", String(error));
+        // UI display fallback in place; unlikely to correlate with
+        // downstream errors.
+        logger.info("Failed to fetch token details:", String(error));
       }
     };
 

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1028,11 +1028,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         new Error(
           "WalletConnect transaction request origin does not match any active session hostname",
         ),
-        {
-          transactionRequestOrigin,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          xdr: sessionRequest.params?.request?.params?.xdr,
-        },
+        { transactionRequestOrigin },
       );
 
       rejectSessionRequest({

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1012,11 +1012,20 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         variant: "error",
       });
 
+      // The Sentry-side message used to read "Bad actor potentially
+      // found in transaction request" - alarmist phrasing that turned out
+      // to be misleading in practice: every flagged origin we have
+      // inspected so far has been a legitimate dApp or developer
+      // environment (Script3 governance, Afreum, Vercel preview deploys,
+      // localhost). The exact-hostname comparison above produces false
+      // positives on legitimate subdomain drift. Fixing the validator
+      // (eTLD+1 match, trusting verifyContext.verified.validation) is a
+      // security-affecting change and intentionally out of scope here.
       logger.error(
         "WalletKitProvider",
         "Invalid transaction origin",
         new Error(
-          "Untrusted Transaction Domain. Bad actor potentially found in transaction request.",
+          "WalletConnect transaction request origin does not match any active session hostname",
         ),
         {
           transactionRequestOrigin,

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1013,15 +1013,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         variant: "error",
       });
 
-      // The Sentry-side message used to read "Bad actor potentially
-      // found in transaction request" - alarmist phrasing that turned out
-      // to be misleading in practice: every flagged origin we have
+      // The exact-hostname comparison above produces false positives
+      // on legitimate subdomain drift — every flagged origin
       // inspected so far has been a legitimate dApp or developer
-      // environment (Script3 governance, Afreum, Vercel preview deploys,
-      // localhost). The exact-hostname comparison above produces false
-      // positives on legitimate subdomain drift. Fixing the validator
-      // (eTLD+1 match, trusting verifyContext.verified.validation) is a
-      // security-affecting change and intentionally out of scope here.
+      // environment. The factual message + the
+      // transactionRequestOrigin arg below are enough to triage which
+      // dApp tripped the check.
       logger.error(
         "WalletKitProvider",
         "Invalid transaction origin",

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -907,7 +907,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const handleSessionRequest = (sessionRequest: WalletKitSessionRequest) => {
     // Simple queue: if already processing a request, store this one as pending
     if (isProcessingRequestRef.current) {
-      logger.warn(
+      // Normal queue flow, not an error condition.
+      logger.info(
         "WalletKitProvider",
         "Request already in progress, queuing new request",
         {

--- a/src/services/SecureClipboardService.ts
+++ b/src/services/SecureClipboardService.ts
@@ -39,8 +39,11 @@ export class SecureClipboardService {
         Clipboard.setString(text);
       }
     } catch (error) {
-      // Fallback to standard clipboard if native module fails
-      logger.warn(
+      // Fallback to standard clipboard if native module fails -
+      // routine fallback path, not error-adjacent (the native module
+      // simply isn't always available depending on Android version /
+      // iOS quirks). Stay info to avoid filling the breadcrumb buffer.
+      logger.info(
         "SecureClipboardService.copyToClipboard",
         "Native module failed, falling back to standard clipboard",
         error,
@@ -60,8 +63,11 @@ export class SecureClipboardService {
         Clipboard.setString("");
       }
     } catch (error) {
-      // Fallback to standard clipboard if native module fails
-      logger.warn(
+      // Fallback to standard clipboard if native module fails -
+      // routine fallback path, not error-adjacent (the native module
+      // simply isn't always available depending on Android version /
+      // iOS quirks). Stay info to avoid filling the breadcrumb buffer.
+      logger.info(
         "SecureClipboardService.clearClipboard",
         "Native clear failed, falling back to standard clipboard",
         error,
@@ -80,8 +86,11 @@ export class SecureClipboardService {
       }
       return await Clipboard.getString();
     } catch (error) {
-      // Fallback to standard clipboard if native module fails
-      logger.warn(
+      // Fallback to standard clipboard if native module fails -
+      // routine fallback path, not error-adjacent (the native module
+      // simply isn't always available depending on Android version /
+      // iOS quirks). Stay info to avoid filling the breadcrumb buffer.
+      logger.info(
         "SecureClipboardService.getClipboardText",
         "Native getString failed, falling back to standard clipboard",
         error,

--- a/src/services/SecureClipboardService.ts
+++ b/src/services/SecureClipboardService.ts
@@ -42,8 +42,11 @@ export class SecureClipboardService {
       // Fallback to standard clipboard if native module fails -
       // routine fallback path, not error-adjacent (the native module
       // simply isn't always available depending on Android version /
-      // iOS quirks). Stay info to avoid filling the breadcrumb buffer.
-      logger.info(
+      // iOS quirks). Use warn so we have a Sentry breadcrumb if
+      // mnemonic copy/paste flows ever regress on a supported device:
+      // production has shown 0 events in 90 days and the call sites
+      // are onboarding-only, so buffer pressure is not a concern.
+      logger.warn(
         "SecureClipboardService.copyToClipboard",
         "Native module failed, falling back to standard clipboard",
         error,
@@ -66,8 +69,11 @@ export class SecureClipboardService {
       // Fallback to standard clipboard if native module fails -
       // routine fallback path, not error-adjacent (the native module
       // simply isn't always available depending on Android version /
-      // iOS quirks). Stay info to avoid filling the breadcrumb buffer.
-      logger.info(
+      // iOS quirks). Use warn so we have a Sentry breadcrumb if
+      // mnemonic copy/paste flows ever regress on a supported device:
+      // production has shown 0 events in 90 days and the call sites
+      // are onboarding-only, so buffer pressure is not a concern.
+      logger.warn(
         "SecureClipboardService.clearClipboard",
         "Native clear failed, falling back to standard clipboard",
         error,
@@ -89,8 +95,11 @@ export class SecureClipboardService {
       // Fallback to standard clipboard if native module fails -
       // routine fallback path, not error-adjacent (the native module
       // simply isn't always available depending on Android version /
-      // iOS quirks). Stay info to avoid filling the breadcrumb buffer.
-      logger.info(
+      // iOS quirks). Use warn so we have a Sentry breadcrumb if
+      // mnemonic copy/paste flows ever regress on a supported device:
+      // production has shown 0 events in 90 days and the call sites
+      // are onboarding-only, so buffer pressure is not a concern.
+      logger.warn(
         "SecureClipboardService.getClipboardText",
         "Native getString failed, falling back to standard clipboard",
         error,

--- a/src/services/SecureClipboardService.ts
+++ b/src/services/SecureClipboardService.ts
@@ -19,6 +19,14 @@ const SecureClipboardModule = SecureClipboard as SecureClipboardNative;
  * - iOS: Uses manual expiration with content verification to prevent overwriting user data (iOS 15.1+)
  * - Both platforms: Graceful fallback to standard clipboard if native modules fail
  * - Safety: Only clears clipboard if content hasn't been overwritten by other applications
+ *
+ * Native-module fallback logging: when the native module is
+ * unavailable (older Android versions, iOS quirks) the catches below
+ * fall back to the standard clipboard. We log at `warn` so we have a
+ * Sentry breadcrumb if mnemonic copy/paste flows ever regress on a
+ * supported device. Call sites are onboarding-only and historical
+ * fallback rate is essentially zero, so buffer pressure is not a
+ * concern.
  */
 export class SecureClipboardService {
   /**
@@ -39,13 +47,8 @@ export class SecureClipboardService {
         Clipboard.setString(text);
       }
     } catch (error) {
-      // Fallback to standard clipboard if native module fails -
-      // routine fallback path, not error-adjacent (the native module
-      // simply isn't always available depending on Android version /
-      // iOS quirks). Use warn so we have a Sentry breadcrumb if
-      // mnemonic copy/paste flows ever regress on a supported device:
-      // production has shown 0 events in 90 days and the call sites
-      // are onboarding-only, so buffer pressure is not a concern.
+      // Fall back to the standard clipboard. Logged at warn — see
+      // class-level rationale.
       logger.warn(
         "SecureClipboardService.copyToClipboard",
         "Native module failed, falling back to standard clipboard",
@@ -66,13 +69,8 @@ export class SecureClipboardService {
         Clipboard.setString("");
       }
     } catch (error) {
-      // Fallback to standard clipboard if native module fails -
-      // routine fallback path, not error-adjacent (the native module
-      // simply isn't always available depending on Android version /
-      // iOS quirks). Use warn so we have a Sentry breadcrumb if
-      // mnemonic copy/paste flows ever regress on a supported device:
-      // production has shown 0 events in 90 days and the call sites
-      // are onboarding-only, so buffer pressure is not a concern.
+      // Fall back to the standard clipboard. Logged at warn — see
+      // class-level rationale.
       logger.warn(
         "SecureClipboardService.clearClipboard",
         "Native clear failed, falling back to standard clipboard",
@@ -92,13 +90,8 @@ export class SecureClipboardService {
       }
       return await Clipboard.getString();
     } catch (error) {
-      // Fallback to standard clipboard if native module fails -
-      // routine fallback path, not error-adjacent (the native module
-      // simply isn't always available depending on Android version /
-      // iOS quirks). Use warn so we have a Sentry breadcrumb if
-      // mnemonic copy/paste flows ever regress on a supported device:
-      // production has shown 0 events in 90 days and the call sites
-      // are onboarding-only, so buffer pressure is not a concern.
+      // Fall back to the standard clipboard. Logged at warn — see
+      // class-level rationale.
       logger.warn(
         "SecureClipboardService.getClipboardText",
         "Native getString failed, falling back to standard clipboard",

--- a/src/services/analytics/core.ts
+++ b/src/services/analytics/core.ts
@@ -98,9 +98,15 @@ export const initAnalytics = (): void => {
         "Experiment client initialized with deployment key",
       );
     } else {
-      logger.warn(
+      // Feature flags are load-bearing for the app's runtime behavior
+      // (gating features, A/B tests, killswitches). If the experiment
+      // deployment key is missing we silently fall back to defaults,
+      // which can mask real config problems - report as error so we
+      // catch deployment-time misconfigurations.
+      logger.error(
         DEBUG_CONFIG.LOG_PREFIX,
         "Experiment deployment key missing, feature flags will use defaults",
+        new Error("Experiment deployment key missing"),
       );
     }
 

--- a/src/services/analytics/core.ts
+++ b/src/services/analytics/core.ts
@@ -257,7 +257,10 @@ const dispatchUnthrottled = (
   }
 
   if (!hasInitialised) {
-    logger.warn(
+    // Fires for every analytics event before init completes - high
+    // per-session volume, not error-adjacent. Stay info to avoid
+    // flooding the breadcrumb ring buffer.
+    logger.info(
       DEBUG_CONFIG.LOG_PREFIX,
       `Analytics not initialized, skipping: ${event}`,
     );

--- a/src/services/analytics/user.ts
+++ b/src/services/analytics/user.ts
@@ -120,16 +120,21 @@ export const identifyUser = async (): Promise<void> => {
 
       logger.debug(DEBUG_CONFIG.LOG_PREFIX, `✅ User identified: ${userId}`);
     } catch (amplitudeError) {
-      // Store user ID even if amplitude fails
+      // Update the local store so other consumers see the resolved
+      // user ID, but do NOT mark the user as identified - leaving
+      // `lastIdentifiedUserId` unchanged means the next identifyUser
+      // call retries the Amplitude side instead of being skipped by
+      // the dedup check. Otherwise a single Amplitude failure breaks
+      // user attribution for the rest of the session.
       setUserId(userId);
 
-      lastIdentifiedUserId = userId;
-
-      // Local storage succeeded; not actionable as a breadcrumb.
-      logger.info(
+      // Warn so a downstream captured event can pick up this
+      // breadcrumb. info would be a no-op on production builds.
+      logger.warn(
         DEBUG_CONFIG.LOG_PREFIX,
         "Failed to set user ID in Amplitude, but stored locally",
-        { userId, amplitudeError },
+        amplitudeError,
+        { userId },
       );
     }
   } catch (userIdError) {

--- a/src/services/analytics/user.ts
+++ b/src/services/analytics/user.ts
@@ -43,9 +43,13 @@ export const getUserId = async (): Promise<string> => {
 
       return newId;
     } catch (setError) {
-      // Session-only fallback is in place; not actionable as a
-      // breadcrumb for downstream errors.
-      logger.info(
+      // Session-only fallback is in place, but if AsyncStorage
+      // rejects writes in production, every launch generates a
+      // fresh session ID and we lose cross-session analytics +
+      // Sentry user correlation. Warn so we have a breadcrumb
+      // signal of that drift without flooding Sentry (this fires
+      // at most once per launch).
+      logger.warn(
         DEBUG_CONFIG.LOG_PREFIX,
         "Failed to persist user ID, using session-only",
         setError,

--- a/src/services/analytics/user.ts
+++ b/src/services/analytics/user.ts
@@ -43,7 +43,9 @@ export const getUserId = async (): Promise<string> => {
 
       return newId;
     } catch (setError) {
-      logger.warn(
+      // Session-only fallback is in place; not actionable as a
+      // breadcrumb for downstream errors.
+      logger.info(
         DEBUG_CONFIG.LOG_PREFIX,
         "Failed to persist user ID, using session-only",
         setError,
@@ -119,7 +121,8 @@ export const identifyUser = async (): Promise<void> => {
 
       lastIdentifiedUserId = userId;
 
-      logger.warn(
+      // Local storage succeeded; not actionable as a breadcrumb.
+      logger.info(
         DEBUG_CONFIG.LOG_PREFIX,
         "Failed to set user ID in Amplitude, but stored locally",
         { userId, amplitudeError },

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -161,9 +161,15 @@ export function createApiService(options: ApiServiceOptions) {
     (response) => response,
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     (error) => {
+      // When the server didn't respond at all (offline, DNS, TLS failure,
+      // captive portal, request aborted before headers), use 0 as the status
+      // to match the ApiError JSDoc ("HTTP status code (or 0 if no response)").
+      // The previous fallback of 500 made connectivity failures look like real
+      // backend 500s in Sentry — they ended up grouped together, hiding both
+      // the actual offline volume and any real server bugs.
       const apiError: ApiError = {
         message: error.message || "An error occurred",
-        status: error.response?.status || 500,
+        status: error.response?.status ?? 0,
         data: error.response?.data,
         isNetworkError: !error.response,
       };

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -167,11 +167,18 @@ export function createApiService(options: ApiServiceOptions) {
       // if no response)"). Avoid defaulting to a real HTTP code like
       // 500: that would make connectivity failures indistinguishable
       // from genuine backend errors in error reporting.
+      //
+      // `isNetworkError` is reserved for genuine connectivity failures
+      // (offline, DNS, TLS, captive portal). Axios timeouts also have
+      // `error.response === undefined` but represent backend latency,
+      // not connectivity - they are deliberately excluded so consumers
+      // branching on `isApiNetworkError` route them to `logger.error`
+      // and preserve Sentry visibility for latency regressions.
       const apiError: ApiError = {
         message: error.message || "An error occurred",
         status: error.response?.status ?? 0,
         data: error.response?.data,
-        isNetworkError: !error.response,
+        isNetworkError: !error.response && error.code !== "ECONNABORTED",
       };
       /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import { logger } from "config/logger";
 import { debug } from "helpers/debug";
 
 /**
@@ -443,3 +444,28 @@ export function isApiNetworkError(error: unknown): error is ApiError {
     (error as ApiError).isNetworkError === true
   );
 }
+
+/**
+ * Routes an API error to `logger.warn` (connectivity failures) or
+ * `logger.error` (real backend bugs / timeouts) based on
+ * `isApiNetworkError`.
+ *
+ * @param context     Logger context (typically the module/function name)
+ * @param warnMessage Message used when the failure is a connectivity issue
+ * @param errorMessage Message used when the failure is a real backend bug
+ * @param error       The thrown value from the API call
+ * @param args        Optional structured args forwarded to the logger
+ */
+export const logApiError = (
+  context: string,
+  warnMessage: string,
+  errorMessage: string,
+  error: unknown,
+  ...args: unknown[]
+): void => {
+  if (isApiNetworkError(error)) {
+    logger.warn(context, warnMessage, error, ...args);
+  } else {
+    logger.error(context, errorMessage, error, ...args);
+  }
+};

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -184,7 +184,10 @@ export function createApiService(options: ApiServiceOptions) {
         // Excluding it from `isNetworkError` keeps timeouts on the
         // logger.error path (real backend latency) rather than the
         // logger.warn / connectivity path.
-        isNetworkError: !error.response && error.code !== "ECONNABORTED",
+        isNetworkError:
+          axios.isAxiosError(error) &&
+          !error.response &&
+          error.code !== "ECONNABORTED",
       };
       /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -178,6 +178,12 @@ export function createApiService(options: ApiServiceOptions) {
         message: error.message || "An error occurred",
         status: error.response?.status ?? 0,
         data: error.response?.data,
+        // ECONNABORTED is the axios code for "request aborted by the
+        // client" - which in practice almost always means the
+        // configured `timeout` elapsed before the server responded.
+        // Excluding it from `isNetworkError` keeps timeouts on the
+        // logger.error path (real backend latency) rather than the
+        // logger.warn / connectivity path.
         isNetworkError: !error.response && error.code !== "ECONNABORTED",
       };
       /* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -162,11 +162,11 @@ export function createApiService(options: ApiServiceOptions) {
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     (error) => {
       // When the server didn't respond at all (offline, DNS, TLS failure,
-      // captive portal, request aborted before headers), use 0 as the status
-      // to match the ApiError JSDoc ("HTTP status code (or 0 if no response)").
-      // The previous fallback of 500 made connectivity failures look like real
-      // backend 500s in Sentry — they ended up grouped together, hiding both
-      // the actual offline volume and any real server bugs.
+      // captive portal, request aborted before headers), use 0 as the
+      // status to match the ApiError contract ("HTTP status code (or 0
+      // if no response)"). Avoid defaulting to a real HTTP code like
+      // 500: that would make connectivity failures indistinguishable
+      // from genuine backend errors in error reporting.
       const apiError: ApiError = {
         message: error.message || "An error occurred",
         status: error.response?.status ?? 0,

--- a/src/services/apiFactory.ts
+++ b/src/services/apiFactory.ts
@@ -412,3 +412,18 @@ export function isRequestCanceled(error: unknown): boolean {
       error.message === "canceled")
   );
 }
+
+/**
+ * Type guard for ApiError values produced by the apiFactory response
+ * interceptor when the server didn't respond at all (offline, DNS, TLS,
+ * captive portal, etc.). Use this to branch error handling so connectivity
+ * failures don't get logged with the same severity as real backend bugs.
+ */
+export function isApiNetworkError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "isNetworkError" in error &&
+    (error as ApiError).isNetworkError === true
+  );
+}

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -482,6 +482,7 @@ export const getTokenDetails = async ({
         logger.warn(
           "backendApi.getTokenDetails",
           "Network unreachable while fetching token details",
+          error,
         );
       } else {
         logger.error(
@@ -546,6 +547,7 @@ export const isSacContractExecutable = async (
       logger.warn(
         "backendApi.isSacContractExecutable",
         "Network unreachable while checking SAC contract",
+        error,
       );
     } else {
       logger.error(
@@ -611,6 +613,7 @@ export const getIndexerAccountHistory = async ({
       logger.warn(
         "backendApi.getAccountHistory",
         "Network unreachable while fetching account history",
+        error,
       );
     } else {
       logger.error(
@@ -1162,6 +1165,7 @@ export const fetchCollectibles = async ({
       logger.warn(
         "backendApi.fetchCollectibles",
         "Network unreachable while fetching collectibles",
+        error,
       );
     } else {
       logger.error(

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -32,7 +32,11 @@ import {
 import { getTokenType } from "helpers/balances";
 import { bigize } from "helpers/bigize";
 import { getNativeContractDetails } from "helpers/soroban";
-import { createApiService, isRequestCanceled } from "services/apiFactory";
+import {
+  createApiService,
+  isApiNetworkError,
+  isRequestCanceled,
+} from "services/apiFactory";
 
 // Create dedicated API services for backend operations
 export const freighterBackendV1 = createApiService({
@@ -1115,11 +1119,23 @@ export const fetchCollectibles = async ({
 
     return data.data.collections;
   } catch (error) {
-    logger.error(
-      "backendApi.fetchCollectibles",
-      "Error fetching collectibles",
-      error,
-    );
+    // Connectivity failures (offline, DNS, TLS, captive portal) are not
+    // backend bugs — demote to warn so they remain as breadcrumb context
+    // without creating top-level Sentry issues. Real failures (4xx/5xx
+    // responses, malformed payloads, the "Invalid response from server"
+    // throw above) still surface as logger.error.
+    if (isApiNetworkError(error)) {
+      logger.warn(
+        "backendApi.fetchCollectibles",
+        "Network unreachable while fetching collectibles",
+      );
+    } else {
+      logger.error(
+        "backendApi.fetchCollectibles",
+        "Error fetching collectibles",
+        error,
+      );
+    }
 
     throw error;
   }

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -1134,10 +1134,15 @@ export const fetchCollectibles = async ({
     );
 
     if (!data.data || !data.data.collections) {
-      logger.error(
+      // Demote this inner log to a breadcrumb so it doesn't fire its
+      // own captureException - the catch below already logs the
+      // thrown Error once. Without this, one bad payload produced
+      // two Sentry events. The breadcrumb keeps the raw payload
+      // visible on the captured event for shape inspection.
+      logger.warn(
         "backendApi.fetchCollectibles",
-        "Invalid response from server",
-        data,
+        "Invalid response shape - missing data.collections",
+        { data },
       );
 
       throw new Error("Invalid response from server");

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -1141,12 +1141,16 @@ export const fetchCollectibles = async ({
       // Demote this inner log to a breadcrumb so it doesn't fire its
       // own captureException - the catch below already logs the
       // thrown Error once. Without this, one bad payload produced
-      // two Sentry events. The breadcrumb keeps the raw payload
-      // visible on the captured event for shape inspection.
+      // two Sentry events. Capture only the payload shape (top-level
+      // and inner keys) so we can recognize a backend contract change
+      // without uploading user-identifying values like account IDs.
       logger.warn(
         "backendApi.fetchCollectibles",
         "Invalid response shape - missing data.collections",
-        { data },
+        {
+          topLevelKeys: Object.keys(data ?? {}),
+          innerKeys: Object.keys((data as { data?: unknown })?.data ?? {}),
+        },
       );
 
       throw new Error("Invalid response from server");

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -472,11 +472,23 @@ export const getTokenDetails = async ({
     }
 
     if (!isRequestCanceled(error)) {
-      logger.error(
-        "backendApi.getTokenDetails",
-        "Error fetching token details",
-        error,
-      );
+      // Connectivity failures (offline, DNS, TLS, captive portal,
+      // axios client-side timeout) - demote to warn so they remain as
+      // breadcrumb context without creating top-level Sentry issues.
+      // Real backend bugs (4xx/5xx responses, malformed payloads)
+      // still surface as logger.error.
+      if (isApiNetworkError(error)) {
+        logger.warn(
+          "backendApi.getTokenDetails",
+          "Network unreachable while fetching token details",
+        );
+      } else {
+        logger.error(
+          "backendApi.getTokenDetails",
+          "Error fetching token details",
+          error,
+        );
+      }
     }
 
     return null;
@@ -529,11 +541,18 @@ export const isSacContractExecutable = async (
 
     return response.data.isSacContract;
   } catch (error) {
-    logger.error(
-      "backendApi.isSacContractExecutable",
-      "Error fetching sac contract executable",
-      error,
-    );
+    if (isApiNetworkError(error)) {
+      logger.warn(
+        "backendApi.isSacContractExecutable",
+        "Network unreachable while checking SAC contract",
+      );
+    } else {
+      logger.error(
+        "backendApi.isSacContractExecutable",
+        "Error fetching sac contract executable",
+        error,
+      );
+    }
 
     return false;
   }
@@ -587,11 +606,18 @@ export const getIndexerAccountHistory = async ({
 
     return response.data;
   } catch (error) {
-    logger.error(
-      "backendApi.getAccountHistory",
-      "Error fetching account history",
-      error,
-    );
+    if (isApiNetworkError(error)) {
+      logger.warn(
+        "backendApi.getAccountHistory",
+        "Network unreachable while fetching account history",
+      );
+    } else {
+      logger.error(
+        "backendApi.getAccountHistory",
+        "Error fetching account history",
+        error,
+      );
+    }
 
     return [];
   }

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -34,8 +34,8 @@ import { bigize } from "helpers/bigize";
 import { getNativeContractDetails } from "helpers/soroban";
 import {
   createApiService,
-  isApiNetworkError,
   isRequestCanceled,
+  logApiError,
 } from "services/apiFactory";
 
 // Create dedicated API services for backend operations
@@ -478,19 +478,12 @@ export const getTokenDetails = async ({
       // responses, malformed payloads) and axios client-side timeouts
       // (carved out of isApiNetworkError so latency regressions stay
       // visible) still surface as logger.error.
-      if (isApiNetworkError(error)) {
-        logger.warn(
-          "backendApi.getTokenDetails",
-          "Network unreachable while fetching token details",
-          error,
-        );
-      } else {
-        logger.error(
-          "backendApi.getTokenDetails",
-          "Error fetching token details",
-          error,
-        );
-      }
+      logApiError(
+        "backendApi.getTokenDetails",
+        "Network unreachable while fetching token details",
+        "Error fetching token details",
+        error,
+      );
     }
 
     return null;
@@ -543,19 +536,12 @@ export const isSacContractExecutable = async (
 
     return response.data.isSacContract;
   } catch (error) {
-    if (isApiNetworkError(error)) {
-      logger.warn(
-        "backendApi.isSacContractExecutable",
-        "Network unreachable while checking SAC contract",
-        error,
-      );
-    } else {
-      logger.error(
-        "backendApi.isSacContractExecutable",
-        "Error fetching sac contract executable",
-        error,
-      );
-    }
+    logApiError(
+      "backendApi.isSacContractExecutable",
+      "Network unreachable while checking SAC contract",
+      "Error fetching sac contract executable",
+      error,
+    );
 
     return false;
   }
@@ -609,19 +595,12 @@ export const getIndexerAccountHistory = async ({
 
     return response.data;
   } catch (error) {
-    if (isApiNetworkError(error)) {
-      logger.warn(
-        "backendApi.getAccountHistory",
-        "Network unreachable while fetching account history",
-        error,
-      );
-    } else {
-      logger.error(
-        "backendApi.getAccountHistory",
-        "Error fetching account history",
-        error,
-      );
-    }
+    logApiError(
+      "backendApi.getAccountHistory",
+      "Network unreachable while fetching account history",
+      "Error fetching account history",
+      error,
+    );
 
     return [];
   }
@@ -1165,19 +1144,12 @@ export const fetchCollectibles = async ({
     // throw above) and axios client-side timeouts (carved out of
     // isApiNetworkError so latency regressions stay visible) still
     // surface as logger.error.
-    if (isApiNetworkError(error)) {
-      logger.warn(
-        "backendApi.fetchCollectibles",
-        "Network unreachable while fetching collectibles",
-        error,
-      );
-    } else {
-      logger.error(
-        "backendApi.fetchCollectibles",
-        "Error fetching collectibles",
-        error,
-      );
-    }
+    logApiError(
+      "backendApi.fetchCollectibles",
+      "Network unreachable while fetching collectibles",
+      "Error fetching collectibles",
+      error,
+    );
 
     throw error;
   }

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -472,11 +472,12 @@ export const getTokenDetails = async ({
     }
 
     if (!isRequestCanceled(error)) {
-      // Connectivity failures (offline, DNS, TLS, captive portal,
-      // axios client-side timeout) - demote to warn so they remain as
-      // breadcrumb context without creating top-level Sentry issues.
-      // Real backend bugs (4xx/5xx responses, malformed payloads)
-      // still surface as logger.error.
+      // Connectivity failures (offline, DNS, TLS, captive portal) -
+      // demote to warn so they remain as breadcrumb context without
+      // creating top-level Sentry issues. Backend bugs (4xx/5xx
+      // responses, malformed payloads) and axios client-side timeouts
+      // (carved out of isApiNetworkError so latency regressions stay
+      // visible) still surface as logger.error.
       if (isApiNetworkError(error)) {
         logger.warn(
           "backendApi.getTokenDetails",
@@ -1152,9 +1153,11 @@ export const fetchCollectibles = async ({
   } catch (error) {
     // Connectivity failures (offline, DNS, TLS, captive portal) are not
     // backend bugs — demote to warn so they remain as breadcrumb context
-    // without creating top-level Sentry issues. Real failures (4xx/5xx
+    // without creating top-level Sentry issues. Backend bugs (4xx/5xx
     // responses, malformed payloads, the "Invalid response from server"
-    // throw above) still surface as logger.error.
+    // throw above) and axios client-side timeouts (carved out of
+    // isApiNetworkError so latency regressions stay visible) still
+    // surface as logger.error.
     if (isApiNetworkError(error)) {
       logger.warn(
         "backendApi.fetchCollectibles",

--- a/src/services/friendbot.ts
+++ b/src/services/friendbot.ts
@@ -1,6 +1,6 @@
 import { FRIENDBOT_URLS, NETWORKS } from "config/constants";
 import { logger } from "config/logger";
-import { createApiService, isApiNetworkError } from "services/apiFactory";
+import { createApiService, logApiError } from "services/apiFactory";
 
 // Create a dedicated API service for backend operations
 const friendBotTestnet = createApiService({
@@ -24,14 +24,11 @@ export const fundAccount = async (publicKey: string, network: NETWORKS) => {
   try {
     await friendBot.get(`?addr=${encodeURIComponent(publicKey)}`);
   } catch (error) {
-    if (isApiNetworkError(error)) {
-      logger.warn(
-        "friendbot",
-        "Network unreachable while funding account",
-        error,
-      );
-    } else {
-      logger.error("friendbot", "Error funding account", error);
-    }
+    logApiError(
+      "friendbot",
+      "Network unreachable while funding account",
+      "Error funding account",
+      error,
+    );
   }
 };

--- a/src/services/friendbot.ts
+++ b/src/services/friendbot.ts
@@ -25,7 +25,11 @@ export const fundAccount = async (publicKey: string, network: NETWORKS) => {
     await friendBot.get(`?addr=${encodeURIComponent(publicKey)}`);
   } catch (error) {
     if (isApiNetworkError(error)) {
-      logger.warn("friendbot", "Network unreachable while funding account");
+      logger.warn(
+        "friendbot",
+        "Network unreachable while funding account",
+        error,
+      );
     } else {
       logger.error("friendbot", "Error funding account", error);
     }

--- a/src/services/friendbot.ts
+++ b/src/services/friendbot.ts
@@ -1,6 +1,6 @@
 import { FRIENDBOT_URLS, NETWORKS } from "config/constants";
 import { logger } from "config/logger";
-import { createApiService } from "services/apiFactory";
+import { createApiService, isApiNetworkError } from "services/apiFactory";
 
 // Create a dedicated API service for backend operations
 const friendBotTestnet = createApiService({
@@ -24,6 +24,10 @@ export const fundAccount = async (publicKey: string, network: NETWORKS) => {
   try {
     await friendBot.get(`?addr=${encodeURIComponent(publicKey)}`);
   } catch (error) {
-    logger.error("friendbot", "Error funding account", error);
+    if (isApiNetworkError(error)) {
+      logger.warn("friendbot", "Network unreachable while funding account");
+    } else {
+      logger.error("friendbot", "Error funding account", error);
+    }
   }
 };

--- a/src/services/stellar.ts
+++ b/src/services/stellar.ts
@@ -118,7 +118,10 @@ export const getSorobanRpcServer = (network: NETWORKS) => {
       allowHttp: getIsAllowHttp(sorobanRpcUrl),
     });
   } catch (serverError) {
-    logger.warn("StellarService", "Failed to instantiate Soroban RPC Server", {
+    // Soroban RPC isn't available on every network/configuration; the
+    // null return is checked by callers and the app falls back to
+    // non-Soroban code paths. Not actionable as a breadcrumb.
+    logger.info("StellarService", "Failed to instantiate Soroban RPC Server", {
       error: String(serverError),
     });
     return null;

--- a/src/services/stellarExpert.ts
+++ b/src/services/stellarExpert.ts
@@ -3,7 +3,11 @@ import { NETWORKS } from "config/constants";
 import { logger, normalizeError } from "config/logger";
 import { SearchTokenResponse } from "config/types";
 import { getApiStellarExpertUrl } from "helpers/stellarExpert";
-import { createApiService, isRequestCanceled } from "services/apiFactory";
+import {
+  createApiService,
+  isApiNetworkError,
+  isRequestCanceled,
+} from "services/apiFactory";
 
 const stellarExpertApiTestnet = createApiService({
   baseURL: getApiStellarExpertUrl(NETWORKS.TESTNET),
@@ -37,7 +41,13 @@ export const searchToken = async (
 
     return response.data;
   } catch (error) {
-    if (!isRequestCanceled(error)) {
+    if (isRequestCanceled(error)) {
+      return null;
+    }
+
+    if (isApiNetworkError(error)) {
+      logger.warn("stellarExpert", "Network unreachable while searching token");
+    } else {
       logger.error("stellarExpert", "Error searching token", error);
     }
 

--- a/src/services/stellarExpert.ts
+++ b/src/services/stellarExpert.ts
@@ -46,7 +46,11 @@ export const searchToken = async (
     }
 
     if (isApiNetworkError(error)) {
-      logger.warn("stellarExpert", "Network unreachable while searching token");
+      logger.warn(
+        "stellarExpert",
+        "Network unreachable while searching token",
+        error,
+      );
     } else {
       logger.error("stellarExpert", "Error searching token", error);
     }

--- a/src/services/stellarExpert.ts
+++ b/src/services/stellarExpert.ts
@@ -1,12 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 import { NETWORKS } from "config/constants";
-import { logger, normalizeError } from "config/logger";
+import { normalizeError } from "config/logger";
 import { SearchTokenResponse } from "config/types";
 import { getApiStellarExpertUrl } from "helpers/stellarExpert";
 import {
   createApiService,
-  isApiNetworkError,
   isRequestCanceled,
+  logApiError,
 } from "services/apiFactory";
 
 const stellarExpertApiTestnet = createApiService({
@@ -45,15 +45,12 @@ export const searchToken = async (
       return null;
     }
 
-    if (isApiNetworkError(error)) {
-      logger.warn(
-        "stellarExpert",
-        "Network unreachable while searching token",
-        error,
-      );
-    } else {
-      logger.error("stellarExpert", "Error searching token", error);
-    }
+    logApiError(
+      "stellarExpert",
+      "Network unreachable while searching token",
+      "Error searching token",
+      error,
+    );
 
     return null;
   }

--- a/src/services/storage/secureStorage.ts
+++ b/src/services/storage/secureStorage.ts
@@ -89,18 +89,16 @@ export const createSecureStorage = (serviceName: string) => ({
 
       await Keychain.setGenericPassword(key, value, storageOptions);
     } catch (error) {
-      if (isInteractionNotAllowed(error)) {
-        logger.warn(
-          "secureStorage.setItem",
-          "Keychain write blocked - app likely backgrounded or device locked",
-        );
-      } else {
-        logger.error(
-          "secureStorage.setItem",
-          "Error storing item in keychain",
-          error,
-        );
-      }
+      // Writes happen on auth-critical paths (createTemporaryStore,
+      // biometricDataStorage.setItem during sign-in/import). The user is
+      // in foreground when these run, so errSecInteractionNotAllowed here
+      // is unusual and indicates a real failure to persist credentials -
+      // keep on logger.error so we have visibility on auth-flow regressions.
+      logger.error(
+        "secureStorage.setItem",
+        "Error storing item in keychain",
+        error,
+      );
       throw new Error("Failed to store item in keychain");
     }
   },
@@ -178,18 +176,14 @@ export const createSecureStorage = (serviceName: string) => ({
         service: `${serviceName}_${keys}`,
       });
     } catch (error) {
-      if (isInteractionNotAllowed(error)) {
-        logger.warn(
-          "secureStorage.remove",
-          "Keychain remove blocked - app likely backgrounded or device locked",
-        );
-      } else {
-        logger.error(
-          "secureStorage.remove",
-          "Error removing keys from keychain",
-          error,
-        );
-      }
+      // Removal failures are security-relevant (used to delete sensitive
+      // keys during logout / wipe / account deletion). Silent failures
+      // would leave stale credentials on device - keep on logger.error.
+      logger.error(
+        "secureStorage.remove",
+        "Error removing keys from keychain",
+        error,
+      );
       // Don't throw since removal failures shouldn't block execution
     }
   },
@@ -239,14 +233,11 @@ export const createSecureStorage = (serviceName: string) => ({
         matching.map((service) => Keychain.resetGenericPassword({ service })),
       );
     } catch (error) {
-      if (isInteractionNotAllowed(error)) {
-        logger.warn(
-          "secureStorage.clear",
-          "Keychain clear blocked - app likely backgrounded or device locked",
-        );
-      } else {
-        logger.error("secureStorage.clear", "Error clearing keychain", error);
-      }
+      // clear() is part of the logout / wipe path. If keychain deletion
+      // is blocked the method swallows the failure (no throw) and logout
+      // proceeds, leaving credentials on device. That's security-relevant
+      // and we want full visibility - keep on logger.error.
+      logger.error("secureStorage.clear", "Error clearing keychain", error);
     }
   },
 });

--- a/src/services/storage/secureStorage.ts
+++ b/src/services/storage/secureStorage.ts
@@ -41,8 +41,12 @@ export const BIOMETRIC_STORAGE_SERVICE = "freighter_biometric_storage";
  */
 const IOS_INTERACTION_NOT_ALLOWED = "User interaction is not allowed.";
 
-const isInteractionNotAllowed = (error: unknown): boolean =>
-  error instanceof Error && error.message === IOS_INTERACTION_NOT_ALLOWED;
+const isInteractionNotAllowed = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") return false;
+  return (
+    (error as { message?: unknown }).message === IOS_INTERACTION_NOT_ALLOWED
+  );
+};
 
 /**
  * Options for storing/retrieving items from secure storage

--- a/src/services/storage/secureStorage.ts
+++ b/src/services/storage/secureStorage.ts
@@ -29,6 +29,22 @@ export const SECURE_STORAGE_SERVICE = "freighter_secure_storage";
 export const BIOMETRIC_STORAGE_SERVICE = "freighter_biometric_storage";
 
 /**
+ * react-native-keychain's iOS bridge translates the Security framework's
+ * errSecInteractionNotAllowed (-25308) status code into this exact string.
+ * It fires when the device is locked or the app is backgrounded and our
+ * BIOMETRY_ANY_OR_DEVICE_PASSCODE access control can't surface a prompt.
+ *
+ * This is an environmental condition (Zustand rehydration on cold start
+ * before unlock, WalletConnect session restore, push notification
+ * handlers reaching for stored credentials), not a real failure — the
+ * caller already handles the empty result gracefully.
+ */
+const IOS_INTERACTION_NOT_ALLOWED = "User interaction is not allowed.";
+
+const isInteractionNotAllowed = (error: unknown): boolean =>
+  error instanceof Error && error.message === IOS_INTERACTION_NOT_ALLOWED;
+
+/**
  * Options for storing/retrieving items from secure storage
  */
 export interface SecureStorageOptions {
@@ -73,11 +89,18 @@ export const createSecureStorage = (serviceName: string) => ({
 
       await Keychain.setGenericPassword(key, value, storageOptions);
     } catch (error) {
-      logger.error(
-        "secureStorage.setItem",
-        "Error storing item in keychain",
-        error,
-      );
+      if (isInteractionNotAllowed(error)) {
+        logger.warn(
+          "secureStorage.setItem",
+          "Keychain write blocked - app likely backgrounded or device locked",
+        );
+      } else {
+        logger.error(
+          "secureStorage.setItem",
+          "Error storing item in keychain",
+          error,
+        );
+      }
       throw new Error("Failed to store item in keychain");
     }
   },
@@ -117,11 +140,18 @@ export const createSecureStorage = (serviceName: string) => ({
       const result = await Keychain.getGenericPassword(getOptions);
       return result;
     } catch (error) {
-      logger.error(
-        "secureStorage.getItem",
-        "Error retrieving item from keychain",
-        error,
-      );
+      if (isInteractionNotAllowed(error)) {
+        logger.warn(
+          "secureStorage.getItem",
+          "Keychain read blocked - app likely backgrounded or device locked",
+        );
+      } else {
+        logger.error(
+          "secureStorage.getItem",
+          "Error retrieving item from keychain",
+          error,
+        );
+      }
       return false;
     }
   },
@@ -148,11 +178,18 @@ export const createSecureStorage = (serviceName: string) => ({
         service: `${serviceName}_${keys}`,
       });
     } catch (error) {
-      logger.error(
-        "secureStorage.remove",
-        "Error removing keys from keychain",
-        error,
-      );
+      if (isInteractionNotAllowed(error)) {
+        logger.warn(
+          "secureStorage.remove",
+          "Keychain remove blocked - app likely backgrounded or device locked",
+        );
+      } else {
+        logger.error(
+          "secureStorage.remove",
+          "Error removing keys from keychain",
+          error,
+        );
+      }
       // Don't throw since removal failures shouldn't block execution
     }
   },
@@ -170,11 +207,18 @@ export const createSecureStorage = (serviceName: string) => ({
       });
       return result;
     } catch (error) {
-      logger.error(
-        "secureStorage.checkIfExists",
-        "Error checking if item exists",
-        error,
-      );
+      if (isInteractionNotAllowed(error)) {
+        logger.warn(
+          "secureStorage.checkIfExists",
+          "Keychain check blocked - app likely backgrounded or device locked",
+        );
+      } else {
+        logger.error(
+          "secureStorage.checkIfExists",
+          "Error checking if item exists",
+          error,
+        );
+      }
       return false;
     }
   },
@@ -195,7 +239,14 @@ export const createSecureStorage = (serviceName: string) => ({
         matching.map((service) => Keychain.resetGenericPassword({ service })),
       );
     } catch (error) {
-      logger.error("secureStorage.clear", "Error clearing keychain", error);
+      if (isInteractionNotAllowed(error)) {
+        logger.warn(
+          "secureStorage.clear",
+          "Keychain clear blocked - app likely backgrounded or device locked",
+        );
+      } else {
+        logger.error("secureStorage.clear", "Error clearing keychain", error);
+      }
     }
   },
 });

--- a/src/services/verified-token-lists/api.ts
+++ b/src/services/verified-token-lists/api.ts
@@ -1,6 +1,6 @@
 import { NETWORKS } from "config/constants";
 import { logger } from "config/logger";
-import { createApiService } from "services/apiFactory";
+import { createApiService, isApiNetworkError } from "services/apiFactory";
 import { DEFAULT_TOKENS_LISTS } from "services/verified-token-lists/constants";
 import {
   TokenListReponseItem,
@@ -31,11 +31,22 @@ export const fetchVerifiedTokens = async ({
       const res = await service.get<TokenListResponse>("");
       return res.data;
     } catch (err) {
-      logger.error(
-        "fetchVerifiedTokens",
-        `Error retrieving verified tokens from token list: ${service.getInstance().getUri()}`,
-        err,
-      );
+      // Connectivity failures (offline, DNS, TLS, captive portal) are not
+      // backend bugs — demote to warn so they remain as breadcrumb context
+      // without creating top-level Sentry issues. Real failures (4xx/5xx
+      // responses, malformed payloads) still surface as logger.error.
+      if (isApiNetworkError(err)) {
+        logger.warn(
+          "fetchVerifiedTokens",
+          `Network unreachable for token list: ${service.getInstance().getUri()}`,
+        );
+      } else {
+        logger.error(
+          "fetchVerifiedTokens",
+          `Error retrieving verified tokens from token list: ${service.getInstance().getUri()}`,
+          err,
+        );
+      }
       return null;
     }
   });

--- a/src/services/verified-token-lists/api.ts
+++ b/src/services/verified-token-lists/api.ts
@@ -35,16 +35,25 @@ export const fetchVerifiedTokens = async ({
       // backend bugs — demote to warn so they remain as breadcrumb context
       // without creating top-level Sentry issues. Real failures (4xx/5xx
       // responses, malformed payloads) still surface as logger.error.
+      //
+      // Keep the per-list URL out of the message and pass it as a
+      // structured arg instead — interpolating it would fragment Sentry
+      // grouping into one issue per token-list URL.
+      const url = service.getInstance().getUri();
       if (isApiNetworkError(err)) {
         logger.warn(
           "fetchVerifiedTokens",
-          `Network unreachable for token list: ${service.getInstance().getUri()}`,
+          "Network unreachable for token list",
+          {
+            url,
+          },
         );
       } else {
         logger.error(
           "fetchVerifiedTokens",
-          `Error retrieving verified tokens from token list: ${service.getInstance().getUri()}`,
+          "Error retrieving verified tokens from token list",
           err,
+          { url },
         );
       }
       return null;

--- a/src/services/verified-token-lists/api.ts
+++ b/src/services/verified-token-lists/api.ts
@@ -44,9 +44,8 @@ export const fetchVerifiedTokens = async ({
         logger.warn(
           "fetchVerifiedTokens",
           "Network unreachable for token list",
-          {
-            url,
-          },
+          err,
+          { url },
         );
       } else {
         logger.error(

--- a/src/services/verified-token-lists/api.ts
+++ b/src/services/verified-token-lists/api.ts
@@ -1,6 +1,5 @@
 import { NETWORKS } from "config/constants";
-import { logger } from "config/logger";
-import { createApiService, isApiNetworkError } from "services/apiFactory";
+import { createApiService, logApiError } from "services/apiFactory";
 import { DEFAULT_TOKENS_LISTS } from "services/verified-token-lists/constants";
 import {
   TokenListReponseItem,
@@ -40,21 +39,13 @@ export const fetchVerifiedTokens = async ({
       // structured arg instead — interpolating it would fragment Sentry
       // grouping into one issue per token-list URL.
       const url = service.getInstance().getUri();
-      if (isApiNetworkError(err)) {
-        logger.warn(
-          "fetchVerifiedTokens",
-          "Network unreachable for token list",
-          err,
-          { url },
-        );
-      } else {
-        logger.error(
-          "fetchVerifiedTokens",
-          "Error retrieving verified tokens from token list",
-          err,
-          { url },
-        );
-      }
+      logApiError(
+        "fetchVerifiedTokens",
+        "Network unreachable for token list",
+        "Error retrieving verified tokens from token list",
+        err,
+        { url },
+      );
       return null;
     }
   });


### PR DESCRIPTION
### What

Cuts ~150K Sentry noise events per month from production down to a small actionable set, ahead of the alert-rule work in #813.

The events drowning Sentry today are mostly expected conditions (offline, biometric cancelled, normal lifecycle) or the same failure logged multiple times. With them out of the way, the real bugs are visible — and any threshold-based alert from #813 won't fire constantly.

### How — at a glance

Standardized three logger severity levels with clear semantics:

| Severity | Sentry behavior | Use for |
| -------- | --------------- | ------- |
| **`logger.error()`** | Top-level Sentry issue. Counts against quota. Alerts fire on it. | Real bugs and load-bearing failures that need engineering action. |
| **`logger.warn()`** | Sentry breadcrumb. Attached to any captured `logger.error()` in the same session. Zero quota cost. | Expected-but-noteworthy conditions providing forensic context. |
| **`logger.info()`** | Console only in dev, **no-op in production builds**. | Routine local-dev observations and high-volume loops. |

Then audited every log call in the codebase against this rubric. Most reductions came from demoting expected lifecycle events to `warn` or `info`. A few moved the opposite way — load-bearing failures that were silent are now `error`.

The full per-issue audit (every flagged Sentry issue, root cause, fix applied) and a deeper technical summary lives in [issue #814's review comment](https://github.com/stellar/freighter-mobile/issues/814#issuecomment-4362867626).

### Privacy hardening

- `publicKey` and snake_case backend variants (`account_id`, `public_key`, `private_key`, etc.) now redact in `sanitizeLogData`.
- A regex scrubber in `beforeSend` strips Stellar StrKeys (`G…` / `S…`) from any string surface before Sentry receives the event — so a future regression that interpolates an account ID into a log message can't leak it.
- The WalletConnect origin-mismatch log no longer attaches the raw transaction XDR.

### Documentation

Patterns + anti-patterns added at [`docs/best-practices/error-handling.md`](docs/best-practices/error-handling.md#logger-severity) so the severity rubric is the single source of truth for future contributors.

### Known limitations

- Verifying the actual volume reduction needs at least a week of post-release production data.

### Follow-ups (not addressed here)

Potential bugs surfaced during the audit are tracked separately:
- #851 — account ID drift
- #852 — encryption type-safety
- #853 — keychain error swallowing
- #855 — Sentry HTTP auto-breadcrumb URL scrubbing

### Checklist

#### PR structure
- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing
- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release
- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)