### PR TITLE
fix(navigation): paint scene background to remove white flicker

### DIFF
--- a/__tests__/config/navigationTheme.test.ts
+++ b/__tests__/config/navigationTheme.test.ts
@@ -1,0 +1,24 @@
+import { DefaultTheme } from "@react-navigation/native";
+import { NAVIGATION_THEME } from "config/navigationTheme";
+import { THEME } from "config/theme";
+
+describe("NAVIGATION_THEME", () => {
+  it("uses the app's dark surface as the scene background", () => {
+    // React Navigation's Native Stack paints each screen's contentStyle with
+    // the theme's `colors.background` by default. If we don't override it, the
+    // light DefaultTheme background flashes through during transitions (most
+    // visibly as a white flicker at the iOS modal's rounded corners). The
+    // navigation theme must therefore match the app's dark surface.
+    expect(NAVIGATION_THEME.colors.background).toBe(
+      THEME.colors.background.default,
+    );
+    expect(NAVIGATION_THEME.colors.card).toBe(THEME.colors.background.default);
+  });
+
+  it("does not fall back to the light DefaultTheme background", () => {
+    expect(NAVIGATION_THEME.colors.background).not.toBe(
+      DefaultTheme.colors.background,
+    );
+    expect(NAVIGATION_THEME.dark).toBe(true);
+  });
+});

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,6 +6,7 @@ import {
 import * as Sentry from "@sentry/react-native";
 import { AuthErrorToastListener } from "components/AuthErrorToastListener";
 import { initializeSentryLogger } from "config/logger";
+import { NAVIGATION_THEME } from "config/navigationTheme";
 import { RootStackParamList } from "config/routes";
 import { initializeSentry } from "config/sentryConfig";
 import { THEME } from "config/theme";
@@ -70,6 +71,7 @@ export const App = (): React.JSX.Element => {
                 <AuthErrorToastListener />
                 <NavigationContainer
                   ref={navigationRef}
+                  theme={NAVIGATION_THEME}
                   onStateChange={onStateChange}
                 >
                   <AuthCheckProvider>

--- a/src/config/navigationTheme.ts
+++ b/src/config/navigationTheme.ts
@@ -1,0 +1,30 @@
+import { DarkTheme, Theme } from "@react-navigation/native";
+import { THEME } from "config/theme";
+
+/**
+ * React Navigation theme for the app's top-level `<NavigationContainer>`.
+ *
+ * Without an explicit theme, React Navigation falls back to its light
+ * `DefaultTheme` (background `rgb(242, 242, 242)`). Native Stack uses the
+ * theme's `colors.background` as each screen's default `contentStyle`
+ * background, so that light native container shows through during transitions
+ * — most visibly as a white flicker at the iOS modal's rounded corners while a
+ * screen slides in horizontally. Painting the native scene background with the
+ * app's dark surface removes that flash for every navigator and every screen.
+ *
+ * The app forces dark mode (see `App.tsx`), so this extends `DarkTheme` and
+ * overrides the surface colors with the app's own background token.
+ *
+ * Kept in its own module (rather than `config/theme.ts`) so the design-token
+ * file stays free of the React Navigation dependency — `config/theme` is
+ * imported by nearly every component, and several component tests replace
+ * `@react-navigation/native` with an inline mock that omits `DarkTheme`.
+ */
+export const NAVIGATION_THEME: Theme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    background: THEME.colors.background.default,
+    card: THEME.colors.background.default,
+  },
+};


### PR DESCRIPTION
### What

Sets an explicit dark theme (`NAVIGATION_THEME`) on the top-level `NavigationContainer` so the native screen background is dark everywhere. Central fix for the white flicker reported in [#899 (comment)](https://github.com/stellar/freighter-mobile/pull/899#issuecomment-4770753612).

### Why

Without a `theme`, React Navigation defaults to its light theme, which Native Stack uses as each screen's native `contentStyle` background — briefly revealed (as a white flash at the corners) during transitions before the dark JS layout paints. See the JSDoc in `config/navigationTheme.ts` for the full breakdown.

#### Before fix

https://github.com/user-attachments/assets/bf490a88-306f-4bd2-8644-27df14ca8a13

https://github.com/user-attachments/assets/04dfba76-371b-4c5f-aea1-eac6328332fc

#### After fix

https://github.com/user-attachments/assets/c028ea51-5fb6-4f85-b9de-7c8b79a82bf6

https://github.com/user-attachments/assets/4bcd2904-1203-4bd9-8c97-fa85669f9183

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [x] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
