### PR TITLE
fix(send): derive the token contract from the asset

### DIFF
--- a/__tests__/services/buildPaymentTransactionContractTarget.test.ts
+++ b/__tests__/services/buildPaymentTransactionContractTarget.test.ts
@@ -1,0 +1,178 @@
+import {
+  Asset,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  Transaction,
+  Operation,
+  Address,
+  scValToNative,
+} from "@stellar/stellar-sdk";
+import { BigNumber } from "bignumber.js";
+import { NETWORKS } from "config/constants";
+import { PricedBalance } from "config/types";
+import { getNativeContractDetails } from "helpers/soroban";
+import { buildPaymentTransaction } from "services/transactionService";
+
+jest.mock("services/stellar", () => ({
+  ...jest.requireActual("services/stellar"),
+  stellarSdkServer: jest.fn(() => ({
+    loadAccount: jest.fn((publicKey: string) => ({
+      accountId: () => publicKey,
+      sequenceNumber: () => "1000",
+      incrementSequenceNumber: jest.fn(),
+    })),
+    fetchTimebounds: jest.fn(() => ({ minTime: 0, maxTime: 2000000000 })),
+  })),
+}));
+
+jest.mock("services/analytics", () => ({
+  analytics: { trackSimulationError: jest.fn() },
+}));
+
+jest.mock("i18next", () => ({ t: jest.fn((key: string) => key) }));
+
+jest.mock("services/backend", () => ({
+  simulateTransaction: jest.fn(),
+  checkContractSupportsMuxed: jest.fn().mockResolvedValue(false),
+}));
+
+const ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const USDC_SAC = new Asset("USDC", ISSUER).contractId(Networks.TESTNET);
+const XLM_SAC = getNativeContractDetails(NETWORKS.TESTNET).contract;
+// An unrelated contract address, standing in for any pasted C... destination
+const UNRELATED_CONTRACT =
+  "CB5OQXIXSBZROO54MDQCH3T55Z46E5E46WBNCT4K4FKQERK3NIFFEJ3W";
+const CUSTOM_TOKEN_CONTRACT =
+  "CBOVW5CXOPHYWGLJPWBQMGX2F3REBY2ZTZX3N47RTYWWHZV2BXCIIGTL";
+
+const sender = Keypair.random();
+
+const baseParams = {
+  tokenAmount: "500",
+  transactionFee: "0.001",
+  transactionTimeout: 300,
+  network: NETWORKS.TESTNET,
+  senderAddress: sender.publicKey(),
+};
+
+const classicUsdcBalance = {
+  token: { code: "USDC", issuer: { key: ISSUER }, type: "credit_alphanum4" },
+  total: new BigNumber("1000"),
+  available: new BigNumber("1000"),
+  limit: new BigNumber("100000"),
+  buyingLiabilities: "0",
+  sellingLiabilities: "0",
+  tokenCode: "USDC",
+} as unknown as PricedBalance;
+
+const nativeBalance = {
+  token: { code: "XLM", type: "native" },
+  total: new BigNumber("1000"),
+  available: new BigNumber("1000"),
+  minimumBalance: new BigNumber("1"),
+  buyingLiabilities: "0",
+  sellingLiabilities: "0",
+  tokenCode: "XLM",
+} as unknown as PricedBalance;
+
+const customTokenBalance = {
+  token: { code: "WETH", issuer: { key: CUSTOM_TOKEN_CONTRACT } },
+  contractId: CUSTOM_TOKEN_CONTRACT,
+  total: new BigNumber("1000"),
+  available: new BigNumber("1000"),
+  name: "Wrapped Ether",
+  symbol: "WETH",
+  decimals: 18,
+  tokenCode: "WETH",
+} as unknown as PricedBalance;
+
+const decodeInvocation = (xdr: string) => {
+  const tx = TransactionBuilder.fromXDR(xdr, Networks.TESTNET) as Transaction;
+  const op = tx.operations[0] as Operation.InvokeHostFunction;
+  const invoke = op.func.invokeContract();
+
+  return {
+    invokedContract: Address.fromScAddress(invoke.contractAddress()).toString(),
+    fnName: invoke.functionName().toString(),
+    args: invoke.args().map((arg) => scValToNative(arg)),
+  };
+};
+
+describe("buildPaymentTransaction — Soroban transfer target selection", () => {
+  it("targets the asset's own SAC when a classic asset goes to a contract address", async () => {
+    const result = await buildPaymentTransaction({
+      ...baseParams,
+      selectedBalance: classicUsdcBalance,
+      recipientAddress: UNRELATED_CONTRACT,
+    } as never);
+
+    // Regression guard: the recipient must never become the token contract.
+    expect(result.contractId).toBe(USDC_SAC);
+    expect(result.contractId).not.toBe(UNRELATED_CONTRACT);
+
+    const { invokedContract, fnName, args } = decodeInvocation(result.xdr);
+    expect(invokedContract).toBe(USDC_SAC);
+    expect(fnName).toBe("transfer");
+    expect(args[0]).toBe(sender.publicKey());
+    expect(args[1]).toBe(UNRELATED_CONTRACT);
+    expect(String(args[2])).toBe("5000000000"); // 500 * 10^7
+  });
+
+  it("does not move a different asset when the destination is another asset's SAC", async () => {
+    const result = await buildPaymentTransaction({
+      ...baseParams,
+      selectedBalance: classicUsdcBalance,
+      recipientAddress: XLM_SAC,
+    } as never);
+
+    // Selecting USDC must never produce a call into the XLM SAC.
+    expect(result.contractId).toBe(USDC_SAC);
+    expect(decodeInvocation(result.xdr).invokedContract).toBe(USDC_SAC);
+  });
+
+  it("targets the native SAC for XLM sent to a contract address", async () => {
+    const result = await buildPaymentTransaction({
+      ...baseParams,
+      selectedBalance: nativeBalance,
+      recipientAddress: UNRELATED_CONTRACT,
+    } as never);
+
+    expect(result.contractId).toBe(XLM_SAC);
+    expect(decodeInvocation(result.xdr).invokedContract).toBe(XLM_SAC);
+  });
+
+  it("targets the token's own contract for a custom token", async () => {
+    const result = await buildPaymentTransaction({
+      ...baseParams,
+      selectedBalance: customTokenBalance,
+      recipientAddress: Keypair.random().publicKey(),
+    } as never);
+
+    expect(result.contractId).toBe(CUSTOM_TOKEN_CONTRACT);
+    expect(decodeInvocation(result.xdr).invokedContract).toBe(
+      CUSTOM_TOKEN_CONTRACT,
+    );
+  });
+
+  // Sending a token to its own token contract credits the contract's own
+  // address, where nothing can spend it again. Refusing to build is defence
+  // in depth: it also catches any future rewiring that lets the recipient
+  // become the invocation target.
+  it.each([
+    ["a classic asset", classicUsdcBalance, USDC_SAC],
+    ["native XLM", nativeBalance, XLM_SAC],
+    ["a custom token", customTokenBalance, CUSTOM_TOKEN_CONTRACT],
+  ])(
+    "refuses to send %s to the token's own contract address",
+    async (_label, selectedBalance, ownContract) => {
+      await expect(
+        buildPaymentTransaction({
+          ...baseParams,
+          selectedBalance,
+          recipientAddress: ownContract,
+        } as never),
+      ).rejects.toThrow("transaction.errors.recipientIsTokenContract");
+    },
+  );
+});

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -1054,7 +1054,8 @@
       "invalidRecipientAddress": "Invalid recipient address",
       "cannotSendToSelf": "Cannot send to yourself",
       "invalidDecimals": "Invalid or missing decimals for custom token",
-      "invalidFederationMemo": "The federation server returned an invalid memo. Please verify the address and try again."
+      "invalidFederationMemo": "The federation server returned an invalid memo. Please verify the address and try again.",
+      "recipientIsTokenContract": "Cannot send to the token's own contract"
     }
   },
   "welcomeBanner": {

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -1054,7 +1054,8 @@
       "invalidRecipientAddress": "Endereço do destinatário inválido",
       "cannotSendToSelf": "Não é possível enviar para você mesmo",
       "invalidDecimals": "Decimais inválidos ou ausentes para token personalizado",
-      "invalidFederationMemo": "O servidor de federação retornou um memo inválido. Por favor, verifique o endereço e tente novamente."
+      "invalidFederationMemo": "O servidor de federação retornou um memo inválido. Por favor, verifique o endereço e tente novamente.",
+      "recipientIsTokenContract": "Não é possível enviar para o contrato do próprio token"
     }
   },
   "welcomeBanner": {

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -445,18 +445,25 @@ export const buildPaymentTransaction = async (
       if (isCustomToken) {
         contractId = selectedBalance.contractId;
       } else {
-        try {
-          const token = getTokenForPayment(selectedBalance);
-          contractId = token.isNative()
-            ? getContractIdForNativeToken(network)
-            : recipientAddress;
-        } catch (error) {
-          if (isCustomToken) {
-            contractId = selectedBalance.contractId;
-          } else {
-            throw error;
-          }
-        }
+        // The token contract is a property of the ASSET being sent, never of
+        // the recipient. For a classic asset that contract is its Stellar
+        // Asset Contract, whose address derives deterministically from
+        // (code, issuer, network passphrase). Using the recipient here would
+        // invoke an arbitrary contract chosen by the destination address and
+        // move whichever asset that contract governs, not the selected one.
+        const token = getTokenForPayment(selectedBalance);
+        contractId = token.isNative()
+          ? getContractIdForNativeToken(network)
+          : token.contractId(networkDetails.networkPassphrase);
+      }
+
+      // Defence in depth against the above being wired wrongly again: a token
+      // transferred to its own token contract is credited to the contract's
+      // own address, where nothing can ever spend it again — the SAC only
+      // moves a balance on `from.require_auth()` and never authorizes on
+      // behalf of itself. Refuse rather than build an irreversible burn.
+      if (contractId === recipientAddress) {
+        throw new Error(t("transaction.errors.recipientIsTokenContract"));
       }
 
       const contractSupportsMuxed = await checkContractMuxedSupport({


### PR DESCRIPTION
### What

When a classic asset is sent to a contract (`C...`) address, `buildPaymentTransaction` used the recipient address as the Soroban `transfer` invocation target. It now derives the target from the selected asset — its Stellar Asset Contract address, which follows deterministically from (code, issuer, network passphrase).

Also in scope:

- Removed the surrounding `try/catch`, whose handler re-dispatched on `isCustomToken` inside a branch where that flag is provably `false` (dead code that swallowed failures).
- Added a guard refusing to send a token to its own contract address, since such a transfer is credited to an address that has no spender.

Native XLM and custom Soroban tokens already resolved correctly and are unchanged.

The extension already does this correctly — `getAssetAddress` in `useSimulateTxData.tsx` resolves the asset's SAC — so this brings mobile in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
