### PR TITLE
fix(copy): "Create a wallet from your seed phrase"

### DIFF
--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -804,7 +804,7 @@
     "title": "Add another wallet",
     "actions": {
       "createNewWallet": "Create a new wallet",
-      "createNewWalletDescription": "Create a wallet on your seed phrase",
+      "createNewWalletDescription": "Create a wallet from your seed phrase",
       "importSecretKey": "Import a Stellar secret key",
       "importSecretKeyDescription": "Add a wallet using a secret key"
     },

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -767,7 +767,7 @@
     "title": "Adicionar outra carteira",
     "actions": {
       "createNewWallet": "Criar uma nova carteira",
-      "createNewWalletDescription": "Criar uma carteira na sua frase de recuperação",
+      "createNewWalletDescription": "Criar uma carteira a partir da sua frase de recuperação",
       "importSecretKey": "Importar uma chave secreta Stellar",
       "importSecretKeyDescription": "Adicionar uma carteira usando uma chave secreta"
     },


### PR DESCRIPTION
Copy fix on the **Add another wallet** screen: "Create a wallet **on** your seed phrase" → "Create a wallet **from** your seed phrase".

Also updated the `pt` translation to match ("na sua frase" → "a partir da sua frase").

Extension commits to put it in parity ([here](https://github.com/stellar/freighter/pull/2935/changes/a01c3450a1435d86f0d37b88af0473f64656906b) and [here](https://github.com/stellar/freighter/pull/2935/changes/4bd8e3c102f1a99f43fa26434adced768d3f4be2)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)