### PR TITLE
show asset issuer on change trust op

### DIFF
--- a/src/components/screens/SignTransactionDetails/components/Operations.tsx
+++ b/src/components/screens/SignTransactionDetails/components/Operations.tsx
@@ -484,11 +484,27 @@ const RenderOperationByType = ({ operation }: { operation: Operation }) => {
           },
         );
       } else {
-        items.push({
-          title: t("signTransactionDetails.operations.tokenCode"),
-          trailingContent: <Text>{line.code}</Text>,
-          titleColor: themeColors.text.secondary,
-        });
+        items.push(
+          {
+            title: t("signTransactionDetails.operations.tokenCode"),
+            trailingContent: <Text>{line.code}</Text>,
+            titleColor: themeColors.text.secondary,
+          },
+          {
+            title: t("signTransactionDetails.operations.assetIssuer"),
+            trailingContent: (
+              <View className="flex-row items-center gap-[8px]">
+                <Icon.Copy01
+                  size={16}
+                  themeColor="gray"
+                  onPress={() => copyToClipboard(line.issuer)}
+                />
+                <Text>{truncateAddress(line.issuer)}</Text>
+              </View>
+            ),
+            titleColor: themeColors.text.secondary,
+          },
+        );
       }
 
       items.push({

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -1235,6 +1235,7 @@
       "destination": "Destination",
       "startingBalance": "Starting Balance",
       "tokenCode": "Token Code",
+      "assetIssuer": "Asset Issuer",
       "token": "Token",
       "amount": "Amount",
       "sendMax": "Send Max",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -1236,6 +1236,7 @@
       "destination": "Destino",
       "startingBalance": "Saldo inicial",
       "tokenCode": "Código do token",
+      "assetIssuer": "Emissor do ativo",
       "token": "Token",
       "amount": "Valor",
       "sendMax": "Enviar máximo",


### PR DESCRIPTION
Closes #363 

Quick fix: adds issuer address and option to copy address on change trust op

<img width="370" height="779" alt="Screenshot 2026-05-25 at 12 48 01" src="https://github.com/user-attachments/assets/3e02d8b4-1c6d-4fbe-9553-8fe09621874e" />


### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [x] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
