### PR TITLE
ci: add iOS Simulator PR Preview workflow (Phase 1)

### DIFF
--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -228,7 +228,7 @@ jobs:
           3. Drag the unzipped \`.app\` onto the Simulator window
           4. The app launches automatically
 
-          ⚠️ Use a fresh wallet — never enter real keys into a preview build.
+          ⚠️ This code is still under review and may contain bugs that haven't been caught yet. Use caution before signing transactions with real funds — consider testing with a testnet wallet instead.
 
           _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
           EOF

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -1,0 +1,263 @@
+# ----------------------------------------------------------------------
+# SECURITY INVARIANT — read before editing.
+#
+# This workflow builds an UNSIGNED iOS Simulator .app for PR review.
+# It deliberately uses NO Apple Developer credentials — no App Store
+# Connect API key, no Match cert, no provisioning profile. If you find
+# yourself wanting to add any of those, you are turning this into a
+# TestFlight workflow; that's a Phase 3 problem with a different
+# threat model. Stop and read § Phase 3 in the design doc first.
+#
+# Do NOT add any of these triggers:
+#   issue_comment, pull_request_target, pull_request_review,
+#   pull_request_review_comment, workflow_run
+# These triggers run with FULL repo secrets and a writable GITHUB_TOKEN
+# even when activity originates from a fork PR — combined with
+# checkout-of-PR-head + execute-code-from-PR (yarn lifecycle scripts,
+# ./scripts/gh-ios-env), they enable Remote Code Execution by anyone
+# who can comment on a PR or open one. This is the same class of
+# vulnerability that was reported against this repo's e2e workflows
+# (Q2 2026, since fixed).
+#
+# The job-level `if:` gate must run BEFORE secrets are injected.
+# `if:` on a job is evaluated by GitHub before the job's `env:` is
+# materialized, so an `if:` that fails skips the job entirely with no
+# secret exposure. Do not move the gate to a step `if:` — by then,
+# secrets are already in scope.
+#
+# See "Fullstack PR Preview Flow" design doc, § Security and
+# § Pathways → Mobile → iOS for the rationale.
+# ----------------------------------------------------------------------
+---
+name: PR Preview iOS Simulator
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build iOS Simulator .app for PR Preview
+    if: |
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+    runs-on: macos-26-xlarge
+    timeout-minutes: 45
+    permissions:
+      contents: write       # draft release create/delete + tag operations
+      pull-requests: write  # sticky preview-link comment
+    concurrency:
+      group: pr-preview-ios-simulator-build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    env:
+      NODE_VERSION: "20"
+      RUBY_VERSION: 3.1.4
+      # === Telemetry intentionally disabled in previews ===
+      SENTRY_PROPERTIES_CONTENT: "disabled-for-preview"
+      SENTRY_DSN: "disabled-for-preview"
+      AMPLITUDE_API_KEY: "disabled-for-preview"
+      AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY: "disabled-for-preview"
+      # === Backend URLs — staging only for Phase 1 (Phase 2 adds freighter-config sandbox URLs) ===
+      FREIGHTER_BACKEND_V1_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
+      FREIGHTER_BACKEND_V1_STG_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
+      FREIGHTER_BACKEND_V1_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
+      FREIGHTER_BACKEND_V2_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      FREIGHTER_BACKEND_V2_STG_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      FREIGHTER_BACKEND_V2_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      # === WalletKit dev keys (existing isolation; production keys never injected) ===
+      WALLET_KIT_PROJECT_ID_PROD: ${{ secrets.WALLET_KIT_PROJECT_ID_DEV }}
+      WALLET_KIT_MT_NAME_PROD: ${{ vars.WALLET_KIT_MT_NAME_DEV }}
+      WALLET_KIT_MT_DESCRIPTION_PROD: ${{ vars.WALLET_KIT_MT_DESCRIPTION_DEV }}
+      WALLET_KIT_MT_URL_PROD: ${{ vars.WALLET_KIT_MT_URL_DEV }}
+      WALLET_KIT_MT_ICON_PROD: ${{ vars.WALLET_KIT_MT_ICON_DEV }}
+      WALLET_KIT_MT_REDIRECT_NATIVE_PROD: ${{ vars.WALLET_KIT_MT_REDIRECT_NATIVE_DEV }}
+      WALLET_KIT_PROJECT_ID_DEV: ${{ secrets.WALLET_KIT_PROJECT_ID_DEV }}
+      WALLET_KIT_MT_NAME_DEV: ${{ vars.WALLET_KIT_MT_NAME_DEV }}
+      WALLET_KIT_MT_DESCRIPTION_DEV: ${{ vars.WALLET_KIT_MT_DESCRIPTION_DEV }}
+      WALLET_KIT_MT_URL_DEV: ${{ vars.WALLET_KIT_MT_URL_DEV }}
+      WALLET_KIT_MT_ICON_DEV: ${{ vars.WALLET_KIT_MT_ICON_DEV }}
+      WALLET_KIT_MT_REDIRECT_NATIVE_DEV: ${{ vars.WALLET_KIT_MT_REDIRECT_NATIVE_DEV }}
+      MP_COLLECTIONS_ADDRESSES: ${{ vars.MP_COLLECTIONS_ADDRESSES }}
+      IS_E2E_TEST: "false"
+      E2E_TEST_RECOVERY_PHRASE: ""
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Make scripts executable
+        run: find scripts -type f -exec chmod +x {} \;
+
+      - name: Display iOS environment information
+        run: ./scripts/display-ios-environment
+
+      - name: Set latest stable Xcode version
+        run: ./scripts/setup-xcode-latest-stable
+
+      - name: Verify selected Xcode version
+        run: xcodebuild -version
+
+      - name: Set env (preview routing)
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          export IOS_SCHEME="freighter-mobile-dev"
+          ./scripts/gh-ios-env >> $GITHUB_ENV
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+          echo "PR_HEAD_SHA=${PR_HEAD_SHA}" >> $GITHUB_ENV
+
+      - name: Stub sentry.properties (no real telemetry in previews)
+        run: echo "disabled-for-preview" > ./ios/sentry.properties
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Cache Cocoapods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Run Yarn Install
+        run: yarn install --immutable
+
+      - name: Run Post Install
+        run: yarn postinstall
+
+      - name: Build iOS Simulator .app (unsigned, universal)
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -workspace ios/freighter-mobile.xcworkspace \
+            -scheme "${IOS_SCHEME}" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -derivedDataPath /tmp/build \
+            -arch arm64 -arch x86_64 \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Locate and zip .app
+        id: pack
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: |
+          set -euo pipefail
+          APP_PATH=$(find /tmp/build/Build/Products -name "*.app" -type d -maxdepth 3 | head -1)
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app bundle found in build output"
+            find /tmp/build -name "*.app" -type d | head -10
+            exit 1
+          fi
+          APP_NAME=$(basename "$APP_PATH")
+          ZIP_NAME="freighter-simulator-pr-${PR_NUMBER}.zip"
+          (cd "$(dirname "$APP_PATH")" && zip -qq -r "/tmp/${ZIP_NAME}" "${APP_NAME}")
+          ls -lh "/tmp/${ZIP_NAME}"
+          echo "zip_path=/tmp/${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "app_name=${APP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete existing preview release (idempotent)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag || true
+
+      - name: Create draft preview release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          ZIP_PATH: ${{ steps.pack.outputs.zip_path }}
+        run: |
+          set -euo pipefail
+          URL=$(gh release create "pr-preview-${PR_NUMBER}" \
+            "${ZIP_PATH}" \
+            --title "PR Preview #${PR_NUMBER} (iOS Simulator)" \
+            --notes "Internal preview iOS Simulator build for PR #${PR_NUMBER}. SDF collaborators only — non-collaborators get 404. Auto-deleted on PR close. Backend: staging." \
+            --draft)
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Post/update sticky PR comment with download link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          PR_HEAD_SHA: ${{ env.PR_HEAD_SHA }}
+          RELEASE_URL: ${{ steps.release.outputs.url }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- pr-preview-ios-simulator-comment -->"
+          BODY=$(cat <<EOF
+          $MARKER
+          ### Freighter iOS Simulator PR Preview
+
+          **Download:** [freighter-simulator-pr-${PR_NUMBER}.zip](${RELEASE_URL})
+          **Visibility:** SDF collaborators only — non-SDF GitHub users get 404 on this URL.
+          **Commit:** ${PR_HEAD_SHA}
+          **Backend:** staging
+
+          **How to install (macOS, requires Xcode):**
+          1. Download and unzip the asset
+          2. Open the Simulator app (Xcode → Open Developer Tool → Simulator, or run \`open -a Simulator\`)
+          3. Drag the unzipped \`.app\` onto the Simulator window
+          4. The app launches automatically
+
+          ⚠️ Use a fresh wallet — never enter real keys into a preview build.
+
+          _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
+          EOF
+          )
+          EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING}" -f body="$BODY"
+          else
+            gh pr comment "${PR_NUMBER}" --body "$BODY"
+          fi
+
+  cleanup:
+    name: Cleanup PR Preview Draft Release (iOS)
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    concurrency:
+      group: pr-preview-ios-simulator-cleanup-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Delete draft release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag || true


### PR DESCRIPTION
## Summary

Adds a new `prPreviewIos.yml` workflow that builds an unsigned iOS Simulator `.app` on every PR opened by an SDF org member, attaches it to a draft GitHub Release on `stellar/freighter-mobile`, and posts a sticky PR comment with download + install instructions.

This is the **mobile half** of the Fullstack PR Preview Phase 1 work. The extension half is at stellar/freighter#2771.

## Why Simulator, not TestFlight

Phase 1 deliberately uses iOS Simulator builds rather than TestFlight. The decision is documented in detail in the Fullstack PR Preview Flow design doc § Pathways → Mobile → iOS, but the short version:

- **Simulator builds need NO Apple Developer credentials** — no App Store Connect API key, no Fastlane Match cert, no provisioning profile. The largest credential surface in the original plan is gone.
- Phase 2 (sandbox-backed previews) wouldn't be able to use TestFlight anyway, because sandbox URLs aren't reachable from iOS devices without an OS-level VPN (sshuttle has no iOS client). TestFlight against sandbox is only viable in Phase 3 with Tailscale.
- Building Phase 1 TestFlight would mean provisioning isolated production-cert-class credentials for one phase of value, then immediately losing the capability in Phase 2.

Physical-device iOS testing returns in Phase 3 alongside Tailscale, pairing TestFlight + Closed Testing with their first-time credential isolation work.

## Security model

Mirrors the extension `prPreview.yml` (stellar/freighter#2771):

- Trigger is `pull_request` only — never `pull_request_target`, `issue_comment`, or `workflow_run`. The forbidden-triggers invariant is documented at the top of the YAML with an explicit reference to the Q2 2026 e2e RCE class that this gate prevents.
- Job-level `if:` gate combining fork-guard + `author_association in ['MEMBER', 'OWNER']`, evaluated before secrets are injected. Verified empirically (stellar/freighter#2760, since closed) that fork PRs do not see workflow secrets.
- Workflow-level `permissions: {}`; `contents: write` and `pull-requests: write` granted per-job only where needed. Cleanup job intentionally lacks `pull-requests: write` — the sticky comment is left on closed PRs as a historical record (the design call was to avoid broadening cleanup's token scope).
- Separate concurrency groups for build vs cleanup so a PR close cannot cancel an in-flight build mid-publish.

## Secret surface — exactly one repo Secret

The workflow references only `WALLET_KIT_PROJECT_ID_DEV` (mapped into both the `_PROD` and `_DEV` WalletKit env slots so production WalletKit is unreachable from preview builds). No Apple Connect, no Match, no Match GitHub App, no Sentry, no Amplitude, no Android keystores. Telemetry stubs are literal strings.

Blast radius if the workflow is ever compromised: the WalletKit DEV project ID. That's it.

## Draft-release visibility

Confirmed on `stellar/freighter` (2026-05-08) — same `stellar` org, same Read-base permission settings apply:

- SDF write+ accounts: can see ✓
- SDF read-only collaborators: can see ✓
- Non-SDF accounts: 404 ✓
- Anonymous: not listed on the public Releases page ✓

If we want to be extra-careful, easy to re-verify on `stellar/freighter-mobile` with a 60-second throwaway draft test before this lands.

## Test plan

- [ ] Workflow lints clean (CI will check)
- [ ] Open a follow-up test PR from an in-repo SDF branch; confirm draft release `pr-preview-N` is created on stellar/freighter-mobile, sticky comment is posted, install instructions render correctly
- [ ] Download the `.app.zip` from the draft, drag into iOS Simulator on Mac (both Intel and Apple Silicon if possible); app launches and reaches staging backend
- [ ] Confirm a non-SDF GitHub account 404s on the draft release URL
- [ ] Confirm closing the PR deletes the draft release
- [ ] Verify no `APPLE_CONNECT_*` / `FASTLANE_MATCH_*` / `MATCH_GITHUB_APP_*` secrets are referenced (grep test)

## Related

- Design doc: `Fullstack PR Preview Flow` (Phase 1 rollout)
- Security review template: `pr-preview-workflow-security-review.md` (Phase 1 extension review; same threat model applies)
- Parallel extension PR: stellar/freighter#2771
- Issue: #860 (rescoped from "Phase 2 iOS Simulator" to "Phase 1 iOS Simulator")
- Phase 2 follow-up: #859 (workflow integration with `freighter-config` for sandbox URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)