### PR TITLE
feat(bottom-sheet): opt-in floating variant

### DIFF
--- a/src/components/BottomSheet.test.tsx
+++ b/src/components/BottomSheet.test.tsx
@@ -65,4 +65,38 @@ describe("BottomSheet floating variant", () => {
     expect(capturedModalProps.backgroundStyle.borderRadius).toBeUndefined();
     expect(typeof capturedModalProps.handleComponent).toBe("function");
   });
+
+  it("rounds and clips the scroll footer's bottom corners when floating", () => {
+    const { getAllByTestId } = render(
+      <BottomSheet
+        floating
+        scrollable
+        modalRef={makeRef()}
+        customContent={<View testID="content" />}
+        scrollViewFooterComponent={() => <View testID="footer-content" />}
+      />,
+    );
+
+    // Only the in-modal footer container carries the testID (the off-screen
+    // pre-measurement probe does not), so there is exactly one.
+    const [footer] = getAllByTestId("bottom-sheet-scroll-footer");
+    expect(footer.props.style.borderBottomLeftRadius).toBe(32);
+    expect(footer.props.style.borderBottomRightRadius).toBe(32);
+    expect(footer.props.style.overflow).toBe("hidden");
+  });
+
+  it("leaves the scroll footer corners square when not floating", () => {
+    const { getAllByTestId } = render(
+      <BottomSheet
+        scrollable
+        modalRef={makeRef()}
+        customContent={<View testID="content" />}
+        scrollViewFooterComponent={() => <View testID="footer-content" />}
+      />,
+    );
+
+    const [footer] = getAllByTestId("bottom-sheet-scroll-footer");
+    expect(footer.props.style.borderBottomLeftRadius).toBeUndefined();
+    expect(footer.props.style.overflow).toBeUndefined();
+  });
 });

--- a/src/components/BottomSheet.test.tsx
+++ b/src/components/BottomSheet.test.tsx
@@ -14,12 +14,14 @@ jest.mock("@gorhom/bottom-sheet", () => {
   const { View: RNView } = require("react-native");
   return {
     __esModule: true,
-    BottomSheetModal: ReactActual.forwardRef((props: any) => {
+    // forwardRef's signature is (props, ref); forward the ref onto the host
+    // View so React does not warn about a one-arg render function.
+    BottomSheetModal: ReactActual.forwardRef((props: any, ref: any) => {
       Object.keys(capturedModalProps).forEach(
         (k) => delete capturedModalProps[k],
       );
       Object.assign(capturedModalProps, props);
-      return ReactActual.createElement(RNView, null, props.children);
+      return ReactActual.createElement(RNView, { ref }, props.children);
     }),
     BottomSheetView: (props: any) =>
       ReactActual.createElement(RNView, props, props.children),

--- a/src/components/BottomSheet.test.tsx
+++ b/src/components/BottomSheet.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react-native";
+import BottomSheet from "components/BottomSheet";
+import React from "react";
+import { View } from "react-native";
+
+// Capture the props the wrapper hands to BottomSheetModal so we can assert the
+// floating contract without needing a real, presented modal.
+const capturedModalProps: Record<string, any> = {};
+
+jest.mock("@gorhom/bottom-sheet", () => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const ReactActual = require("react");
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const { View: RNView } = require("react-native");
+  return {
+    __esModule: true,
+    BottomSheetModal: ReactActual.forwardRef((props: any) => {
+      Object.keys(capturedModalProps).forEach(
+        (k) => delete capturedModalProps[k],
+      );
+      Object.assign(capturedModalProps, props);
+      return ReactActual.createElement(RNView, null, props.children);
+    }),
+    BottomSheetView: (props: any) =>
+      ReactActual.createElement(RNView, props, props.children),
+    BottomSheetScrollView: (props: any) =>
+      ReactActual.createElement(RNView, props, props.children),
+    BottomSheetBackdrop: () => null,
+  };
+});
+
+describe("BottomSheet floating variant", () => {
+  const makeRef = () => React.createRef<any>();
+
+  it("passes floating layout props to BottomSheetModal when `floating` is set", () => {
+    render(
+      <BottomSheet
+        floating
+        modalRef={makeRef()}
+        customContent={<View testID="content" />}
+      />,
+    );
+
+    expect(capturedModalProps.detached).toBe(true);
+    // insets.bottom is mocked to 0 in jest.setup.js, so bottomInset === 0 + 8
+    expect(capturedModalProps.bottomInset).toBe(8);
+    expect(capturedModalProps.style).toEqual({ marginHorizontal: 8 });
+    expect(capturedModalProps.backgroundStyle.borderRadius).toBe(32);
+    expect(capturedModalProps.handleComponent).toBeNull();
+  });
+
+  it("keeps the classic (attached, handled) layout when `floating` is not set", () => {
+    render(
+      <BottomSheet
+        modalRef={makeRef()}
+        customContent={<View testID="content" />}
+      />,
+    );
+
+    expect(capturedModalProps.detached).toBeFalsy();
+    expect(capturedModalProps.bottomInset).toBeFalsy();
+    expect(capturedModalProps.style).toBeFalsy();
+    expect(capturedModalProps.backgroundStyle.borderRadius).toBeUndefined();
+    expect(typeof capturedModalProps.handleComponent).toBe("function");
+  });
+});

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -322,12 +322,23 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
             </BottomSheetScrollView>
             {scrollViewFooterComponent && (
               <View
+                testID="bottom-sheet-scroll-footer"
                 style={{
                   position: "absolute",
                   bottom:
                     keyboardHeight > 0 ? keyboardHeight - insets.bottom : 0,
                   left: 0,
                   right: 0,
+                  // On a floating card the footer sits over the rounded bottom
+                  // edge; round + clip it so an opaque footer background does
+                  // not square off the card's bottom corners.
+                  ...(floating
+                    ? {
+                        borderBottomLeftRadius: FLOATING_CORNER_RADIUS,
+                        borderBottomRightRadius: FLOATING_CORNER_RADIUS,
+                        overflow: "hidden" as const,
+                      }
+                    : {}),
                 }}
               >
                 {scrollViewFooterComponent()}

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -47,6 +47,10 @@ const Icons = {
   },
 } as const;
 
+// Floating variant: small transparent margins + a fully rounded card.
+const FLOATING_MARGIN = 8;
+const FLOATING_CORNER_RADIUS = 32;
+
 /**
  * Props for the shared BottomSheet wrapper.
  *
@@ -87,6 +91,12 @@ export type BottomSheetProps = {
   analyticsProps?: AnalyticsProps;
   scrollViewFooterComponent?: () => React.ReactNode;
   scrollable?: boolean;
+  /**
+   * Render as a detached "floating" card: small transparent margins on the
+   * sides and bottom, all four corners rounded, and no drag handle. Opt-in;
+   * defaults to the classic bottom-attached sheet.
+   */
+  floating?: boolean;
 };
 
 const BottomSheet: React.FC<BottomSheetProps> = ({
@@ -109,6 +119,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   analyticsProps,
   scrollViewFooterComponent = undefined,
   scrollable = false,
+  floating = false,
 }) => {
   if (__DEV__ && scrollable && snapPoints) {
     throw new Error(
@@ -224,6 +235,24 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
     [],
   );
 
+  // Floating cards drop the content background so the rounded (borderRadius)
+  // sheet background shows through the corners; the classic variant keeps its
+  // own background because its rounded top comes from the handle instead.
+  const contentClassName = floating
+    ? "pl-6 pr-6 pt-6 gap-6"
+    : "bg-background-primary pl-6 pr-6 pt-6 gap-6";
+
+  // Floating sheets are already lifted off the safe area by `bottomInset`, so
+  // the content must not add `insets.bottom` again (that would double the gap).
+  const contentPaddingBottom = (() => {
+    if (!useInsetsBottomPadding) {
+      return 0;
+    }
+    return floating
+      ? pxValue(DEFAULT_PADDING)
+      : insets.bottom + pxValue(DEFAULT_PADDING);
+  })();
+
   return (
     <>
       {/* Pre-measurement render — kept off-screen and out of the
@@ -263,10 +292,14 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
         enableOverDrag={false}
         snapPoints={snapPoints}
         topInset={scrollable ? insets.top : undefined}
+        detached={floating || undefined}
+        bottomInset={floating ? insets.bottom + FLOATING_MARGIN : undefined}
+        style={floating ? { marginHorizontal: FLOATING_MARGIN } : undefined}
         backdropComponent={renderBackdrop}
-        handleComponent={renderHandle}
+        handleComponent={floating ? null : renderHandle}
         backgroundStyle={{
           backgroundColor: themeColors.background.primary,
+          ...(floating ? { borderRadius: FLOATING_CORNER_RADIUS } : {}),
         }}
         {...bottomSheetModalProps}
         onChange={handleChange}
@@ -274,12 +307,10 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
         {scrollable ? (
           <View>
             <BottomSheetScrollView
-              className="bg-background-primary pl-6 pr-6 pt-6 gap-6"
+              className={contentClassName}
               showsVerticalScrollIndicator={false}
               style={{
-                paddingBottom: useInsetsBottomPadding
-                  ? insets.bottom + pxValue(DEFAULT_PADDING)
-                  : 0,
+                paddingBottom: contentPaddingBottom,
               }}
               {...bottomSheetViewProps}
             >
@@ -305,11 +336,9 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
           </View>
         ) : (
           <BottomSheetView
-            className="bg-background-primary pl-6 pr-6 pt-6 gap-6"
+            className={contentClassName}
             style={{
-              paddingBottom: useInsetsBottomPadding
-                ? insets.bottom + pxValue(DEFAULT_PADDING)
-                : 0,
+              paddingBottom: contentPaddingBottom,
             }}
             {...bottomSheetViewProps}
           >

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -10,7 +10,11 @@ import { BottomSheetViewProps } from "@gorhom/bottom-sheet/lib/typescript/compon
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { AnalyticsEvent } from "config/analyticsConfig";
-import { DEFAULT_PADDING } from "config/constants";
+import {
+  BOTTOM_SHEET_FLOATING_CORNER_RADIUS,
+  BOTTOM_SHEET_FLOATING_MARGIN,
+  DEFAULT_PADDING,
+} from "config/constants";
 import { pxValue } from "helpers/dimensions";
 import useColors from "hooks/useColors";
 import { useKeyboardHeight } from "hooks/useKeyboardHeight";
@@ -46,10 +50,6 @@ const Icons = {
     color: "gold",
   },
 } as const;
-
-// Floating variant: small transparent margins + a fully rounded card.
-const FLOATING_MARGIN = 8;
-const FLOATING_CORNER_RADIUS = 32;
 
 /**
  * Props for the shared BottomSheet wrapper.
@@ -293,13 +293,21 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
         snapPoints={snapPoints}
         topInset={scrollable ? insets.top : undefined}
         detached={floating || undefined}
-        bottomInset={floating ? insets.bottom + FLOATING_MARGIN : undefined}
-        style={floating ? { marginHorizontal: FLOATING_MARGIN } : undefined}
+        bottomInset={
+          floating ? insets.bottom + BOTTOM_SHEET_FLOATING_MARGIN : undefined
+        }
+        style={
+          floating
+            ? { marginHorizontal: BOTTOM_SHEET_FLOATING_MARGIN }
+            : undefined
+        }
         backdropComponent={renderBackdrop}
         handleComponent={floating ? null : renderHandle}
         backgroundStyle={{
           backgroundColor: themeColors.background.primary,
-          ...(floating ? { borderRadius: FLOATING_CORNER_RADIUS } : {}),
+          ...(floating
+            ? { borderRadius: BOTTOM_SHEET_FLOATING_CORNER_RADIUS }
+            : {}),
         }}
         {...bottomSheetModalProps}
         onChange={handleChange}
@@ -334,8 +342,10 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
                   // not square off the card's bottom corners.
                   ...(floating
                     ? {
-                        borderBottomLeftRadius: FLOATING_CORNER_RADIUS,
-                        borderBottomRightRadius: FLOATING_CORNER_RADIUS,
+                        borderBottomLeftRadius:
+                          BOTTOM_SHEET_FLOATING_CORNER_RADIUS,
+                        borderBottomRightRadius:
+                          BOTTOM_SHEET_FLOATING_CORNER_RADIUS,
                         overflow: "hidden" as const,
                       }
                     : {}),

--- a/src/components/primitives/BottomSheetAdaptiveContainer.tsx
+++ b/src/components/primitives/BottomSheetAdaptiveContainer.tsx
@@ -1,11 +1,13 @@
 import {
   BOTTOM_SHEET_CONTENT_GAP,
   BOTTOM_SHEET_CONTENT_TOP_PADDING,
+  BOTTOM_SHEET_FLOATING_MARGIN,
   BOTTOM_SHEET_MAX_HEIGHT_RATIO,
 } from "config/constants";
 import { calculateScrollableMaxHeight } from "helpers/bottomSheet";
 import React, { useMemo, useState } from "react";
 import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface BottomSheetAdaptiveContainerProps {
   header?: React.ReactNode;
@@ -14,6 +16,13 @@ interface BottomSheetAdaptiveContainerProps {
   topPaddingPx?: number;
   bottomPaddingPx?: number;
   contentGapPx?: number;
+  /**
+   * Set when the host sheet uses the floating variant. A floating sheet is
+   * lifted off the bottom by its inset, so gorhom gives it a shorter container;
+   * this reserves that inset in the height budget so scroll content fits the
+   * card instead of overflowing its rounded bottom.
+   */
+  floating?: boolean;
 }
 
 /**
@@ -55,17 +64,38 @@ const BottomSheetAdaptiveContainer: React.FC<
   topPaddingPx = BOTTOM_SHEET_CONTENT_TOP_PADDING,
   bottomPaddingPx = 0,
   contentGapPx = BOTTOM_SHEET_CONTENT_GAP,
+  floating = false,
 }) => {
+  const insets = useSafeAreaInsets();
   const [headerHeight, setHeaderHeight] = useState(0);
+  // A floating sheet's gorhom container is shorter by its bottom inset
+  // (safe-area bottom + the floating margin); reserve that here so scroll
+  // content fits the card instead of overflowing its rounded bottom.
+  const reservedVerticalPx = floating
+    ? insets.bottom + BOTTOM_SHEET_FLOATING_MARGIN
+    : 0;
+  // The header carries a `contentGapPx` marginBottom that the base height calc
+  // omits. On a floating card that must fit exactly, fold it into the header
+  // height so the scroll area accounts for it. (Classic sheets tolerate the
+  // omission because gorhom clips their overflow.)
+  const effectiveHeaderHeightPx =
+    floating && header ? headerHeight + contentGapPx : headerHeight;
   const maxContentHeight = useMemo(
     () =>
       calculateScrollableMaxHeight({
-        headerHeightPx: headerHeight,
+        headerHeightPx: effectiveHeaderHeightPx,
         sheetMaxHeightRatio,
         topPaddingPx,
         bottomPaddingPx,
+        reservedVerticalPx,
       }),
-    [headerHeight, bottomPaddingPx, sheetMaxHeightRatio, topPaddingPx],
+    [
+      effectiveHeaderHeightPx,
+      bottomPaddingPx,
+      sheetMaxHeightRatio,
+      topPaddingPx,
+      reservedVerticalPx,
+    ],
   );
 
   return (

--- a/src/components/screens/HistoryScreen/HistoryList.tsx
+++ b/src/components/screens/HistoryScreen/HistoryList.tsx
@@ -130,6 +130,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
     () => (
       <TransactionDetailsFooter
         externalUrl={transactionDetails?.externalUrl ?? ""}
+        floating
       />
     ),
     [transactionDetails?.externalUrl],
@@ -204,6 +205,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
         handleCloseModal={() =>
           transactionDetailsBottomSheetModalRef.current?.dismiss()
         }
+        floating
         scrollable
         useInsetsBottomPadding={false}
         maxDynamicContentSize={windowHeight * 0.9}

--- a/src/components/screens/HistoryScreen/TransactionDetailsBottomSheetCustomContent.tsx
+++ b/src/components/screens/HistoryScreen/TransactionDetailsBottomSheetCustomContent.tsx
@@ -350,11 +350,17 @@ export const TransactionDetailsBottomSheetCustomContent: React.FC<
 
 interface TransactionDetailsFooterProps {
   externalUrl: string;
+  /**
+   * When the host sheet is floating, it already clears the safe area via its
+   * bottom inset, so the footer must not add `insets.bottom` again — that
+   * would leave a large empty gap below the button.
+   */
+  floating?: boolean;
 }
 
 export const TransactionDetailsFooter: React.FC<
   TransactionDetailsFooterProps
-> = ({ externalUrl }) => {
+> = ({ externalUrl, floating = false }) => {
   const { t } = useAppTranslation();
   const { themeColors } = useColors();
   const { open: openInAppBrowser } = useInAppBrowser();
@@ -364,7 +370,9 @@ export const TransactionDetailsFooter: React.FC<
     <View
       className="bg-background-primary w-full px-6 py-6 mt-6"
       style={{
-        paddingBottom: insets.bottom + pxValue(DEFAULT_PADDING),
+        paddingBottom: floating
+          ? pxValue(DEFAULT_PADDING)
+          : insets.bottom + pxValue(DEFAULT_PADDING),
       }}
     >
       <Button

--- a/src/components/screens/HomeScreen/ManageAccounts.tsx
+++ b/src/components/screens/HomeScreen/ManageAccounts.tsx
@@ -161,6 +161,7 @@ const ManageAccounts: React.FC<ManageAccountsProps> = ({
         snapPoints={[toPercent(SNAP_VALUE_PERCENT)]}
         modalRef={bottomSheetRef}
         handleCloseModal={handleCloseModal}
+        floating
         enablePanDownToClose={false}
         enableDynamicSizing={false}
         analyticsEvent={AnalyticsEvent.VIEW_MANAGE_WALLETS}

--- a/src/components/screens/SignTransactionDetails/SignTransactionDetails.tsx
+++ b/src/components/screens/SignTransactionDetails/SignTransactionDetails.tsx
@@ -49,6 +49,7 @@ const SignTransactionDetails: React.FC<SignTransactionDetailsProps> = ({
         handleCloseModal={() =>
           signTransactionDetailsBottomSheetModalRef.current?.dismiss()
         }
+        floating
         enableDynamicSizing={false}
         useInsetsBottomPadding={false}
         enablePanDownToClose={false}
@@ -58,6 +59,7 @@ const SignTransactionDetails: React.FC<SignTransactionDetailsProps> = ({
           <SignTransactionDetailsBottomSheet
             data={data}
             onDismiss={handleDismiss}
+            floating
           />
         }
       />

--- a/src/components/screens/SignTransactionDetails/components/SignTransactionDetailsBottomSheet.tsx
+++ b/src/components/screens/SignTransactionDetails/components/SignTransactionDetailsBottomSheet.tsx
@@ -14,11 +14,14 @@ import { View } from "react-native";
 interface SignTransactionDetailsBottomSheetProps {
   data: SignTransactionDetailsInterface;
   onDismiss: () => void;
+  /** Set when hosted in a floating BottomSheet so the scroll area fits the card. */
+  floating?: boolean;
 }
 
 const SignTransactionDetailsBottomSheet = ({
   data,
   onDismiss,
+  floating = false,
 }: SignTransactionDetailsBottomSheetProps) => {
   const { t } = useAppTranslation();
 
@@ -26,6 +29,7 @@ const SignTransactionDetailsBottomSheet = ({
     <View className="flex-1 gap-[16px] w-full pb-[64px]">
       {/* Header */}
       <BottomSheetAdaptiveContainer
+        floating={floating}
         header={
           <View className="w-full gap-[16px]">
             <View className="flex-row items-center justify-between">

--- a/src/components/screens/SwapScreen/components/SwapReviewBottomSheet.tsx
+++ b/src/components/screens/SwapScreen/components/SwapReviewBottomSheet.tsx
@@ -239,6 +239,7 @@ const SwapReviewBottomSheet: React.FC<SwapReviewBottomSheetProps> = ({
           handleCloseModal={() =>
             swapTransactionDetailsBottomSheetModalRef.current?.dismiss()
           }
+          floating
           enableDynamicSizing={false}
           useInsetsBottomPadding={false}
           enablePanDownToClose={false}
@@ -248,6 +249,7 @@ const SwapReviewBottomSheet: React.FC<SwapReviewBottomSheetProps> = ({
             <SignTransactionDetailsBottomSheet
               data={transactionDetails}
               onDismiss={handleDismiss}
+              floating
             />
           }
         />

--- a/src/components/screens/SwapScreen/components/SwapReviewBottomSheet.tsx
+++ b/src/components/screens/SwapScreen/components/SwapReviewBottomSheet.tsx
@@ -254,6 +254,7 @@ const SwapReviewBottomSheet: React.FC<SwapReviewBottomSheetProps> = ({
       )}
       <BottomSheet
         modalRef={trustlineInfoRef}
+        floating
         handleCloseModal={() => trustlineInfoRef.current?.dismiss()}
         customContent={
           <TrustlineInfoBottomSheet

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -113,6 +113,10 @@ export const BOTTOM_SHEET_CONTENT_TOP_PADDING = DEFAULT_PADDING;
 export const BOTTOM_SHEET_CONTENT_BOTTOM_PADDING = 64;
 export const BOTTOM_SHEET_CONTENT_GAP = 16;
 
+// Floating bottom-sheet variant: transparent margins + fully rounded card
+export const BOTTOM_SHEET_FLOATING_MARGIN = 8;
+export const BOTTOM_SHEET_FLOATING_CORNER_RADIUS = 32;
+
 // settings screen URLs
 export const FREIGHTER_BASE_URL = "https://www.freighter.app";
 export const FREIGHTER_DISCORD_URL = "https://discord.gg/rtXyAXPHYT";

--- a/src/helpers/bottomSheet.test.ts
+++ b/src/helpers/bottomSheet.test.ts
@@ -1,0 +1,26 @@
+import { calculateScrollableMaxHeight } from "helpers/bottomSheet";
+
+describe("calculateScrollableMaxHeight", () => {
+  it("removes reservedVerticalPx from the window height before applying the ratio", () => {
+    const base = calculateScrollableMaxHeight({ headerHeightPx: 40 });
+    const reserved = calculateScrollableMaxHeight({
+      headerHeightPx: 40,
+      reservedVerticalPx: 50,
+    });
+
+    // reservedVerticalPx is subtracted from the window height before the
+    // 0.9 ratio, so the budget drops by reservedVerticalPx * ratio. This
+    // mirrors gorhom reducing a modal sheet's container height by its
+    // bottom inset, keeping scroll content sized to the actual card.
+    expect(base - reserved).toBeCloseTo(50 * 0.9, 5);
+  });
+
+  it("defaults reservedVerticalPx to 0 (no reduction)", () => {
+    expect(calculateScrollableMaxHeight({ headerHeightPx: 40 })).toBe(
+      calculateScrollableMaxHeight({
+        headerHeightPx: 40,
+        reservedVerticalPx: 0,
+      }),
+    );
+  });
+});

--- a/src/helpers/bottomSheet.ts
+++ b/src/helpers/bottomSheet.ts
@@ -10,6 +10,13 @@ export interface BottomSheetMaxHeightOptions {
   sheetMaxHeightRatio?: number;
   topPaddingPx?: number;
   bottomPaddingPx?: number;
+  /**
+   * Vertical space the host sheet removes from the window before sizing (e.g.
+   * a floating sheet's bottom inset). gorhom reduces a modal sheet's container
+   * height by its insets, so this must be subtracted here too — otherwise
+   * scroll content is sized for a taller card and overflows the shorter one.
+   */
+  reservedVerticalPx?: number;
 }
 
 export const DEFAULT_SHEET_MAX_HEIGHT_RATIO = 0.9;
@@ -22,12 +29,15 @@ export const calculateScrollableMaxHeight = (
     sheetMaxHeightRatio = BOTTOM_SHEET_MAX_HEIGHT_RATIO,
     topPaddingPx = BOTTOM_SHEET_CONTENT_TOP_PADDING,
     bottomPaddingPx = BOTTOM_SHEET_CONTENT_BOTTOM_PADDING,
+    reservedVerticalPx = 0,
   } = options;
 
   const windowHeight = Dimensions.get("window").height;
 
   const availableHeight =
-    windowHeight * sheetMaxHeightRatio - headerHeightPx - topPaddingPx;
+    (windowHeight - reservedVerticalPx) * sheetMaxHeightRatio -
+    headerHeightPx -
+    topPaddingPx;
 
   const maxHeight = Math.max(0, availableHeight - bottomPaddingPx);
 


### PR DESCRIPTION
## Summary

Adds an opt-in **floating** variant to the shared `BottomSheet` wrapper (`@gorhom/bottom-sheet` v5) — a detached card with small transparent margins on the sides and bottom, all four corners rounded, and no drag handle — and adopts it on several experimental sheets.

The variant is opt-in via a new `floating` prop (default `false`), so all existing (~52) sheets render exactly as before.

## How it works

When `floating` is set, the wrapper uses gorhom's native detached mode:
- `detached` + `bottomInset = insets.bottom + 8` (lifts the card off the bottom, safe on devices without a home indicator)
- `style={{ marginHorizontal: 8 }}` (side gaps)
- `backgroundStyle.borderRadius = 32` (all-corner rounding)
- `handleComponent={null}` (no drag pill — dismiss via the X button / backdrop tap)

## Sheets adopted

- **History transaction details** — scrollable + absolutely-positioned footer
- **Manage wallets** — fixed 80% snap
- **Trustline info** (swap flow) — dynamic size
- **Sign transaction details** (swap + dApp signing) — fixed 90% snap

https://github.com/user-attachments/assets/e3147543-e92e-44d6-b2dd-f1dddeabf5cd

## Known limitation

On the fixed-snap Sign-transaction-details sheet, the scroll content's **bottom corners stay square** against the rounded card. gorhom doesn't round-clip content for detached sheets (the rounded corners are a background layer only) and its content view is absolutely positioned, so masking the scroll content to the rounded bottom isn't straightforward. Content fits and scrolls correctly; only the corner mask is missing. Left as a follow-up.

## Testing

- Unit tests for the wrapper's floating props, the footer rounding, and the `reservedVerticalPx` height math.
- Manually verified each adopted sheet on an iOS simulator (iPhone 17 Pro).
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
