### PR TITLE
fix(analytics): emit screen.viewed for the Scan/Receive tabs

### DIFF
--- a/__tests__/components/screens/ScanReceiveScreen/ScanReceiveScreen.test.tsx
+++ b/__tests__/components/screens/ScanReceiveScreen/ScanReceiveScreen.test.tsx
@@ -114,6 +114,11 @@ describe("ScanReceiveScreen", () => {
       <ScanReceiveScreen {...makeProps("scan")} />,
     );
     fireEvent.press(getByText("Receive"));
+
+    // Assert the calls happened before inspecting them: if both tabs stopped
+    // resolving to catalogued screens the screen would track nothing at all,
+    // and a loop over an empty call list would pass vacuously.
+    expect(mockTrack).toHaveBeenCalledTimes(2);
     mockTrack.mock.calls.forEach(([event]) => {
       expect(event).toBe(AnalyticsEvent.SCREEN_VIEWED);
     });

--- a/__tests__/components/screens/ScanReceiveScreen/ScanReceiveScreen.test.tsx
+++ b/__tests__/components/screens/ScanReceiveScreen/ScanReceiveScreen.test.tsx
@@ -2,7 +2,7 @@ import { useIsFocused } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { act, fireEvent } from "@testing-library/react-native";
 import ScanReceiveScreen from "components/screens/ScanReceiveScreen";
-import { AnalyticsEvent } from "config/analyticsConfig";
+import { AnalyticsEvent, AnalyticsFlow } from "config/analyticsConfig";
 import { ROOT_NAVIGATOR_ROUTES, RootStackParamList } from "config/routes";
 import { renderWithProviders } from "helpers/testUtils";
 import React from "react";
@@ -79,14 +79,22 @@ describe("ScanReceiveScreen", () => {
       previousAppState;
   });
 
+  // Per-tab views go out as the canonical screen.viewed event carrying the
+  // tab's screen_name -- track() drops a VIEW_* slug passed as an event name.
   it("fires the scan view event by default", () => {
     renderWithProviders(<ScanReceiveScreen {...makeProps()} />);
-    expect(mockTrack).toHaveBeenCalledWith(AnalyticsEvent.VIEW_SCAN_QR_CODE);
+    expect(mockTrack).toHaveBeenCalledWith(AnalyticsEvent.SCREEN_VIEWED, {
+      screen_name: AnalyticsEvent.VIEW_SCAN_QR_CODE,
+      flow: AnalyticsFlow.ASSETS,
+    });
   });
 
   it("fires the account-qr view event when opened on the receive tab", () => {
     renderWithProviders(<ScanReceiveScreen {...makeProps("receive")} />);
-    expect(mockTrack).toHaveBeenCalledWith(AnalyticsEvent.VIEW_ACCOUNT_QR_CODE);
+    expect(mockTrack).toHaveBeenCalledWith(AnalyticsEvent.SCREEN_VIEWED, {
+      screen_name: AnalyticsEvent.VIEW_ACCOUNT_QR_CODE,
+      flow: AnalyticsFlow.ASSETS,
+    });
   });
 
   it("fires the account-qr view event when switching to Receive", () => {
@@ -95,7 +103,20 @@ describe("ScanReceiveScreen", () => {
     );
     mockTrack.mockClear();
     fireEvent.press(getByText("Receive"));
-    expect(mockTrack).toHaveBeenCalledWith(AnalyticsEvent.VIEW_ACCOUNT_QR_CODE);
+    expect(mockTrack).toHaveBeenCalledWith(AnalyticsEvent.SCREEN_VIEWED, {
+      screen_name: AnalyticsEvent.VIEW_ACCOUNT_QR_CODE,
+      flow: AnalyticsFlow.ASSETS,
+    });
+  });
+
+  it("never passes a VIEW_* slug to track() as an event name", () => {
+    const { getByText } = renderWithProviders(
+      <ScanReceiveScreen {...makeProps("scan")} />,
+    );
+    fireEvent.press(getByText("Receive"));
+    mockTrack.mock.calls.forEach(([event]) => {
+      expect(event).toBe(AnalyticsEvent.SCREEN_VIEWED);
+    });
   });
 
   it("closes via goBack when the close button is pressed", () => {

--- a/__tests__/config/analyticsConfig.test.ts
+++ b/__tests__/config/analyticsConfig.test.ts
@@ -219,5 +219,21 @@ describe("Analytics Configuration", () => {
       // (was the legacy "loaded screen: scan qr code").
       expect(AnalyticsEvent.VIEW_SCAN_QR_CODE).toBe("scan_qr_code");
     });
+
+    it("catalogues both tab views so they retarget to screen.viewed", () => {
+      // The screen fires these two manually; an uncatalogued one would slip
+      // past track()'s screen-view guard and leak its bare slug as an
+      // Amplitude event name instead of becoming screen.viewed.
+      expect(getScreenViewedProps(AnalyticsEvent.VIEW_SCAN_QR_CODE)).toEqual({
+        screen_name: "scan_qr_code",
+        flow: AnalyticsFlow.ASSETS,
+      });
+      expect(getScreenViewedProps(AnalyticsEvent.VIEW_ACCOUNT_QR_CODE)).toEqual(
+        {
+          screen_name: "view_public_key_generator",
+          flow: AnalyticsFlow.ASSETS,
+        },
+      );
+    });
   });
 });

--- a/src/components/screens/ScanReceiveScreen/ScanReceiveScreen.tsx
+++ b/src/components/screens/ScanReceiveScreen/ScanReceiveScreen.tsx
@@ -5,7 +5,7 @@ import { ReceiveTabView } from "components/screens/ScanReceiveScreen/ReceiveTabV
 import { ScanTabView } from "components/screens/ScanReceiveScreen/ScanTabView";
 import Icon from "components/sds/Icon";
 import Tabs from "components/sds/Tabs";
-import { AnalyticsEvent } from "config/analyticsConfig";
+import { AnalyticsEvent, getScreenViewedProps } from "config/analyticsConfig";
 import { DEFAULT_PADDING } from "config/constants";
 import {
   ROOT_NAVIGATOR_ROUTES,
@@ -96,13 +96,20 @@ const ScanReceiveScreen: React.FC<ScanReceiveScreenProps> = ({
   }, [activeTab, receiveAnim]);
 
   // Per-tab screen-view analytics (preserves prior per-screen tracking): fires
-  // on initial mount and on every tab switch.
+  // on initial mount and on every tab switch. Each tab is a screen load, so it
+  // goes out as the canonical `screen.viewed` event carrying that tab's
+  // screen_name -- passing the VIEW_* slug as the event name would be dropped
+  // by track()'s screen-view guard.
   useEffect(() => {
-    track(
+    const screenViewedProps = getScreenViewedProps(
       activeTab === "receive"
         ? AnalyticsEvent.VIEW_ACCOUNT_QR_CODE
         : AnalyticsEvent.VIEW_SCAN_QR_CODE,
     );
+
+    if (screenViewedProps) {
+      track(AnalyticsEvent.SCREEN_VIEWED, screenViewedProps);
+    }
   }, [activeTab]);
 
   const insetsTop = insets.top || pxValue(MIN_INSETS_TOP - DEFAULT_PADDING);

--- a/src/config/analyticsConfig.ts
+++ b/src/config/analyticsConfig.ts
@@ -388,7 +388,12 @@ const SCREEN_CATALOG: Record<string, { flow?: AnalyticsFlow; step?: Step }> = {
   [AnalyticsEvent.VIEW_TOKEN_DETAILS]: {
     flow: AnalyticsFlow.ASSETS,
   },
+  // Both tabs of the unified Scan/Receive screen. They are catalogued like any
+  // other screen so the manual per-tab emission retargets to `screen.viewed`.
   [AnalyticsEvent.VIEW_ACCOUNT_QR_CODE]: {
+    flow: AnalyticsFlow.ASSETS,
+  },
+  [AnalyticsEvent.VIEW_SCAN_QR_CODE]: {
     flow: AnalyticsFlow.ASSETS,
   },
   [AnalyticsEvent.VIEW_MANAGE_TOKENS]: {


### PR DESCRIPTION
### What

`ScanReceiveScreen` now emits its per-tab screen views as `screen.viewed` (via `getScreenViewedProps()`, same as `BottomSheet`) instead of passing the `VIEW_*` slug to `track()` as an event name. Also adds the missing `VIEW_SCAN_QR_CODE` entry to `SCREEN_CATALOG`.

### Why

Every view of the Receive tab logged:

```
[Analytics] Screen-view "view_public_key_generator" passed to track() directly; emit SCREEN_VIEWED via the navigation choke points instead. Event dropped.
```

Sample: https://stellarorg.sentry.io/issues/7633220935/

#944 added the unified screen firing `track(VIEW_ACCOUNT_QR_CODE)`; #936 then made screen views a single `screen.viewed` event with a guard that drops screen-view slugs passed as event names. The screen was never migrated, so the Receive view was dropped entirely.

The Scan tab had the same bug silently: `VIEW_SCAN_QR_CODE` wasn't catalogued, so the guard couldn't see it and it emitted a bare `scan_qr_code` event.

Both tabs now emit `screen.viewed` with `{ screen_name, flow: "assets" }`. Tests previously passed through both bugs because they mock `track()`; they now assert the event name and props.

`Refs` the Sentry issue rather than `Fixes` — resolving manually after prod verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
