### PR TITLE
(Android) Add a per-origin camera/microphone prompt to the in-app browser

### DIFF
--- a/android/app/src/main/java/com/freightermobile/MainApplication.kt
+++ b/android/app/src/main/java/com/freightermobile/MainApplication.kt
@@ -23,6 +23,7 @@ class MainApplication : Application(), ReactApplication {
               // add(MyReactNativePackage())
               add(org.stellar.freighterwallet.SecureClipboardPackage())
               add(org.stellar.freighterwallet.PrivacyShieldPackage())
+              add(org.stellar.freighterwallet.WebViewMediaConsentPackage())
             }
 
         override fun getJSMainModuleName(): String = "index"

--- a/android/app/src/main/java/org/stellar/freighterwallet/WebViewMediaConsentModule.kt
+++ b/android/app/src/main/java/org/stellar/freighterwallet/WebViewMediaConsentModule.kt
@@ -1,0 +1,25 @@
+package org.stellar.freighterwallet
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.reactnativecommunity.webview.RNCWebChromeClient
+
+/**
+ * Bridges the in-app browser's per-origin camera/microphone consent so JS can
+ * clear it as part of the logout / data-wipe scrub, keeping it in sync with the
+ * rest of the WebView data cleanup. Android-only (iOS WKWebView prompts
+ * per-origin on its own, so there is no equivalent state to clear there).
+ */
+class WebViewMediaConsentModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+  override fun getName(): String = "WebViewMediaConsent"
+
+  @ReactMethod
+  fun clearConsent(promise: Promise) {
+    RNCWebChromeClient.clearMediaCaptureConsent()
+    promise.resolve(null)
+  }
+}

--- a/android/app/src/main/java/org/stellar/freighterwallet/WebViewMediaConsentPackage.kt
+++ b/android/app/src/main/java/org/stellar/freighterwallet/WebViewMediaConsentPackage.kt
@@ -1,0 +1,16 @@
+package org.stellar.freighterwallet
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class WebViewMediaConsentPackage : ReactPackage {
+  override fun createNativeModules(
+      reactContext: ReactApplicationContext,
+  ): List<NativeModule> = listOf(WebViewMediaConsentModule(reactContext))
+
+  override fun createViewManagers(
+      reactContext: ReactApplicationContext,
+  ): List<ViewManager<*, *>> = emptyList()
+}

--- a/patches/react-native-webview+13.16.0.patch
+++ b/patches/react-native-webview+13.16.0.patch
@@ -1,0 +1,133 @@
+diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+index 07f73fd0..133412d2 100644
+--- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
++++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+@@ -3,6 +3,8 @@ package com.reactnativecommunity.webview;
+ import android.Manifest;
+ import android.annotation.TargetApi;
+ import android.app.Activity;
++import android.app.AlertDialog;
++import android.content.DialogInterface;
+ import android.content.pm.PackageManager;
+ import android.net.Uri;
+ import android.os.Build;
+@@ -34,7 +36,9 @@ import com.reactnativecommunity.webview.events.TopOpenWindowEvent;
+ 
+ import java.util.ArrayList;
+ import java.util.Collections;
++import java.util.HashMap;
+ import java.util.List;
++import java.util.Map;
+ 
+ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEventListener {
+     protected static final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
+@@ -66,6 +70,12 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
+     // Webview camera & audio permission already granted
+     protected List<String> grantedPermissions;
+ 
++    // Per-origin, per-session consent memory for camera/microphone access, so a
++    // web origin's request is confirmed by the user once rather than inheriting
++    // the app's OS-level camera permission. Keyed by "origin|resources"; static so
++    // the decision is shared across WebView instances for the session.
++    protected static final Map<String, Boolean> sMediaCaptureConsent = new HashMap<>();
++
+     // Webview geolocation permission callback
+     protected GeolocationPermissions.Callback geolocationPermissionCallback;
+     // Webview geolocation permission origin callback
+@@ -144,6 +154,96 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
+ 
+     @Override
+     public void onPermissionRequest(final PermissionRequest request) {
++        // Require explicit, per-origin user consent before granting camera or
++        // microphone access to web content, instead of auto-granting based on the
++        // app's OS-level permission. Camera/mic requests surface a per-origin
++        // prompt; other permission requests keep the default handling.
++        boolean requestsMediaCapture = false;
++        for (String requestedResource : request.getResources()) {
++            if (PermissionRequest.RESOURCE_VIDEO_CAPTURE.equals(requestedResource)
++                    || PermissionRequest.RESOURCE_AUDIO_CAPTURE.equals(requestedResource)) {
++                requestsMediaCapture = true;
++                break;
++            }
++        }
++
++        if (!requestsMediaCapture) {
++            grantPermissionRequest(request);
++            return;
++        }
++
++        final String consentKey =
++                (request.getOrigin() != null ? request.getOrigin().toString() : "")
++                        + "|" + android.text.TextUtils.join(",", request.getResources());
++        final Boolean remembered = sMediaCaptureConsent.get(consentKey);
++        if (remembered != null) {
++            if (remembered) {
++                grantPermissionRequest(request);
++            } else {
++                request.deny();
++            }
++            return;
++        }
++
++        final Activity activity = this.mWebView.getThemedReactContext().getCurrentActivity();
++        if (activity == null || activity.isFinishing()) {
++            // No UI available to confirm access -- deny the request.
++            request.deny();
++            return;
++        }
++
++        boolean wantsCamera = false;
++        boolean wantsMic = false;
++        for (String requestedResource : request.getResources()) {
++            if (PermissionRequest.RESOURCE_VIDEO_CAPTURE.equals(requestedResource)) {
++                wantsCamera = true;
++            } else if (PermissionRequest.RESOURCE_AUDIO_CAPTURE.equals(requestedResource)) {
++                wantsMic = true;
++            }
++        }
++        final String what = (wantsCamera && wantsMic)
++                ? "camera and microphone"
++                : (wantsCamera ? "camera" : "microphone");
++        final String host =
++                (request.getOrigin() != null && request.getOrigin().getHost() != null)
++                        ? request.getOrigin().getHost()
++                        : "This site";
++
++        activity.runOnUiThread(new Runnable() {
++            @Override
++            public void run() {
++                new AlertDialog.Builder(activity)
++                        .setTitle("Allow " + what + " access?")
++                        .setMessage("\"" + host + "\" is requesting access to your "
++                                + what + ".")
++                        .setPositiveButton("Allow", new DialogInterface.OnClickListener() {
++                            @Override
++                            public void onClick(DialogInterface dialog, int which) {
++                                sMediaCaptureConsent.put(consentKey, Boolean.TRUE);
++                                grantPermissionRequest(request);
++                            }
++                        })
++                        .setNegativeButton("Don't allow", new DialogInterface.OnClickListener() {
++                            @Override
++                            public void onClick(DialogInterface dialog, int which) {
++                                sMediaCaptureConsent.put(consentKey, Boolean.FALSE);
++                                request.deny();
++                            }
++                        })
++                        .setOnCancelListener(new DialogInterface.OnCancelListener() {
++                            @Override
++                            public void onCancel(DialogInterface dialog) {
++                                request.deny();
++                            }
++                        })
++                        .show();
++            }
++        });
++    }
++
++    // Original react-native-webview grant flow. Now only reached after per-origin
++    // consent has been granted (camera/mic) or for non-media permission requests.
++    private void grantPermissionRequest(final PermissionRequest request) {
+ 
+         grantedPermissions = new ArrayList<>();
+ 

--- a/patches/react-native-webview+13.16.0.patch
+++ b/patches/react-native-webview+13.16.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
-index 07f73fd0..9719b3a8 100644
+index 07f73fd0..b11c5d69 100644
 --- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
 +++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
 @@ -3,6 +3,8 @@ package com.reactnativecommunity.webview;
@@ -15,26 +15,36 @@ index 07f73fd0..9719b3a8 100644
  
  import java.util.ArrayList;
  import java.util.Collections;
-+import java.util.HashMap;
++import java.util.HashSet;
  import java.util.List;
-+import java.util.Map;
++import java.util.Set;
  
  public class RNCWebChromeClient extends WebChromeClient implements LifecycleEventListener {
      protected static final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
-@@ -66,6 +70,12 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
+@@ -66,6 +70,22 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
      // Webview camera & audio permission already granted
      protected List<String> grantedPermissions;
  
-+    // Per-origin, per-session consent memory for camera/microphone access, so a
-+    // web origin's request is confirmed by the user once rather than inheriting
-+    // the app's OS-level camera permission. Keyed by "origin|sorted-resources";
-+    // static so the decision is shared across WebView instances for the session.
-+    protected static final Map<String, Boolean> sMediaCaptureConsent = new HashMap<>();
++    // Camera/microphone grants the user has explicitly approved, so a repeat
++    // request from the same origin isn't re-prompted within the session. Denials
++    // are intentionally NOT stored: a deny simply re-prompts next time (fail-safe),
++    // which avoids an unrecoverable "blocked forever" state with no way to undo.
++    // Cleared on logout / data wipe via clearMediaCaptureConsent(). Keyed by
++    // "origin|sorted-resources".
++    protected static final Set<String> sMediaCaptureAllowed =
++            Collections.synchronizedSet(new HashSet<String>());
++
++    // Invoked from the app's logout / data-wipe path (via a native module) so
++    // camera/microphone consent doesn't outlive the session or leak to another
++    // account signed in on the same device.
++    public static void clearMediaCaptureConsent() {
++        sMediaCaptureAllowed.clear();
++    }
 +
      // Webview geolocation permission callback
      protected GeolocationPermissions.Callback geolocationPermissionCallback;
      // Webview geolocation permission origin callback
-@@ -144,6 +154,102 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
+@@ -144,6 +164,98 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
  
      @Override
      public void onPermissionRequest(final PermissionRequest request) {
@@ -63,13 +73,8 @@ index 07f73fd0..9719b3a8 100644
 +        final String consentKey =
 +                (request.getOrigin() != null ? request.getOrigin().toString() : "")
 +                        + "|" + android.text.TextUtils.join(",", sortedResources);
-+        final Boolean remembered = sMediaCaptureConsent.get(consentKey);
-+        if (remembered != null) {
-+            if (remembered) {
-+                grantPermissionRequest(request);
-+            } else {
-+                request.deny();
-+            }
++        if (sMediaCaptureAllowed.contains(consentKey)) {
++            grantPermissionRequest(request);
 +            return;
 +        }
 +
@@ -109,14 +114,15 @@ index 07f73fd0..9719b3a8 100644
 +                        .setPositiveButton("Allow", new DialogInterface.OnClickListener() {
 +                            @Override
 +                            public void onClick(DialogInterface dialog, int which) {
-+                                sMediaCaptureConsent.put(consentKey, Boolean.TRUE);
++                                sMediaCaptureAllowed.add(consentKey);
 +                                grantPermissionRequest(request);
 +                            }
 +                        })
 +                        .setNegativeButton("Don't allow", new DialogInterface.OnClickListener() {
 +                            @Override
 +                            public void onClick(DialogInterface dialog, int which) {
-+                                sMediaCaptureConsent.put(consentKey, Boolean.FALSE);
++                                // Deny only this request; do not remember it, so the
++                                // user can be re-prompted rather than locked out.
 +                                request.deny();
 +                            }
 +                        })

--- a/patches/react-native-webview+13.16.0.patch
+++ b/patches/react-native-webview+13.16.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
-index 07f73fd0..133412d2 100644
+index 07f73fd0..9719b3a8 100644
 --- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
 +++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
 @@ -3,6 +3,8 @@ package com.reactnativecommunity.webview;
@@ -27,14 +27,14 @@ index 07f73fd0..133412d2 100644
  
 +    // Per-origin, per-session consent memory for camera/microphone access, so a
 +    // web origin's request is confirmed by the user once rather than inheriting
-+    // the app's OS-level camera permission. Keyed by "origin|resources"; static so
-+    // the decision is shared across WebView instances for the session.
++    // the app's OS-level camera permission. Keyed by "origin|sorted-resources";
++    // static so the decision is shared across WebView instances for the session.
 +    protected static final Map<String, Boolean> sMediaCaptureConsent = new HashMap<>();
 +
      // Webview geolocation permission callback
      protected GeolocationPermissions.Callback geolocationPermissionCallback;
      // Webview geolocation permission origin callback
-@@ -144,6 +154,96 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
+@@ -144,6 +154,102 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
  
      @Override
      public void onPermissionRequest(final PermissionRequest request) {
@@ -56,9 +56,13 @@ index 07f73fd0..133412d2 100644
 +            return;
 +        }
 +
++        // Sort the requested resources so the key is stable regardless of the
++        // order the WebView lists them in (e.g. audio+video vs video+audio).
++        final String[] sortedResources = request.getResources().clone();
++        java.util.Arrays.sort(sortedResources);
 +        final String consentKey =
 +                (request.getOrigin() != null ? request.getOrigin().toString() : "")
-+                        + "|" + android.text.TextUtils.join(",", request.getResources());
++                        + "|" + android.text.TextUtils.join(",", sortedResources);
 +        final Boolean remembered = sMediaCaptureConsent.get(consentKey);
 +        if (remembered != null) {
 +            if (remembered) {
@@ -88,9 +92,11 @@ index 07f73fd0..133412d2 100644
 +        final String what = (wantsCamera && wantsMic)
 +                ? "camera and microphone"
 +                : (wantsCamera ? "camera" : "microphone");
-+        final String host =
-+                (request.getOrigin() != null && request.getOrigin().getHost() != null)
-+                        ? request.getOrigin().getHost()
++        // Show the full serialized origin (scheme + host + port), not just the
++        // host, so distinct origins are distinguishable in the prompt.
++        final String originLabel =
++                (request.getOrigin() != null && request.getOrigin().toString().length() > 0)
++                        ? request.getOrigin().toString()
 +                        : "This site";
 +
 +        activity.runOnUiThread(new Runnable() {
@@ -98,7 +104,7 @@ index 07f73fd0..133412d2 100644
 +            public void run() {
 +                new AlertDialog.Builder(activity)
 +                        .setTitle("Allow " + what + " access?")
-+                        .setMessage("\"" + host + "\" is requesting access to your "
++                        .setMessage("\"" + originLabel + "\" is requesting access to your "
 +                                + what + ".")
 +                        .setPositiveButton("Allow", new DialogInterface.OnClickListener() {
 +                            @Override

--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -2,6 +2,7 @@ import CookieManager from "@react-native-cookies/cookies";
 import { BROWSER_CONSTANTS } from "config/constants";
 import { logger } from "config/logger";
 import { clearAllScreenshots } from "helpers/screenshots";
+import { clearWebViewMediaConsent } from "helpers/webViewMediaConsent";
 
 /**
  * Checks if the given URL is the homepage URL.
@@ -164,6 +165,10 @@ export const clearAllWebViewData = async (): Promise<boolean> => {
     const [cookieResult, screenshotResult] = await Promise.all([
       clearAllCookies(),
       clearAllScreenshots(),
+      // Android-only, best-effort (returns void, not part of the success
+      // signal): drop the in-app browser's per-origin camera/mic consent so it
+      // doesn't survive logout or leak to another account on this device.
+      clearWebViewMediaConsent(),
     ]);
 
     const success = cookieResult && screenshotResult;

--- a/src/helpers/webViewMediaConsent.ts
+++ b/src/helpers/webViewMediaConsent.ts
@@ -1,0 +1,27 @@
+import { NativeModules } from "react-native";
+
+interface WebViewMediaConsentModule {
+  clearConsent?: () => Promise<void>;
+}
+
+const getModule = (): WebViewMediaConsentModule | undefined =>
+  NativeModules.WebViewMediaConsent as WebViewMediaConsentModule | undefined;
+
+/**
+ * Clears the in-app browser's remembered per-origin camera/microphone consent.
+ * Called from the WebView data scrub on logout so a grant doesn't outlive the
+ * session or leak to another account on the same device.
+ *
+ * No-op where the native module isn't present (e.g. iOS, where WKWebView
+ * already prompts per-origin and there's no equivalent state to clear).
+ */
+export const clearWebViewMediaConsent = async (): Promise<void> => {
+  const consentModule = getModule();
+  if (!consentModule?.clearConsent) return;
+
+  try {
+    await consentModule.clearConsent();
+  } catch {
+    // Best effort — consent also dies with the app process if this ever fails.
+  }
+};


### PR DESCRIPTION
## Summary

Adds an explicit, per-origin consent prompt for camera/microphone access in the
in-app browser (Android). Each web origin must be approved by the user — matching
standalone browsers and iOS (`WKWebView`), which already prompt per-origin.

- Web camera/mic requests show a prompt naming the requesting origin; the choice is
  remembered for that origin and the media it requested, for the session.
- Legitimate flows that need the camera (e.g. dApp KYC) keep working — the user
  just approves once.
- Other permission types are unchanged. Android-only (iOS already prompts per-origin).
- Implemented via a `patch-package` patch to `react-native-webview`'s Android
  `WebChromeClient.onPermissionRequest` (the library exposes no JS hook for this).

## Demo

https://github.com/user-attachments/assets/e56082d9-13c8-4406-9a64-dde806a57e00

Closes https://github.com/stellar/wallet-eng-monorepo/issues/25
