### PR TITLE
feat(ci): trigger tests on release PRs via GitHub App toke

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, release, emergency-release, "v*.*.*"]
   push:
-    branches: [main, release, emergency-release, "v*.*.*"]
+    branches: [main, release, emergency-release]
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, release, emergency-release, "v*.*.*"]
   push:
-    branches: [main, release, emergency-release, "v*.*.*"]
+    branches: [main, release, emergency-release]
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -48,9 +48,26 @@ jobs:
           echo "APP_VERSION=${APP_VERSION}" >> $GITHUB_ENV
           echo "✓ Using normalized version: ${APP_VERSION}"
 
+      # Events created with the default GITHUB_TOKEN don't trigger other
+      # workflows, so release/bump-version PRs opened with it never run the unit
+      # or e2e test workflows. A GitHub App installation token is not subject to
+      # that limitation.
+      - name: Generate release automation token
+        id: release-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # It's preferable to hardcode "stellar" here for security reasons instead of "github.repository_owner"
+          owner: stellar
+          repositories: freighter-mobile
+
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          # Persist the App token so the git push steps below push with it
+          token: ${{ steps.release-token.outputs.token }}
+          persist-credentials: true
           fetch-depth: 0
           fetch-tags: true
 
@@ -233,6 +250,8 @@ jobs:
           VERSION_BRANCH: ${{ steps.set_branches.outputs.version_branch }}
           BRANCH_FROM: ${{ steps.validate_branch_from.outputs.branch_or_tag }}
         with:
+          # Use the App token so `pull_request: opened` triggers the test workflows
+          github-token: ${{ steps.release-token.outputs.token }}
           script: |
             const releaseBranch = process.env.RELEASE_BRANCH;
             const versionBranch = process.env.VERSION_BRANCH;
@@ -334,6 +353,8 @@ jobs:
         env:
           APP_VERSION: ${{ steps.normalize_version.outputs.app_version }}
         with:
+          # Use the App token so `pull_request: opened` triggers the test workflows
+          github-token: ${{ steps.release-token.outputs.token }}
           script: |
             const version = process.env.APP_VERSION;
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [main, release, emergency-release, "v*.*.*"]
+    branches: [main, release, emergency-release]
   pull_request:
     branches: [main, release, emergency-release, "v*.*.*"]
 


### PR DESCRIPTION
### What

1. This closes https://github.com/stellar/freighter-mobile/issues/882: Wires the pre-provisioned **Freighter Mobile Release** GitHub App into `new-release.yml`, in three places.
2. Also removes version branches (`v*.*.*`) from the **push** trigger of `test.yml`, `ios-e2e.yml` and `android-e2e.yml`. They remain in the `pull_request` trigger.

### Why

1. Events created with the default `GITHUB_TOKEN` don't trigger other workflows, so the release and bump-version PRs opened by `new-release.yml` never started `test.yml`, `ios-e2e.yml` or `android-e2e.yml`.
2. The trigger change avoids the flip side of the fix. Once pushes carry the App token, a version branch fires **both** a `push` run and a `pull_request` run for the same commit. GitHub treats them as unrelated events and doesn't dedupe.

Note: the ops ticket specifies `RELEASE_APP_ID` as a repository **variable**, but it was provisioned as a **secret**, so this uses `secrets.RELEASE_APP_ID`.

### Testing

Tested by dispatching this branch's `new-release.yml` against tag `v1.20.27` ([run](https://github.com/stellar/freighter-mobile/actions/runs/30562511039)): the App token minted,  auto-triggered tests:

Test [30562543177](https://github.com/stellar/freighter-mobile/actions/runs/30562543177)
iOS E2E Tests [30562539889](https://github.com/stellar/freighter-mobile/actions/runs/30562539889)
Android E2E Tests [30562542302](https://github.com/stellar/freighter-mobile/actions/runs/30562542302)

### Known limitations

- Creating the `release` branch still fires a full CI round (Test + both e2e) on a commit identical to `main`
- The push-trigger change can't be verified before merge

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
