### PR TITLE
ci: add iOS Simulator PR Preview workflow (Phase 1)

### DIFF
--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -132,7 +132,21 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           export IOS_SCHEME="freighter-mobile-dev"
-          ./scripts/gh-ios-env >> $GITHUB_ENV
+          # Allowlist what scripts/gh-ios-env can write into $GITHUB_ENV.
+          # The script is PR-controlled code that runs before any privileged
+          # step; without this filter, a modified script could inject
+          # arbitrary env (e.g., PATH=/tmp/evil:$PATH) that poisons later
+          # steps' shell resolution and exfils GH_TOKEN through a shim.
+          # This is NOT a primary security control — a write-access attacker
+          # can submit a PR that both modifies the script AND removes this
+          # filter in the same diff (pull_request workflows run from PR
+          # HEAD's YAML). The real defenses are CODEOWNERS on .github/**
+          # and code-review discipline on CI changes. This filter is a
+          # tripwire / narrow-scenario defense / documentation of the
+          # script's expected output contract.
+          ./scripts/gh-ios-env \
+            | grep -E '^(IOS_SCHEME|FASTLANE_LANE|APP_ID|APP_VERSION|APP_NAME|BUILD_VERSION|ENVFILE)=' \
+            >> $GITHUB_ENV
           echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
           echo "PR_HEAD_SHA=${PR_HEAD_SHA}" >> $GITHUB_ENV
 

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -113,6 +113,12 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Default leaves a GITHUB_TOKEN auth header in .git/config for
+          # the rest of the job. With contents:write granted, any later
+          # code execution (yarn lifecycle scripts, build scripts) could
+          # `git push` using those persisted creds. `gh` uses GH_TOKEN env
+          # separately so disabling this doesn't affect the release flow.
+          persist-credentials: false
 
       - name: Make scripts executable
         run: find scripts -type f -exec chmod +x {} \;
@@ -171,15 +177,22 @@ jobs:
           bundler-cache: true
 
       - name: Cache Cocoapods
+        # Scope the cache to this PR so a poisoned Podfile.lock from one
+        # PR cannot contaminate another build via the prefix `restore-keys`
+        # fallback. Pre-fix layout used a bare `${{ runner.os }}-pods-`
+        # prefix which let any branch's cache restore into any other
+        # branch's build. PR-scoped keys cost one cache miss on the first
+        # build of each new PR; thereafter the same PR reuses its own
+        # cache across pushes.
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ios/Pods
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-pr-${{ github.event.pull_request.number }}-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-pods-
+            ${{ runner.os }}-pods-pr-${{ github.event.pull_request.number }}-
 
       - name: Run Yarn Install
         # WORKAROUND for a bug in scripts/build-scrypt-16kb-aligned.js (invoked
@@ -288,7 +301,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
-        run: gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag || true
+        # Check-then-delete instead of `|| true`. `|| true` would also
+        # swallow transient API errors (network, 422 tag-conflict) and let
+        # the subsequent `gh release create` silently reuse a stale tag
+        # pointing at an old commit.
+        run: |
+          if gh release view "pr-preview-${PR_NUMBER}" > /dev/null 2>&1; then
+            gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag
+          fi
 
       - name: Create draft preview release
         id: release
@@ -324,13 +344,19 @@ jobs:
           # Don't capture stdout from `gh release create` — it can include
           # progress/status lines, not just the URL. Query the URL with a
           # dedicated `gh release view --json url` call instead.
-          # Pass --target so if the draft is ever manually published, the
-          # resulting git tag points at the PR's HEAD commit, not main.
+          #
+          # No --target: if the draft is ever manually published, the tag
+          # falls back to main HEAD (reviewed code) rather than the PR's
+          # HEAD commit (unreviewed). Dropping the targeted-tag property
+          # closes a one-click escalation path where any account that can
+          # click "Publish release" on a draft mints an official-looking
+          # release containing arbitrary PR-head code; branch-protection
+          # rules do not extend to release publication. The PR's HEAD
+          # commit is still recorded in the release notes for traceability.
           gh release create "pr-preview-${PR_NUMBER}" \
             "${ZIP_PATH}" \
             --title "PR Preview #${PR_NUMBER} (iOS Simulator)" \
             --notes-file /tmp/release-notes.md \
-            --target "${PR_HEAD_SHA}" \
             --draft > /dev/null
           URL=$(gh release view "pr-preview-${PR_NUMBER}" --json url --jq '.url')
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
@@ -376,4 +402,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag || true
+        # Skip silently if the release doesn't exist (race with a cancelled
+        # build), but fail loudly on any other delete error rather than
+        # masking it with `|| true`.
+        run: |
+          if gh release view "pr-preview-${PR_NUMBER}" > /dev/null 2>&1; then
+            gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag
+          fi

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -38,6 +38,21 @@ on:
 permissions: {}
 
 jobs:
+  debug-context:
+    name: DEBUG dump github.event (temporary)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump key fields
+        run: |
+          echo "github.event_name = ${{ github.event_name }}"
+          echo "github.event.action = ${{ github.event.action }}"
+          echo "github.repository = ${{ github.repository }}"
+          echo "github.event.pull_request.head.repo.full_name = ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "github.event.pull_request.author_association = ${{ github.event.pull_request.author_association }}"
+          echo "head_match: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+          echo "is_member_or_owner: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) }}"
+          echo "action_not_closed: ${{ github.event.action != 'closed' }}"
+
   build:
     name: Build iOS Simulator .app for PR Preview
     if: >-

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -75,13 +75,23 @@ jobs:
       SENTRY_DSN: "disabled-for-preview"
       AMPLITUDE_API_KEY: "disabled-for-preview"
       AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY: "disabled-for-preview"
-      # === Backend URLs — staging only for Phase 1 (Phase 2 adds freighter-config sandbox URLs) ===
-      FREIGHTER_BACKEND_V1_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
-      FREIGHTER_BACKEND_V1_STG_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
-      FREIGHTER_BACKEND_V1_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
-      FREIGHTER_BACKEND_V2_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
-      FREIGHTER_BACKEND_V2_STG_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
-      FREIGHTER_BACKEND_V2_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      # === Backend URLs — PROD freighter-backend in Phase 1 (Phase 2 adds freighter-config sandbox URLs) ===
+      # NOTE: previews point at PROD backend URLs, not staging. Reason:
+      # v1 staging does NOT have a public DNS entry (only the kube-internal
+      # freighter-backend-stg.kube001-dev.services.stellar-ops.com, which
+      # requires sshuttle). Pointing at prod keeps previews reachable
+      # without VPN, at the cost of read-only prod backend traffic.
+      # freighter-backend is a read-side indexer (balances, assets,
+      # history); the wallet submits txs directly to Horizon/RPC, so
+      # the choice of backend here doesn't affect write paths.
+      # When v1 stg gets a public ingress (Ops follow-up), swap back to
+      # the _STG_URL variants.
+      FREIGHTER_BACKEND_V1_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V1_PROD_URL }}
+      FREIGHTER_BACKEND_V1_STG_URL: ${{ vars.FREIGHTER_BACKEND_V1_PROD_URL }}
+      FREIGHTER_BACKEND_V1_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V1_PROD_URL }}
+      FREIGHTER_BACKEND_V2_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V2_PROD_URL }}
+      FREIGHTER_BACKEND_V2_STG_URL: ${{ vars.FREIGHTER_BACKEND_V2_PROD_URL }}
+      FREIGHTER_BACKEND_V2_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V2_PROD_URL }}
       # === WalletKit dev keys (existing isolation; production keys never injected) ===
       WALLET_KIT_PROJECT_ID_PROD: ${{ secrets.WALLET_KIT_PROJECT_ID_DEV }}
       WALLET_KIT_MT_NAME_PROD: ${{ vars.WALLET_KIT_MT_NAME_DEV }}
@@ -282,7 +292,7 @@ jobs:
           Internal preview iOS Simulator build for PR [#${PR_NUMBER}](${PR_URL}). SDF collaborators only — non-SDF GitHub users get 404 on this page. Auto-deleted when the PR is closed.
 
           **Commit:** ${PR_HEAD_SHA}
-          **Backend:** staging
+          **Backend:** production (read-only indexer; wallet writes go direct to Horizon/RPC)
 
           ### How to install (macOS, requires Xcode)
 

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -228,7 +228,7 @@ jobs:
           3. Drag the unzipped \`.app\` onto the Simulator window
           4. The app launches automatically
 
-          ⚠️ Use a fresh wallet — never enter real keys into a preview build.
+          ⚠️ This code is still under review and may contain bugs that haven't been caught yet. Use caution before signing transactions with real funds — consider testing with a testnet wallet instead.
 
           _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
           EOF

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -38,27 +38,20 @@ on:
 permissions: {}
 
 jobs:
-  debug-context:
-    name: DEBUG dump github.event (temporary)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump key fields
-        run: |
-          echo "github.event_name = ${{ github.event_name }}"
-          echo "github.event.action = ${{ github.event.action }}"
-          echo "github.repository = ${{ github.repository }}"
-          echo "github.event.pull_request.head.repo.full_name = ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "github.event.pull_request.author_association = ${{ github.event.pull_request.author_association }}"
-          echo "head_match: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
-          echo "is_member_or_owner: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) }}"
-          echo "action_not_closed: ${{ github.event.action != 'closed' }}"
-
   build:
     name: Build iOS Simulator .app for PR Preview
+    # Two-layer gate evaluated BEFORE any secret is injected:
+    #   1. Skip on PR close (handled by cleanup job)
+    #   2. Reject fork PRs (defense-in-depth — platform also withholds secrets)
+    # NOTE: we don't gate on author_association because the field in the
+    # webhook event payload only reflects PUBLIC org membership; SDF members
+    # with private memberships show as CONTRIBUTOR, which would lock them
+    # out. Non-SDF gating is handled by the org-level "Require approval
+    # for outside collaborators" setting plus the platform-level fork-PR
+    # secret-withholding.
     if: >-
       github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: macos-26-xlarge
     timeout-minutes: 45
     permissions:
@@ -260,8 +253,7 @@ jobs:
     name: Cleanup PR Preview Draft Release (iOS)
     if: >-
       github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -178,6 +178,15 @@ jobs:
         run: yarn postinstall
 
       - name: Build iOS Simulator .app (unsigned, universal)
+        env:
+          # The Xcode project has a Sentry "Upload Debug Symbols" build phase
+          # that calls sentry-cli with the SENTRY_PROPERTIES_CONTENT / SENTRY_DSN
+          # env. Preview builds intentionally disable Sentry (see workflow env
+          # above), but the build phase still tries to upload and fails the
+          # build with "An organization ID or slug is required". Setting this
+          # env var tells the Sentry build phase to skip the upload entirely.
+          # Mirrors ios-e2e.yml's pattern.
+          SENTRY_DISABLE_AUTO_UPLOAD: "true"
         run: |
           set -euo pipefail
           xcodebuild \

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -223,13 +223,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
+          PR_HEAD_SHA: ${{ env.PR_HEAD_SHA }}
           ZIP_PATH: ${{ steps.pack.outputs.zip_path }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set -euo pipefail
+          NOTES=$(cat <<EOF
+          Internal preview iOS Simulator build for PR [#${PR_NUMBER}](${PR_URL}). SDF collaborators only — non-SDF GitHub users get 404 on this page. Auto-deleted when the PR is closed.
+
+          **Commit:** ${PR_HEAD_SHA}
+          **Backend:** staging
+
+          ### How to install (macOS, requires Xcode)
+
+          1. Download the \`.zip\` from the Assets section below and unzip it
+          2. Open the Simulator app (Xcode → Open Developer Tool → Simulator, or run \`open -a Simulator\`)
+          3. Drag the unzipped \`.app\` onto the Simulator window — the app launches automatically
+
+          ### Important
+
+          This code is still under review and may contain bugs that haven't been caught yet. **Use caution before signing transactions with real funds** — consider testing with a testnet wallet instead.
+
+          _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
+          EOF
+          )
           URL=$(gh release create "pr-preview-${PR_NUMBER}" \
             "${ZIP_PATH}" \
             --title "PR Preview #${PR_NUMBER} (iOS Simulator)" \
-            --notes "Internal preview iOS Simulator build for PR #${PR_NUMBER}. SDF collaborators only — non-collaborators get 404. Auto-deleted on PR close. Backend: staging." \
+            --notes "${NOTES}" \
             --draft)
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
@@ -238,31 +259,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
-          PR_HEAD_SHA: ${{ env.PR_HEAD_SHA }}
           RELEASE_URL: ${{ steps.release.outputs.url }}
         run: |
           set -euo pipefail
           MARKER="<!-- pr-preview-ios-simulator-comment -->"
-          BODY=$(cat <<EOF
-          $MARKER
-          ### Freighter iOS Simulator PR Preview
+          BODY="${MARKER}"$'\n'"iOS Simulator preview build is ready: ${RELEASE_URL} (SDF collaborators only — install instructions in the release description)"
 
-          **Download:** [freighter-simulator-pr-${PR_NUMBER}.zip](${RELEASE_URL})
-          **Visibility:** SDF collaborators only — non-SDF GitHub users get 404 on this URL.
-          **Commit:** ${PR_HEAD_SHA}
-          **Backend:** staging
-
-          **How to install (macOS, requires Xcode):**
-          1. Download and unzip the asset
-          2. Open the Simulator app (Xcode → Open Developer Tool → Simulator, or run \`open -a Simulator\`)
-          3. Drag the unzipped \`.app\` onto the Simulator window
-          4. The app launches automatically
-
-          ⚠️ This code is still under review and may contain bugs that haven't been caught yet. Use caution before signing transactions with real funds — consider testing with a testnet wallet instead.
-
-          _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
-          EOF
-          )
           EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
           if [ -n "$EXISTING" ]; then

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -212,6 +212,16 @@ jobs:
           # "Failed to set key ${id}" on every key write. Ad-hoc signing is
           # sufficient for the iOS Simulator to embed and enforce the
           # entitlements, without needing a real cert or provisioning profile.
+          #
+          # We do NOT pass CODE_SIGN_ENTITLEMENTS on the command line — that
+          # applies the override to EVERY target in the workspace, including
+          # Pods/* targets that resolve the relative path from their own
+          # source directory and fail with:
+          #   error: Build input file cannot be found:
+          #     '.../ios/Pods/ios/freighter-mobile/freighter-mobile-dev.entitlements'
+          # The main app target already declares CODE_SIGN_ENTITLEMENTS in
+          # its .pbxproj; leaving it alone lets each target use the
+          # entitlements file (or lack thereof) it's configured for.
           xcodebuild \
             -workspace ios/freighter-mobile.xcworkspace \
             -scheme "${IOS_SCHEME}" \
@@ -224,7 +234,6 @@ jobs:
             CODE_SIGNING_REQUIRED=YES \
             CODE_SIGNING_ALLOWED=YES \
             CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_ENTITLEMENTS=ios/freighter-mobile/freighter-mobile-dev.entitlements \
             DEVELOPMENT_TEAM="" \
             PROVISIONING_PROFILE_SPECIFIER="" \
             build

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -75,23 +75,22 @@ jobs:
       SENTRY_DSN: "disabled-for-preview"
       AMPLITUDE_API_KEY: "disabled-for-preview"
       AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY: "disabled-for-preview"
-      # === Backend URLs — PROD freighter-backend in Phase 1 (Phase 2 adds freighter-config sandbox URLs) ===
-      # NOTE: previews point at PROD backend URLs, not staging. Reason:
-      # v1 staging does NOT have a public DNS entry (only the kube-internal
-      # freighter-backend-stg.kube001-dev.services.stellar-ops.com, which
-      # requires sshuttle). Pointing at prod keeps previews reachable
-      # without VPN, at the cost of read-only prod backend traffic.
+      # === Backend URLs — V1 PROD, V2 STG in Phase 1 (Phase 2 adds freighter-config sandbox URLs) ===
+      # V1: PROD. V1 staging does NOT have a public DNS entry — the only
+      #   v1 stg ingress is kube-internal (freighter-backend-stg.kube001-
+      #   dev.services.stellar-ops.com, sshuttle-required). When v1 stg
+      #   gets a public ingress (Ops follow-up), swap back to V1_STG.
+      # V2: STG. freighter-backend-v2-stg.stellar.org IS publicly
+      #   reachable and is the right target for preview-stage testing.
       # freighter-backend is a read-side indexer (balances, assets,
-      # history); the wallet submits txs directly to Horizon/RPC, so
-      # the choice of backend here doesn't affect write paths.
-      # When v1 stg gets a public ingress (Ops follow-up), swap back to
-      # the _STG_URL variants.
+      # history); the wallet submits txs directly to Horizon/RPC, so the
+      # backend choice here doesn't affect write paths.
       FREIGHTER_BACKEND_V1_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V1_PROD_URL }}
       FREIGHTER_BACKEND_V1_STG_URL: ${{ vars.FREIGHTER_BACKEND_V1_PROD_URL }}
       FREIGHTER_BACKEND_V1_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V1_PROD_URL }}
-      FREIGHTER_BACKEND_V2_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V2_PROD_URL }}
-      FREIGHTER_BACKEND_V2_STG_URL: ${{ vars.FREIGHTER_BACKEND_V2_PROD_URL }}
-      FREIGHTER_BACKEND_V2_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V2_PROD_URL }}
+      FREIGHTER_BACKEND_V2_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      FREIGHTER_BACKEND_V2_STG_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      FREIGHTER_BACKEND_V2_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
       # === WalletKit dev keys (existing isolation; production keys never injected) ===
       WALLET_KIT_PROJECT_ID_PROD: ${{ secrets.WALLET_KIT_PROJECT_ID_DEV }}
       WALLET_KIT_MT_NAME_PROD: ${{ vars.WALLET_KIT_MT_NAME_DEV }}
@@ -292,7 +291,7 @@ jobs:
           Internal preview iOS Simulator build for PR [#${PR_NUMBER}](${PR_URL}). SDF collaborators only — non-SDF GitHub users get 404 on this page. Auto-deleted when the PR is closed.
 
           **Commit:** ${PR_HEAD_SHA}
-          **Backend:** production (read-only indexer; wallet writes go direct to Horizon/RPC)
+          **Backend:** V1 production, V2 staging/beta (read-only indexer; wallet writes go direct to Horizon/RPC)
 
           ### How to install (macOS, requires Xcode)
 

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -150,9 +150,31 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Run Yarn Install
+        # WORKAROUND for a bug in scripts/build-scrypt-16kb-aligned.js (invoked
+        # via package.json postinstall, which yarn install triggers). The script
+        # reads ANDROID_NDK_HOME / ANDROID_NDK_ROOT and expects them to point at
+        # the PARENT `ndk/` directory so it can readdirSync and pick the latest
+        # NDK version. The macos-26-xlarge runner image sets ANDROID_NDK_ROOT
+        # to a specific version subdirectory (e.g. .../ndk/27.3.13750724),
+        # which makes the script's version-detection fail with
+        # "Error: No NDK version found in ...".
+        #
+        # We override here to point at the parent directory. Other repo
+        # workflows (ios.yml, ios-e2e.yml) will hit the same error once their
+        # next runner-image refresh picks up this env-var default — the proper
+        # fix is to patch build-scrypt-16kb-aligned.js to handle a
+        # version-pinned NDK path (just use it directly if the path is already
+        # a valid NDK version dir instead of trying to readdirSync).
+        # That patch is out of scope for this PR; track separately.
+        env:
+          ANDROID_NDK_HOME: /Users/runner/Library/Android/sdk/ndk
+          ANDROID_NDK_ROOT: /Users/runner/Library/Android/sdk/ndk
         run: yarn install --immutable
 
       - name: Run Post Install
+        env:
+          ANDROID_NDK_HOME: /Users/runner/Library/Android/sdk/ndk
+          ANDROID_NDK_ROOT: /Users/runner/Library/Android/sdk/ndk
         run: yarn postinstall
 
       - name: Build iOS Simulator .app (unsigned, universal)

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -1,0 +1,263 @@
+# ----------------------------------------------------------------------
+# SECURITY INVARIANT — read before editing.
+#
+# This workflow builds an UNSIGNED iOS Simulator .app for PR review.
+# It deliberately uses NO Apple Developer credentials — no App Store
+# Connect API key, no Match cert, no provisioning profile. If you find
+# yourself wanting to add any of those, you are turning this into a
+# TestFlight workflow; that's a Phase 3 problem with a different
+# threat model. Stop and read § Phase 3 in the design doc first.
+#
+# Do NOT add any of these triggers:
+#   issue_comment, pull_request_target, pull_request_review,
+#   pull_request_review_comment, workflow_run
+# These triggers run with FULL repo secrets and a writable GITHUB_TOKEN
+# even when activity originates from a fork PR — combined with
+# checkout-of-PR-head + execute-code-from-PR (yarn lifecycle scripts,
+# ./scripts/gh-ios-env), they enable Remote Code Execution by anyone
+# who can comment on a PR or open one. This is the same class of
+# vulnerability that was reported against this repo's e2e workflows
+# (Q2 2026, since fixed).
+#
+# The job-level `if:` gate must run BEFORE secrets are injected.
+# `if:` on a job is evaluated by GitHub before the job's `env:` is
+# materialized, so an `if:` that fails skips the job entirely with no
+# secret exposure. Do not move the gate to a step `if:` — by then,
+# secrets are already in scope.
+#
+# See "Fullstack PR Preview Flow" design doc, § Security and
+# § Pathways → Mobile → iOS for the rationale.
+# ----------------------------------------------------------------------
+---
+name: PR Preview iOS Simulator
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build iOS Simulator .app for PR Preview
+    if: |
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+    runs-on: macos-26-xlarge
+    timeout-minutes: 45
+    permissions:
+      contents: write       # draft release create/delete + tag operations
+      pull-requests: write  # sticky preview-link comment
+    concurrency:
+      group: pr-preview-ios-simulator-build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    env:
+      NODE_VERSION: "20"
+      RUBY_VERSION: 3.1.4
+      # === Telemetry intentionally disabled in previews ===
+      SENTRY_PROPERTIES_CONTENT: "disabled-for-preview"
+      SENTRY_DSN: "disabled-for-preview"
+      AMPLITUDE_API_KEY: "disabled-for-preview"
+      AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY: "disabled-for-preview"
+      # === Backend URLs — staging only for Phase 1 (Phase 2 adds freighter-config sandbox URLs) ===
+      FREIGHTER_BACKEND_V1_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
+      FREIGHTER_BACKEND_V1_STG_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
+      FREIGHTER_BACKEND_V1_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V1_STG_URL }}
+      FREIGHTER_BACKEND_V2_PROD_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      FREIGHTER_BACKEND_V2_STG_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      FREIGHTER_BACKEND_V2_DEV_URL: ${{ vars.FREIGHTER_BACKEND_V2_STG_URL }}
+      # === WalletKit dev keys (existing isolation; production keys never injected) ===
+      WALLET_KIT_PROJECT_ID_PROD: ${{ secrets.WALLET_KIT_PROJECT_ID_DEV }}
+      WALLET_KIT_MT_NAME_PROD: ${{ vars.WALLET_KIT_MT_NAME_DEV }}
+      WALLET_KIT_MT_DESCRIPTION_PROD: ${{ vars.WALLET_KIT_MT_DESCRIPTION_DEV }}
+      WALLET_KIT_MT_URL_PROD: ${{ vars.WALLET_KIT_MT_URL_DEV }}
+      WALLET_KIT_MT_ICON_PROD: ${{ vars.WALLET_KIT_MT_ICON_DEV }}
+      WALLET_KIT_MT_REDIRECT_NATIVE_PROD: ${{ vars.WALLET_KIT_MT_REDIRECT_NATIVE_DEV }}
+      WALLET_KIT_PROJECT_ID_DEV: ${{ secrets.WALLET_KIT_PROJECT_ID_DEV }}
+      WALLET_KIT_MT_NAME_DEV: ${{ vars.WALLET_KIT_MT_NAME_DEV }}
+      WALLET_KIT_MT_DESCRIPTION_DEV: ${{ vars.WALLET_KIT_MT_DESCRIPTION_DEV }}
+      WALLET_KIT_MT_URL_DEV: ${{ vars.WALLET_KIT_MT_URL_DEV }}
+      WALLET_KIT_MT_ICON_DEV: ${{ vars.WALLET_KIT_MT_ICON_DEV }}
+      WALLET_KIT_MT_REDIRECT_NATIVE_DEV: ${{ vars.WALLET_KIT_MT_REDIRECT_NATIVE_DEV }}
+      MP_COLLECTIONS_ADDRESSES: ${{ vars.MP_COLLECTIONS_ADDRESSES }}
+      IS_E2E_TEST: "false"
+      E2E_TEST_RECOVERY_PHRASE: ""
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Make scripts executable
+        run: find scripts -type f -exec chmod +x {} \;
+
+      - name: Display iOS environment information
+        run: ./scripts/display-ios-environment
+
+      - name: Set latest stable Xcode version
+        run: ./scripts/setup-xcode-latest-stable
+
+      - name: Verify selected Xcode version
+        run: xcodebuild -version
+
+      - name: Set env (preview routing)
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          export IOS_SCHEME="freighter-mobile-dev"
+          ./scripts/gh-ios-env >> $GITHUB_ENV
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+          echo "PR_HEAD_SHA=${PR_HEAD_SHA}" >> $GITHUB_ENV
+
+      - name: Stub sentry.properties (no real telemetry in previews)
+        run: echo "disabled-for-preview" > ./ios/sentry.properties
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Cache Cocoapods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Run Yarn Install
+        run: yarn install --immutable
+
+      - name: Run Post Install
+        run: yarn postinstall
+
+      - name: Build iOS Simulator .app (unsigned, universal)
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -workspace ios/freighter-mobile.xcworkspace \
+            -scheme "${IOS_SCHEME}" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -derivedDataPath /tmp/build \
+            -arch arm64 -arch x86_64 \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Locate and zip .app
+        id: pack
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: |
+          set -euo pipefail
+          APP_PATH=$(find /tmp/build/Build/Products -name "*.app" -type d -maxdepth 3 | head -1)
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app bundle found in build output"
+            find /tmp/build -name "*.app" -type d | head -10
+            exit 1
+          fi
+          APP_NAME=$(basename "$APP_PATH")
+          ZIP_NAME="freighter-simulator-pr-${PR_NUMBER}.zip"
+          (cd "$(dirname "$APP_PATH")" && zip -qq -r "/tmp/${ZIP_NAME}" "${APP_NAME}")
+          ls -lh "/tmp/${ZIP_NAME}"
+          echo "zip_path=/tmp/${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "app_name=${APP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete existing preview release (idempotent)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag || true
+
+      - name: Create draft preview release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          ZIP_PATH: ${{ steps.pack.outputs.zip_path }}
+        run: |
+          set -euo pipefail
+          URL=$(gh release create "pr-preview-${PR_NUMBER}" \
+            "${ZIP_PATH}" \
+            --title "PR Preview #${PR_NUMBER} (iOS Simulator)" \
+            --notes "Internal preview iOS Simulator build for PR #${PR_NUMBER}. SDF collaborators only — non-collaborators get 404. Auto-deleted on PR close. Backend: staging." \
+            --draft)
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Post/update sticky PR comment with download link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          PR_HEAD_SHA: ${{ env.PR_HEAD_SHA }}
+          RELEASE_URL: ${{ steps.release.outputs.url }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- pr-preview-ios-simulator-comment -->"
+          BODY=$(cat <<EOF
+          $MARKER
+          ### Freighter iOS Simulator PR Preview
+
+          **Download:** [freighter-simulator-pr-${PR_NUMBER}.zip](${RELEASE_URL})
+          **Visibility:** SDF collaborators only — non-SDF GitHub users get 404 on this URL.
+          **Commit:** ${PR_HEAD_SHA}
+          **Backend:** staging
+
+          **How to install (macOS, requires Xcode):**
+          1. Download and unzip the asset
+          2. Open the Simulator app (Xcode → Open Developer Tool → Simulator, or run \`open -a Simulator\`)
+          3. Drag the unzipped \`.app\` onto the Simulator window
+          4. The app launches automatically
+
+          ⚠️ Use a fresh wallet — never enter real keys into a preview build.
+
+          _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
+          EOF
+          )
+          EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING}" -f body="$BODY"
+          else
+            gh pr comment "${PR_NUMBER}" --body "$BODY"
+          fi
+
+  cleanup:
+    name: Cleanup PR Preview Draft Release (iOS)
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    concurrency:
+      group: pr-preview-ios-simulator-cleanup-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Delete draft release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag || true

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -37,6 +37,16 @@ on:
 
 permissions: {}
 
+# Single concurrency group across build and cleanup. When a PR closes
+# mid-build, the close-event cleanup job cancels the still-running build
+# (cancel-in-progress: true) so the build can't finish and create an
+# orphaned release after the cleanup has already deleted whatever was
+# there. The next build's "Delete existing preview release" step is
+# idempotent, so a cancelled cleanup leaves no permanent half-state.
+concurrency:
+  group: pr-preview-ios-simulator-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build iOS Simulator .app for PR Preview
@@ -57,9 +67,6 @@ jobs:
     permissions:
       contents: write       # draft release create/delete + tag operations
       pull-requests: write  # sticky preview-link comment
-    concurrency:
-      group: pr-preview-ios-simulator-build-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     env:
       NODE_VERSION: "20"
       RUBY_VERSION: 3.1.4
@@ -215,7 +222,9 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
           set -euo pipefail
-          APP_PATH=$(find /tmp/build/Build/Products -name "*.app" -type d -maxdepth 3 | head -1)
+          # -maxdepth must come before other predicates on BSD/macOS find,
+          # otherwise it is silently ignored or rejected.
+          APP_PATH=$(find /tmp/build/Build/Products -maxdepth 3 -name "*.app" -type d | head -1)
           if [ -z "$APP_PATH" ]; then
             echo "::error::No .app bundle found in build output"
             find /tmp/build -name "*.app" -type d | head -10
@@ -265,11 +274,18 @@ jobs:
 
           _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
           EOF
-          URL=$(gh release create "pr-preview-${PR_NUMBER}" \
+          # Don't capture stdout from `gh release create` — it can include
+          # progress/status lines, not just the URL. Query the URL with a
+          # dedicated `gh release view --json url` call instead.
+          # Pass --target so if the draft is ever manually published, the
+          # resulting git tag points at the PR's HEAD commit, not main.
+          gh release create "pr-preview-${PR_NUMBER}" \
             "${ZIP_PATH}" \
             --title "PR Preview #${PR_NUMBER} (iOS Simulator)" \
             --notes-file /tmp/release-notes.md \
-            --draft)
+            --target "${PR_HEAD_SHA}" \
+            --draft > /dev/null
+          URL=$(gh release view "pr-preview-${PR_NUMBER}" --json url --jq '.url')
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
       - name: Post/update sticky PR comment with download link
@@ -283,7 +299,10 @@ jobs:
           MARKER="<!-- pr-preview-ios-simulator-comment -->"
           BODY="${MARKER}"$'\n'"iOS Simulator preview build is ready: ${RELEASE_URL} (SDF collaborators only — install instructions in the release description)"
 
-          EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+          # --paginate so this works on PRs with >30 comments (default page
+          # size). Without it, the marker comment can fall off a later page
+          # and we'd post a duplicate instead of editing in place.
+          EXISTING=$(gh api --paginate "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
           if [ -n "$EXISTING" ]; then
             gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING}" -f body="$BODY"
@@ -293,6 +312,10 @@ jobs:
 
   cleanup:
     name: Cleanup PR Preview Draft Release (iOS)
+    # Shares the workflow-level concurrency group with the build job so a
+    # close-event cancels any in-flight build before deleting the release —
+    # prevents the build from finishing AFTER cleanup and re-creating an
+    # orphaned release.
     if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -300,9 +323,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    concurrency:
-      group: pr-preview-ios-simulator-cleanup-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
     steps:
       - name: Delete draft release and tag
         env:

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   build:
     name: Build iOS Simulator .app for PR Preview
-    if: |
+    if: >-
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
@@ -243,7 +243,7 @@ jobs:
 
   cleanup:
     name: Cleanup PR Preview Draft Release (iOS)
-    if: |
+    if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -237,7 +237,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set -euo pipefail
-          NOTES=$(cat <<EOF
+          # Write notes to a file rather than $(cat <<EOF) because bash's
+          # command-substitution parser tokenizes single quotes inside the
+          # heredoc body, breaking on apostrophes in prose (e.g., "haven't").
+          cat > /tmp/release-notes.md <<EOF
           Internal preview iOS Simulator build for PR [#${PR_NUMBER}](${PR_URL}). SDF collaborators only — non-SDF GitHub users get 404 on this page. Auto-deleted when the PR is closed.
 
           **Commit:** ${PR_HEAD_SHA}
@@ -251,15 +254,14 @@ jobs:
 
           ### Important
 
-          This code is still under review and may contain bugs that haven't been caught yet. **Use caution before signing transactions with real funds** — consider testing with a testnet wallet instead.
+          This code is still under review and may contain bugs that have not been caught yet. **Use caution before signing transactions with real funds** — consider testing with a testnet wallet instead.
 
           _Physical-device iOS testing returns in Phase 3 (Tailscale + TestFlight) — not available today._
           EOF
-          )
           URL=$(gh release create "pr-preview-${PR_NUMBER}" \
             "${ZIP_PATH}" \
             --title "PR Preview #${PR_NUMBER} (iOS Simulator)" \
-            --notes "${NOTES}" \
+            --notes-file /tmp/release-notes.md \
             --draft)
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -143,19 +143,21 @@ jobs:
         run: corepack enable
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        # ruby/setup-ruby uses a `v1` branch (not a tag) as its stable pointer;
+        # we pin the SHA the branch currently points at.
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
 
       - name: Cache Cocoapods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ios/Pods

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -307,7 +307,15 @@ jobs:
         # pointing at an old commit.
         run: |
           if gh release view "pr-preview-${PR_NUMBER}" > /dev/null 2>&1; then
-            gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag
+            # `--cleanup-tag` 422s on draft releases because drafts don't
+            # create the git tag until publish. Branch on isDraft so we
+            # only ask for tag-cleanup when there is actually a tag.
+            IS_DRAFT=$(gh release view "pr-preview-${PR_NUMBER}" --json isDraft --jq '.isDraft')
+            if [ "$IS_DRAFT" = "true" ]; then
+              gh release delete "pr-preview-${PR_NUMBER}" --yes
+            else
+              gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag
+            fi
           fi
 
       - name: Create draft preview release
@@ -407,5 +415,13 @@ jobs:
         # masking it with `|| true`.
         run: |
           if gh release view "pr-preview-${PR_NUMBER}" > /dev/null 2>&1; then
-            gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag
+            # `--cleanup-tag` 422s on draft releases because drafts don't
+            # create the git tag until publish. Branch on isDraft so we
+            # only ask for tag-cleanup when there is actually a tag.
+            IS_DRAFT=$(gh release view "pr-preview-${PR_NUMBER}" --json isDraft --jq '.isDraft')
+            if [ "$IS_DRAFT" = "true" ]; then
+              gh release delete "pr-preview-${PR_NUMBER}" --yes
+            else
+              gh release delete "pr-preview-${PR_NUMBER}" --yes --cleanup-tag
+            fi
           fi

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -184,7 +184,7 @@ jobs:
           ANDROID_NDK_ROOT: /Users/runner/Library/Android/sdk/ndk
         run: yarn postinstall
 
-      - name: Build iOS Simulator .app (unsigned, universal)
+      - name: Build iOS Simulator .app (ad-hoc signed for entitlements)
         env:
           # The Xcode project has a Sentry "Upload Debug Symbols" build phase
           # that calls sentry-cli with the SENTRY_PROPERTIES_CONTENT / SENTRY_DSN
@@ -203,6 +203,15 @@ jobs:
           # reviewers to maintain a local freighter-mobile checkout + run
           # Metro to launch the app. Release makes the .app self-contained.
           # Matches fastlane dev lane (fastlane/Fastfile :dev lane).
+          #
+          # SIGNING: ad-hoc (CODE_SIGN_IDENTITY="-") rather than no-signing.
+          # The entitlements file declares keychain-access-groups, which
+          # iOS only honors when the binary is signed (even ad-hoc). Without
+          # signing, the app cannot write to the org.stellar.freighterdev
+          # keychain group and react-native-keychain throws
+          # "Failed to set key ${id}" on every key write. Ad-hoc signing is
+          # sufficient for the iOS Simulator to embed and enforce the
+          # entitlements, without needing a real cert or provisioning profile.
           xcodebuild \
             -workspace ios/freighter-mobile.xcworkspace \
             -scheme "${IOS_SCHEME}" \
@@ -211,9 +220,13 @@ jobs:
             -derivedDataPath /tmp/build \
             -arch arm64 -arch x86_64 \
             ONLY_ACTIVE_ARCH=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=YES \
+            CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_ENTITLEMENTS=ios/freighter-mobile/freighter-mobile-dev.entitlements \
+            DEVELOPMENT_TEAM="" \
+            PROVISIONING_PROFILE_SPECIFIER="" \
             build
 
       - name: Locate and zip .app

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -189,10 +189,17 @@ jobs:
           SENTRY_DISABLE_AUTO_UPLOAD: "true"
         run: |
           set -euo pipefail
+          # IMPORTANT: configuration is Release, NOT Debug. Release triggers
+          # React Native's "Bundle React Native code and images" build phase,
+          # which embeds the JS bundle into the .app. Debug skips that phase
+          # and expects a Metro dev server at runtime — which would force
+          # reviewers to maintain a local freighter-mobile checkout + run
+          # Metro to launch the app. Release makes the .app self-contained.
+          # Matches fastlane dev lane (fastlane/Fastfile :dev lane).
           xcodebuild \
             -workspace ios/freighter-mobile.xcworkspace \
             -scheme "${IOS_SCHEME}" \
-            -configuration Debug \
+            -configuration Release \
             -sdk iphonesimulator \
             -derivedDataPath /tmp/build \
             -arch arm64 -arch x86_64 \


### PR DESCRIPTION
## Summary

Adds a new `prPreviewIos.yml` workflow that builds an unsigned iOS Simulator `.app` on every PR opened from an in-repo branch on stellar/freighter-mobile (i.e., by SDF contributors with write access), attaches it to a draft GitHub Release on `stellar/freighter-mobile`, and posts a sticky PR comment with download + install instructions.

This is the **mobile half** of the Fullstack PR Preview Phase 1 work. The extension half is at stellar/freighter#2771.

## Why Simulator, not TestFlight

Phase 1 deliberately uses iOS Simulator builds rather than TestFlight. The decision is documented in detail in the Fullstack PR Preview Flow design doc § Pathways → Mobile → iOS, but the short version:

- **Simulator builds need NO Apple Developer credentials** — no App Store Connect API key, no Fastlane Match cert, no provisioning profile. The largest credential surface in the original plan is gone.
- Phase 2 (sandbox-backed previews) wouldn't be able to use TestFlight anyway, because sandbox URLs aren't reachable from iOS devices without an OS-level VPN (sshuttle has no iOS client). TestFlight against sandbox is only viable in Phase 3 with Tailscale.
- Building Phase 1 TestFlight would mean provisioning isolated production-cert-class credentials for one phase of value, then immediately losing the capability in Phase 2.

Physical-device iOS testing returns in Phase 3 alongside Tailscale, pairing TestFlight + Closed Testing with their first-time credential isolation work.

## Security model

Mirrors the extension `prPreview.yml` (stellar/freighter#2771):

- Trigger is `pull_request` only — never `pull_request_target`, `issue_comment`, or `workflow_run`. The forbidden-triggers invariant is documented at the top of the YAML with an explicit reference to the Q2 2026 e2e RCE class that this gate prevents.
- Job-level `if:` gate (`head.repo.full_name == github.repository`) skips fork PRs cleanly. Real defense is platform-level: fork PRs run with empty secrets and a read-only `GITHUB_TOKEN` regardless of YAML. Verified empirically via stellar/freighter#2760 (since closed). The author_association check (originally part of the gate) was removed: the field in the webhook event payload only reflects PUBLIC org membership, locking out SDF members with private memberships. Non-SDF gating is handled by the org-level "Require approval for outside collaborators" setting plus platform-level fork-PR secret-withholding.
- Workflow-level `permissions: {}`; `contents: write` and `pull-requests: write` granted per-job only where needed. Cleanup job intentionally lacks `pull-requests: write` — the sticky comment is left on closed PRs as a historical record (the design call was to avoid broadening cleanup's token scope).
- `actions/checkout` runs with `persist-credentials: false` so the GITHUB_TOKEN auth header is not left in `.git/config` for subsequent steps to abuse via `git push`.
- Single workflow-level concurrency group across build and cleanup. A close-event cancels any in-flight build before the cleanup deletes the release, preventing the build from completing after cleanup and re-creating an orphaned release. The build's pre-create `gh release delete` is check-then-delete (not `|| true`), so a cancelled cleanup leaves no permanent half-state and transient API errors fail loudly instead of being masked.
- Cocoapods cache key is scoped per-PR (`pods-pr-${{ github.event.pull_request.number }}-${{ hashFiles('ios/Podfile.lock') }}`) so a poisoned `Podfile.lock` from one PR cannot contaminate another build via a prefix `restore-keys` fallback.
- `gh release create` does NOT pass `--target`. If a draft is ever manually published, the tag falls back to main HEAD (reviewed code) rather than the PR's HEAD commit. Closes a one-click escalation path where any account that can click "Publish release" on a draft would otherwise mint an official-looking release containing arbitrary PR-head code (branch protection rules do not extend to release publication). The PR's HEAD commit is still recorded in the release notes for traceability.

## Secret surface — exactly one repo Secret

The workflow references only `WALLET_KIT_PROJECT_ID_DEV` (mapped into both the `_PROD` and `_DEV` WalletKit env slots so production WalletKit is unreachable from preview builds). No Apple Connect, no Match, no Match GitHub App, no Sentry, no Amplitude, no Android keystores. Telemetry stubs are literal strings.

Blast radius if the workflow is ever compromised: the WalletKit DEV project ID. That's it.

## Draft-release visibility

Confirmed on `stellar/freighter` (2026-05-08) — same `stellar` org, same Read-base permission settings apply:

- SDF write+ accounts: can see ✓
- SDF read-only collaborators: can see ✓
- Non-SDF accounts: 404 ✓
- Anonymous: not listed on the public Releases page ✓

If we want to be extra-careful, easy to re-verify on `stellar/freighter-mobile` with a 60-second throwaway draft test before this lands.



## Build configuration: Release (not Debug)

The workflow uses `-configuration Release`, not Debug. **Release triggers React Native's "Bundle React Native code and images" Xcode build phase**, which runs Metro at build time and embeds the JS bundle into the `.app`. Debug skips that phase and expects a Metro dev server at runtime — which would force reviewers to maintain a local `freighter-mobile` checkout + run Metro to launch the preview. Release makes the `.app` self-contained. This matches the existing fastlane `:dev` lane (`fastlane/Fastfile:128-140`).

## Test plan

- [ ] Workflow lints clean (CI will check)
- [ ] Open a follow-up test PR from an in-repo SDF branch; confirm draft release `pr-preview-N` is created on stellar/freighter-mobile, sticky comment is posted, install instructions render correctly
- [ ] Download the `.app.zip` from the draft, drag into iOS Simulator on Mac (both Intel and Apple Silicon if possible); app launches and reaches staging backend
- [ ] Confirm a non-SDF GitHub account 404s on the draft release URL
- [ ] Confirm closing the PR deletes the draft release
- [ ] Verify no `APPLE_CONNECT_*` / `FASTLANE_MATCH_*` / `MATCH_GITHUB_APP_*` secrets are referenced (grep test)

## Related

- Design doc: `Fullstack PR Preview Flow` (Phase 1 rollout)
- Security review template: `pr-preview-workflow-security-review.md` (Phase 1 extension review; same threat model applies)
- Parallel extension PR: stellar/freighter#2771
- Issue: #860 (rescoped from "Phase 2 iOS Simulator" to "Phase 1 iOS Simulator")
- Phase 2 follow-up: #859 (workflow integration with `freighter-config` for sandbox URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



