### PR TITLE
copy(preferences): "Usage data sharing" toggle + accurate disclosure

### DIFF
--- a/src/components/screens/SettingsScreen/PreferencesScreen/PreferencesScreen.tsx
+++ b/src/components/screens/SettingsScreen/PreferencesScreen/PreferencesScreen.tsx
@@ -98,9 +98,9 @@ const PreferencesScreen: React.FC<PreferencesScreenProps> = () => {
   const preferencesItems: PreferenceListItem[] = useMemo(
     () => [
       {
-        title: t("preferences.anonymousDataSharing.title"),
+        title: t("preferences.usageDataSharing.title"),
         titleColor: themeColors.text.primary,
-        description: t("preferences.anonymousDataSharing.description"),
+        description: t("preferences.usageDataSharing.description"),
         trailingContent: renderAnalyticsToggle(),
         testID: "anonymous-data-sharing-item",
       },

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -85,19 +85,19 @@
     "deleteAccountConfirmMessage": "Make sure you have your recovery phrase in a safe place. You will not be able to recover your wallet without it."
   },
   "preferences": {
-    "anonymousDataSharing": {
-      "title": "Anonymous data sharing",
-      "description": "Allow Freighter to collect limited information about usage. We will collect public keys, transaction amounts, and balances. This information will not be used for marketing or to identify you personally. We will not collect information such as name, address, email addresses, phone numbers, etc."
+    "usageDataSharing": {
+      "title": "Usage data sharing",
+      "description": "Help us improve Freighter by sharing usage, device, and activity data, including your public keys, IP address, and a persistent ID that links your wallet across extension and mobile, with our analytics and crash-reporting providers. You can turn this off at any time. See our Privacy Policy for details."
     },
     "permissionModal": {
       "enable": {
         "title": "Enable Analytics",
-        "description": "To enable anonymous data sharing, you'll need to allow tracking permissions in your device settings.",
+        "description": "To enable usage data sharing, you'll need to allow tracking permissions in your device settings.",
         "instruction": "Tap \"Open Settings\" below, then find Freighter and enable \"Allow Tracking\"."
       },
       "disable": {
         "title": "Disable Analytics",
-        "description": "To disable anonymous data sharing, you'll need to change tracking permissions in your device settings.",
+        "description": "To disable usage data sharing, you'll need to change tracking permissions in your device settings.",
         "instruction": "Tap \"Open Settings\" below, then find Freighter and disable \"Allow Tracking\"."
       },
       "openSettings": "Open Settings",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -85,15 +85,19 @@
     "deleteAccountConfirmMessage": "Certifique-se de que você tem sua frase de recuperação em um local seguro. Você não conseguirá recuperar sua carteira sem ela."
   },
   "preferences": {
+    "usageDataSharing": {
+      "title": "Compartilhamento de dados de uso",
+      "description": "Ajude-nos a melhorar o Freighter compartilhando dados de uso, do dispositivo e de atividade — incluindo suas chaves públicas, endereço IP e um ID persistente que vincula sua carteira entre a extensão e o aplicativo móvel — com nossos provedores de análise de dados e de relatórios de falhas. Você pode desativar essa opção a qualquer momento. Consulte nossa Política de Privacidade para mais detalhes."
+    },
     "permissionModal": {
       "enable": {
         "title": "Habilitar Analytics",
-        "description": "Para habilitar o compartilhamento de dados anônimos, você precisará permitir permissões de rastreamento nas configurações do seu dispositivo.",
+        "description": "Para habilitar o compartilhamento de dados de uso, você precisará permitir permissões de rastreamento nas configurações do seu dispositivo.",
         "instruction": "Toque em \"Abrir Configurações\" abaixo, depois encontre Freighter e habilite \"Permitir Rastreamento\"."
       },
       "disable": {
         "title": "Desabilitar Analytics",
-        "description": "Para desabilitar o compartilhamento de dados anônimos, você precisará alterar as permissões de rastreamento nas configurações do seu dispositivo.",
+        "description": "Para desabilitar o compartilhamento de dados de uso, você precisará alterar as permissões de rastreamento nas configurações do seu dispositivo.",
         "instruction": "Toque em \"Abrir Configurações\" abaixo, depois encontre Freighter e desabilite \"Permitir Rastreamento\"."
       },
       "openSettings": "Abrir Configurações",

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -85,10 +85,6 @@
     "deleteAccountConfirmMessage": "Certifique-se de que você tem sua frase de recuperação em um local seguro. Você não conseguirá recuperar sua carteira sem ela."
   },
   "preferences": {
-    "anonymousDataSharing": {
-      "title": "Compartilhamento de dados anônimos",
-      "description": "Permitir que o Freighter colete informações limitadas sobre o uso. Coletaremos chaves públicas, valores de transações e saldos. Essas informações não serão usadas para marketing ou para identificar você pessoalmente. Não coletaremos informações como nome, endereço, e-mails, números de telefone, etc."
-    },
     "permissionModal": {
       "enable": {
         "title": "Habilitar Analytics",


### PR DESCRIPTION
## TL;DR

Renames the Preferences data-sharing toggle from **"Anonymous data sharing"** to **"Usage data sharing"** and replaces its description with an accurate disclosure. The old copy said we collect only "public keys, transaction amounts, and balances," which understated what's actually sent.

Both strings are translated into Portuguese, and the ATT permission-modal wording is aligned in both languages. **The Portuguese copy needs native-speaker sign-off before merge** — see the review thread.

Paired with stellar/freighter#2922, which makes the identical change in the extension. The copy is deliberately byte-identical across both.

<details>
<summary>Implementation details (for agents)</summary>

**Why:** the toggle's data includes usage/device/activity events, public keys (the seed-derived auth key as `user_id` + a hashed account key), IP address (→ approximate geolocation), and a persistent ID that links a wallet across extension and mobile, sent to our analytics (Amplitude) and crash-reporting (Sentry) providers. "Anonymous" was inaccurate, and so was the narrow list of collected fields.

**New English copy:** "Help us improve Freighter by sharing usage, device, and activity data, including your public keys, IP address, and a persistent ID that links your wallet across extension and mobile, with our analytics and crash-reporting providers. You can turn this off at any time. See our Privacy Policy for details."

**New Portuguese copy:** "Ajude-nos a melhorar o Freighter compartilhando dados de uso, do dispositivo e de atividade — incluindo suas chaves públicas, endereço IP e um ID persistente que vincula sua carteira entre a extensão e o aplicativo móvel — com nossos provedores de análise de dados e de relatórios de falhas. Você pode desativar essa opção a qualquer momento. Consulte nossa Política de Privacidade para mais detalhes." Title: "Compartilhamento de dados de uso". Terminology follows the existing catalog (`Política de Privacidade`, `chave pública`, `dispositivo`, `carteira`, `extensão`, and the `o Freighter` article convention).

**Changes:**
- `en/translations.json`: renamed key `preferences.anonymousDataSharing` → `usageDataSharing`; `title` → "Usage data sharing"; `description` → the new copy. Aligned the two ATT permission-modal descriptions ("anonymous" → "usage data sharing").
- `PreferencesScreen.tsx`: updated the two `t()` references to the renamed key.
- `pt/translations.json`: same key changes with Portuguese values, plus the two permission-modal descriptions moved off "compartilhamento de dados anônimos" — without that, Portuguese users saw the modal contradict the toggle description and still read "anonymous", the inaccuracy this PR removes.

**Verification:**
- 940/940 en/pt leaf-key parity, 0 missing, 0 extra. 35 pt values are pre-existing English placeholders; neither new key is among them.
- 0 occurrences of `anônim` left in pt, 0 of `anonymous` in en, and 0 remaining references to the old `anonymousDataSharing` key anywhere in `src/`, `e2e/`, or `__tests__/` — the rename is complete.
- All four en/pt strings verified byte-identical to stellar/freighter#2922.
- `yarn lint:translations` → no `missing-translations` errors; `yarn lint:ts` clean; prettier clean.
- Full test suite green: 209 suites, 2793 passed, 6 skipped, 0 failures. Targeted `PreferencesScreen.test.tsx` + `ducks/preferences.test.ts` → 13/13.
- Pre-existing and unrelated: 6 `import/order` errors in `parseTransaction.ts`, `buildAuthJwt.ts`, `deriveAuthKeypair.ts`, confirmed identical on `main`.

**Follow-ups:**
- If "Privacy Policy" should be a link rather than plain text, that needs wiring — left as provided.
- The list item keeps `testID="anonymous-data-sharing-item"`. Not user-visible; renaming it is a gratuitous break risk in a copy PR, so it's better bundled with the next real change to this screen.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
