### PR TITLE
feat(balances): align the total USD label with the extension ("$0.00" vs "--")

### DIFF
--- a/__tests__/components/screens/HomeScreen.test.tsx
+++ b/__tests__/components/screens/HomeScreen.test.tsx
@@ -284,6 +284,7 @@ jest.mock("hooks/useBalancesList", () => ({
 jest.mock("hooks/useTotalBalance", () => ({
   useTotalBalance: jest.fn(() => ({
     formattedBalance: "$350.75",
+    totalLabel: "$350.75",
     totalBalance: "350.75",
     hasFiatTotal: true,
   })),
@@ -339,6 +340,7 @@ describe("HomeScreen", () => {
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValueOnce({
       formattedBalance: "$0.00",
+      totalLabel: "$0.00",
       totalBalance: "0",
       hasFiatTotal: false,
     });
@@ -348,10 +350,29 @@ describe("HomeScreen", () => {
     expect(getByText("$0.00")).toBeTruthy();
   });
 
+  it("shows the placeholder when a funded account's prices fail", () => {
+    // Nothing is loading anymore, so the hero commits to a label — and a
+    // confident $0.00 would misreport a funded wallet as empty.
+    const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
+    useTotalBalance.mockReturnValueOnce({
+      formattedBalance: "$0.00",
+      totalLabel: "--",
+      totalBalance: "0",
+      hasFiatTotal: false,
+    });
+
+    const { getByText, queryByText, queryByTestId } = renderHomeScreen();
+
+    expect(getByText("--")).toBeTruthy();
+    expect(queryByText("$0.00")).toBeNull();
+    expect(queryByTestId("home-fiat-total-spinner")).toBeNull();
+  });
+
   it("shows a spinner instead of a placeholder $0.00 while balances load", () => {
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValue({
       formattedBalance: "$0.00",
+      totalLabel: "$0.00",
       totalBalance: "0",
       hasFiatTotal: false,
     });
@@ -364,6 +385,7 @@ describe("HomeScreen", () => {
 
     useTotalBalance.mockReturnValue({
       formattedBalance: "$350.75",
+      totalLabel: "$350.75",
       totalBalance: "350.75",
       hasFiatTotal: true,
     });
@@ -375,6 +397,7 @@ describe("HomeScreen", () => {
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValueOnce({
       formattedBalance: "$0.00",
+      totalLabel: "$0.00",
       totalBalance: "0",
       hasFiatTotal: false,
     });

--- a/__tests__/components/screens/HomeScreen.test.tsx
+++ b/__tests__/components/screens/HomeScreen.test.tsx
@@ -291,7 +291,6 @@ jest.mock("hooks/useBalancesList", () => ({
 
 jest.mock("hooks/useTotalBalance", () => ({
   useTotalBalance: jest.fn(() => ({
-    formattedBalance: "$350.75",
     totalLabel: "$350.75",
     totalBalance: "350.75",
     hasFiatTotal: true,
@@ -351,7 +350,6 @@ describe("HomeScreen", () => {
   it("shows a zero fiat total when no balance is priced", () => {
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValueOnce({
-      formattedBalance: "$0.00",
       totalLabel: "$0.00",
       totalBalance: "0",
       hasFiatTotal: false,
@@ -367,7 +365,6 @@ describe("HomeScreen", () => {
     // confident $0.00 would misreport a funded wallet as empty.
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValueOnce({
-      formattedBalance: "$0.00",
       totalLabel: "--",
       totalBalance: "0",
       hasFiatTotal: false,
@@ -383,7 +380,6 @@ describe("HomeScreen", () => {
   it("shows a spinner instead of a placeholder $0.00 while balances load", () => {
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValue({
-      formattedBalance: "$0.00",
       totalLabel: "$0.00",
       totalBalance: "0",
       hasFiatTotal: false,
@@ -396,7 +392,6 @@ describe("HomeScreen", () => {
     expect(queryByText("$0.00")).toBeNull();
 
     useTotalBalance.mockReturnValue({
-      formattedBalance: "$350.75",
       totalLabel: "$350.75",
       totalBalance: "350.75",
       hasFiatTotal: true,
@@ -408,7 +403,6 @@ describe("HomeScreen", () => {
     // quotes are still in flight — the hero must not flash $0.00.
     const { useTotalBalance } = jest.requireMock("hooks/useTotalBalance");
     useTotalBalance.mockReturnValueOnce({
-      formattedBalance: "$0.00",
       totalLabel: "$0.00",
       totalBalance: "0",
       hasFiatTotal: false,

--- a/__tests__/components/screens/HomeScreen/AccountItemRow.test.tsx
+++ b/__tests__/components/screens/HomeScreen/AccountItemRow.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent } from "@testing-library/react-native";
-import { BigNumber } from "bignumber.js";
 import AccountItemRow from "components/screens/HomeScreen/AccountItemRow";
 import { Account } from "config/types";
 import { renderWithProviders } from "helpers/testUtils";
@@ -58,7 +57,7 @@ describe("AccountItemRow", () => {
 
   it("shows the formatted fiat total when available", () => {
     const { getByText } = renderWithProviders(
-      <AccountItemRow {...defaultProps} fiatTotal={new BigNumber("1149.23")} />,
+      <AccountItemRow {...defaultProps} fiatTotal={{ label: "$1,149.23", hasError: false }} />,
     );
 
     expect(getByText("$1,149.23")).toBeTruthy();
@@ -73,22 +72,44 @@ describe("AccountItemRow", () => {
     expect(queryByText("$0.00")).toBeNull();
   });
 
-  it("shows a zero fiat total when it is unavailable", () => {
+  it("shows the placeholder when the total could not be read", () => {
     const { getByText, queryByTestId } = renderWithProviders(
-      <AccountItemRow {...defaultProps} fiatTotal={null} />,
+      <AccountItemRow
+        {...defaultProps}
+        fiatTotal={{ label: "--", hasError: true }}
+      />,
     );
 
-    expect(getByText("$0.00")).toBeTruthy();
+    // A zero here would claim the account is empty when its balances are
+    // simply unknown.
+    expect(getByText("--")).toBeTruthy();
     expect(queryByTestId("account-row-0-total-spinner")).toBeNull();
   });
 
   it("shows the spinner while a failed total is being retried", () => {
     const { getByTestId, queryByText } = renderWithProviders(
-      <AccountItemRow {...defaultProps} fiatTotal={null} isLoadingFiatTotal />,
+      <AccountItemRow
+        {...defaultProps}
+        fiatTotal={{ label: "--", hasError: true }}
+        isLoadingFiatTotal
+      />,
     );
 
     expect(getByTestId("account-row-0-total-spinner")).toBeTruthy();
-    expect(queryByText("$0.00")).toBeNull();
+    expect(queryByText("--")).toBeNull();
+  });
+
+  it("keeps a fetched total visible while other rows refresh", () => {
+    const { getByText, queryByTestId } = renderWithProviders(
+      <AccountItemRow
+        {...defaultProps}
+        fiatTotal={{ label: "$1,149.23", hasError: false }}
+        isLoadingFiatTotal
+      />,
+    );
+
+    expect(getByText("$1,149.23")).toBeTruthy();
+    expect(queryByTestId("account-row-0-total-spinner")).toBeNull();
   });
 
   it("shows a zero fiat total when none was fetched and nothing is loading", () => {
@@ -143,7 +164,7 @@ describe("AccountItemRow", () => {
       <AccountItemRow
         {...defaultProps}
         account={{ ...mockAccount, importedFromSecretKey: true }}
-        fiatTotal={new BigNumber("1149.23")}
+        fiatTotal={{ label: "$1,149.23", hasError: false }}
       />,
     );
 

--- a/__tests__/components/screens/HomeScreen/ManageAccountBottomSheet.test.tsx
+++ b/__tests__/components/screens/HomeScreen/ManageAccountBottomSheet.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent } from "@testing-library/react-native";
-import { BigNumber } from "bignumber.js";
 import ManageAccountBottomSheet, {
   ManageAccountSheetHeader,
 } from "components/screens/HomeScreen/ManageAccountBottomSheet";
@@ -36,8 +35,8 @@ describe("ManageAccountBottomSheet", () => {
     isAccountSwitching: false,
     switchingToPublicKey: null,
     fiatTotals: {
-      [PK_1]: new BigNumber("1149.23"),
-      [PK_2]: new BigNumber("872.48"),
+      [PK_1]: { label: "$1,149.23", hasError: false },
+      [PK_2]: { label: "$872.48", hasError: false },
     },
     isLoadingFiatTotals: false,
   };

--- a/__tests__/ducks/accountsFiatTotals.test.ts
+++ b/__tests__/ducks/accountsFiatTotals.test.ts
@@ -123,8 +123,8 @@ describe("accountsFiatTotals duck", () => {
       useAccountsFiatTotalsStore.getState();
 
     // 100 XLM * $0.5 + 200 USDC * $1 = $250
-    expect(fiatTotals[PK_1]?.toString()).toBe("250");
-    expect(fiatTotals[PK_2]?.toString()).toBe("250");
+    expect(fiatTotals[PK_1]?.label).toBe("$250.00");
+    expect(fiatTotals[PK_2]?.label).toBe("$250.00");
     expect(isLoading).toBe(false);
     expect(lastUpdatedAt).not.toBeNull();
     expect(lastNetwork).toBe(NETWORKS.PUBLIC);
@@ -152,8 +152,8 @@ describe("accountsFiatTotals duck", () => {
 
     // Only XLM priced: 100 * $0.5
     expect(
-      useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]?.toString(),
-    ).toBe("50");
+      useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]?.label,
+    ).toBe("$50.00");
   });
 
   it("returns zero for unfunded accounts (empty balances)", async () => {
@@ -171,11 +171,11 @@ describe("accountsFiatTotals duck", () => {
     });
 
     expect(
-      useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]?.toString(),
-    ).toBe("0");
+      useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]?.label,
+    ).toBe("$0.00");
   });
 
-  it("isolates per-account fetch failures as null totals", async () => {
+  it("isolates per-account fetch failures behind the placeholder", async () => {
     mockFetchBalances.mockImplementation(({ publicKey }) =>
       publicKey === PK_2
         ? Promise.reject(new Error("network error"))
@@ -194,14 +194,16 @@ describe("accountsFiatTotals duck", () => {
     });
 
     const { fiatTotals, isLoading } = useAccountsFiatTotalsStore.getState();
-    expect(fiatTotals[PK_1]?.toString()).toBe("250");
-    expect(fiatTotals[PK_2]).toBeNull();
+    expect(fiatTotals[PK_1]?.label).toBe("$250.00");
+    // A zero here would claim the account is empty when its balances are
+    // simply unknown; hasError keeps it eligible for the next retry.
+    expect(fiatTotals[PK_2]).toEqual({ label: "--", hasError: true });
     expect(isLoading).toBe(false);
   });
 
   it("does not fetch on non-mainnet networks and clears totals", async () => {
     useAccountsFiatTotalsStore.setState({
-      fiatTotals: { [PK_1]: new BigNumber("250") },
+      fiatTotals: { [PK_1]: { label: "$250.00", hasError: false } },
       lastUpdatedAt: Date.now(),
       lastNetwork: NETWORKS.PUBLIC,
     });
@@ -214,7 +216,12 @@ describe("accountsFiatTotals duck", () => {
     });
 
     expect(mockFetchBalances).not.toHaveBeenCalled();
-    expect(useAccountsFiatTotalsStore.getState().fiatTotals).toEqual({});
+    // No feed here, so every account's total is a known zero rather than a
+    // missing entry the row would have to interpret — and never "--", which
+    // would imply a reading was attempted and failed.
+    expect(useAccountsFiatTotalsStore.getState().fiatTotals).toEqual({
+      [PK_1]: { label: "$0.00", hasError: false },
+    });
   });
 
   it("skips refetch within the TTL when all accounts are cached", async () => {
@@ -312,7 +319,7 @@ describe("accountsFiatTotals duck", () => {
 
     const { fiatTotals } = useAccountsFiatTotalsStore.getState();
     publicKeys.forEach((publicKey) => {
-      expect(fiatTotals[publicKey]?.toString()).toBe("250");
+      expect(fiatTotals[publicKey]?.label).toBe("$250.00");
     });
   });
 
@@ -429,8 +436,8 @@ describe("accountsFiatTotals duck", () => {
     expect(mockFetchBalances).toHaveBeenCalledTimes(3);
     const { fiatTotals, isLoading, lastUpdatedAt } =
       useAccountsFiatTotalsStore.getState();
-    expect(fiatTotals[PK_1]?.toString()).toBe("250");
-    expect(fiatTotals[PK_2]?.toString()).toBe("250");
+    expect(fiatTotals[PK_1]?.label).toBe("$250.00");
+    expect(fiatTotals[PK_2]?.label).toBe("$250.00");
     expect(isLoading).toBe(false);
     expect(lastUpdatedAt).not.toBeNull();
   });
@@ -474,7 +481,11 @@ describe("accountsFiatTotals duck", () => {
     await mainnetFetch;
 
     const { fiatTotals, lastNetwork } = useAccountsFiatTotalsStore.getState();
-    expect(fiatTotals).toEqual({});
+    // Every entry is the testnet zero the switch wrote — none of the aborted
+    // cycle's mainnet totals leaked through.
+    expect(Object.values(fiatTotals)).toEqual(
+      publicKeys.map(() => ({ label: "$0.00", hasError: false })),
+    );
     expect(lastNetwork).toBe(NETWORKS.TESTNET);
     // Second mainnet batch never starts after the abort
     expect(mockFetchBalances).toHaveBeenCalledTimes(
@@ -482,7 +493,7 @@ describe("accountsFiatTotals duck", () => {
     );
   });
 
-  it("retries failed (null) totals on the next fetch within the TTL", async () => {
+  it("retries failed totals on the next fetch within the TTL", async () => {
     mockFetchBalances.mockRejectedValueOnce(new Error("offline"));
 
     const { fetchAccountsFiatTotals } = useAccountsFiatTotalsStore.getState();
@@ -491,7 +502,10 @@ describe("accountsFiatTotals duck", () => {
       publicKeys: [PK_1],
       network: NETWORKS.PUBLIC,
     });
-    expect(useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]).toBeNull();
+    expect(useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]).toEqual({
+      label: "--",
+      hasError: true,
+    });
 
     await fetchAccountsFiatTotals({
       publicKeys: [PK_1],
@@ -500,8 +514,8 @@ describe("accountsFiatTotals duck", () => {
 
     expect(mockFetchBalances).toHaveBeenCalledTimes(2);
     expect(
-      useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]?.toString(),
-    ).toBe("250");
+      useAccountsFiatTotalsStore.getState().fiatTotals[PK_1]?.label,
+    ).toBe("$250.00");
   });
 
   describe("syncAccountFiatTotal", () => {
@@ -523,11 +537,13 @@ describe("accountsFiatTotals duck", () => {
         publicKey: PK_1,
         network: NETWORKS.PUBLIC,
         pricedBalances,
+        isFunded: true,
+        hasError: false,
       });
 
       const { fiatTotals, lastUpdatedAt } =
         useAccountsFiatTotalsStore.getState();
-      expect(fiatTotals[PK_1]?.toString()).toBe("250");
+      expect(fiatTotals[PK_1]?.label).toBe("$250.00");
       expect(lastUpdatedAt).toBeNull();
     });
 
@@ -535,8 +551,8 @@ describe("accountsFiatTotals duck", () => {
       const now = Date.now();
       useAccountsFiatTotalsStore.setState({
         fiatTotals: {
-          [PK_1]: new BigNumber("100"),
-          [PK_2]: new BigNumber("7"),
+          [PK_1]: { label: "$100.00", hasError: false },
+          [PK_2]: { label: "$7.00", hasError: false },
         },
         lastUpdatedAt: now,
         lastNetwork: NETWORKS.PUBLIC,
@@ -548,12 +564,14 @@ describe("accountsFiatTotals duck", () => {
         publicKey: PK_1,
         network: NETWORKS.PUBLIC,
         pricedBalances,
+        isFunded: true,
+        hasError: false,
       });
 
       const { fiatTotals, lastUpdatedAt } =
         useAccountsFiatTotalsStore.getState();
-      expect(fiatTotals[PK_1]?.toString()).toBe("250");
-      expect(fiatTotals[PK_2]?.toString()).toBe("7");
+      expect(fiatTotals[PK_1]?.label).toBe("$250.00");
+      expect(fiatTotals[PK_2]?.label).toBe("$7.00");
       // Value changes are mostly price drift (fiatTotals move with live
       // prices on every balances poll) — invalidating here used to defeat
       // the TTL and refetch every account per poll. The other rows refresh
@@ -564,7 +582,7 @@ describe("accountsFiatTotals duck", () => {
     it("does nothing when the total is unchanged", () => {
       const now = Date.now();
       useAccountsFiatTotalsStore.setState({
-        fiatTotals: { [PK_1]: new BigNumber("250") },
+        fiatTotals: { [PK_1]: { label: "$250.00", hasError: false } },
         lastUpdatedAt: now,
         lastNetwork: NETWORKS.PUBLIC,
       });
@@ -575,6 +593,8 @@ describe("accountsFiatTotals duck", () => {
         publicKey: PK_1,
         network: NETWORKS.PUBLIC,
         pricedBalances,
+        isFunded: true,
+        hasError: false,
       });
 
       expect(useAccountsFiatTotalsStore.getState().lastUpdatedAt).toBe(now);
@@ -583,7 +603,13 @@ describe("accountsFiatTotals duck", () => {
     it.each([
       [
         "empty balances (mid account-switch)",
-        { publicKey: PK_1, network: NETWORKS.PUBLIC, pricedBalances: {} },
+        {
+          publicKey: PK_1,
+          network: NETWORKS.PUBLIC,
+          pricedBalances: {},
+          isFunded: true,
+          hasError: false,
+        },
       ],
       [
         "unpriced balances (prices not loaded yet)",
@@ -591,11 +617,19 @@ describe("accountsFiatTotals duck", () => {
           publicKey: PK_1,
           network: NETWORKS.PUBLIC,
           pricedBalances: { XLM: { ...nativeBalance } },
+          isFunded: true,
+          hasError: false,
         },
       ],
       [
         "non-mainnet networks",
-        { publicKey: PK_1, network: NETWORKS.TESTNET, pricedBalances },
+        {
+          publicKey: PK_1,
+          network: NETWORKS.TESTNET,
+          pricedBalances,
+          isFunded: true,
+          hasError: false,
+        },
       ],
     ])("ignores %s", (_label, params) => {
       const { syncAccountFiatTotal } = useAccountsFiatTotalsStore.getState();
@@ -623,7 +657,7 @@ describe("accountsFiatTotals duck", () => {
     );
 
     const { fiatTotals, lastUpdatedAt } = useAccountsFiatTotalsStore.getState();
-    expect(fiatTotals[PK_2]?.toString()).toBe("250");
+    expect(fiatTotals[PK_2]?.label).toBe("$250.00");
     // The excluded (active) account is the sync's responsibility.
     expect(fiatTotals[PK_1]).toBeUndefined();
     expect(lastUpdatedAt).not.toBeNull();
@@ -714,7 +748,7 @@ describe("accountsFiatTotals duck", () => {
 
   it("clears totals from another network before fetching", async () => {
     useAccountsFiatTotalsStore.setState({
-      fiatTotals: { STALE_KEY: new BigNumber("999") },
+      fiatTotals: { STALE_KEY: { label: "$999.00", hasError: false } },
       lastUpdatedAt: Date.now(),
       lastNetwork: NETWORKS.TESTNET,
     });
@@ -728,7 +762,7 @@ describe("accountsFiatTotals duck", () => {
 
     const { fiatTotals } = useAccountsFiatTotalsStore.getState();
     expect(fiatTotals.STALE_KEY).toBeUndefined();
-    expect(fiatTotals[PK_1]?.toString()).toBe("250");
+    expect(fiatTotals[PK_1]?.label).toBe("$250.00");
   });
 
   it("preserves the excluded account's synced total through the network clear", async () => {
@@ -737,7 +771,7 @@ describe("accountsFiatTotals duck", () => {
     // so the cycle takes the different-network clear path. The active entry
     // must survive — this cycle won't refetch it.
     useAccountsFiatTotalsStore.setState({
-      fiatTotals: { [PK_1]: new BigNumber("44") },
+      fiatTotals: { [PK_1]: { label: "$44.00", hasError: false } },
       lastNetwork: null,
     });
 
@@ -750,8 +784,8 @@ describe("accountsFiatTotals duck", () => {
     });
 
     const { fiatTotals } = useAccountsFiatTotalsStore.getState();
-    expect(fiatTotals[PK_1]?.toString()).toBe("44");
-    expect(fiatTotals[PK_2]?.toString()).toBe("250");
+    expect(fiatTotals[PK_1]?.label).toBe("$44.00");
+    expect(fiatTotals[PK_2]?.label).toBe("$250.00");
     expect(mockFetchBalances).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/helpers/getTotalUsdLabel.test.ts
+++ b/__tests__/helpers/getTotalUsdLabel.test.ts
@@ -1,0 +1,65 @@
+import { BigNumber } from "bignumber.js";
+import { getTotalUsdLabel } from "helpers/balances";
+import { NO_FIAT_VALUE } from "helpers/formatAmount";
+
+/**
+ * Mirrors the extension's `getTotalUsdLabel` suite so both clients are pinned
+ * to the same rule for "$0.00" vs "--".
+ */
+const label = (overrides: Partial<Parameters<typeof getTotalUsdLabel>[0]>) =>
+  getTotalUsdLabel({
+    hasError: false,
+    hasPriceFeed: true,
+    isFunded: true,
+    hasPrices: true,
+    totalUsd: new BigNumber("1149.239"),
+    ...overrides,
+  });
+
+describe("getTotalUsdLabel", () => {
+  // NOTE: the extension's suite expects "$1,149.23" for this input — its
+  // roundUsdValue truncates the third decimal where mobile's formatFiatAmount
+  // rounds it. That's pre-existing formatting, not part of the "$0.00" vs "--"
+  // rule this helper ports, so mobile's behavior is pinned as-is.
+  it("formats the total when it can be determined", () => {
+    expect(label({})).toBe("$1,149.24");
+  });
+
+  // Zero is a fact here, not a stand-in for a total that went missing.
+  it("returns zero where the network prices no tokens", () => {
+    expect(label({ hasPriceFeed: false })).toBe("$0.00");
+  });
+
+  it("returns zero for an unfunded account", () => {
+    expect(label({ isFunded: false })).toBe("$0.00");
+  });
+
+  // Zero would claim the account is empty when its balances are unknown.
+  it("returns the placeholder when account data failed", () => {
+    expect(label({ hasError: true })).toBe(NO_FIAT_VALUE);
+  });
+
+  it("returns the placeholder when a funded account prices nothing", () => {
+    expect(label({ hasPrices: false })).toBe(NO_FIAT_VALUE);
+  });
+
+  // A real zero on a priced network still reads as a total, not a gap.
+  it("keeps a genuine zero total distinct from the placeholder", () => {
+    expect(label({ totalUsd: new BigNumber(0) })).toBe("$0.00");
+  });
+
+  // An error outranks every other input: nothing else is trustworthy once the
+  // balances themselves failed to load.
+  it("prefers the placeholder over zero when an unfunded fetch also failed", () => {
+    expect(label({ hasError: true, isFunded: false })).toBe(NO_FIAT_VALUE);
+  });
+
+  // No feed means no prices to miss, so the zero must survive hasPrices=false.
+  it("returns zero on a feedless network even with nothing priced", () => {
+    expect(label({ hasPriceFeed: false, hasPrices: false })).toBe("$0.00");
+  });
+
+  it("treats a missing total as zero once a price feed reported in", () => {
+    expect(label({ totalUsd: undefined })).toBe("$0.00");
+  });
+});

--- a/__tests__/hooks/useSyncAccountsFiatTotals.test.tsx
+++ b/__tests__/hooks/useSyncAccountsFiatTotals.test.tsx
@@ -35,6 +35,10 @@ describe("useSyncAccountsFiatTotals", () => {
       fetchedPublicKey: PK_OLD,
       fetchedNetwork: NETWORKS.PUBLIC,
       isLoading: false,
+      // Funded state and the fetch error travel with the snapshot: the store
+      // needs both to pick between "$0.00" and "--" for the active row.
+      isFunded: true,
+      error: null,
     };
   });
 
@@ -50,6 +54,8 @@ describe("useSyncAccountsFiatTotals", () => {
       publicKey: PK_OLD,
       network: NETWORKS.PUBLIC,
       pricedBalances: mockPricedBalances,
+      isFunded: true,
+      hasError: false,
     });
   });
 

--- a/__tests__/hooks/useSyncAccountsFiatTotals.test.tsx
+++ b/__tests__/hooks/useSyncAccountsFiatTotals.test.tsx
@@ -72,6 +72,48 @@ describe("useSyncAccountsFiatTotals", () => {
     expect(mockSyncAccountFiatTotal).not.toHaveBeenCalled();
   });
 
+  // Regression: a failed fetch is never stamped, so the guard used to drop the
+  // error and leave the row on "$0.00" while the Home header showed "--".
+  it("syncs a failed fetch even though it was never stamped", () => {
+    mockBalancesState = {
+      ...mockBalancesState,
+      fetchedPublicKey: null,
+      fetchedNetwork: null,
+      error: "Failed to fetch balances",
+    };
+
+    renderHook(() =>
+      useSyncAccountsFiatTotals({
+        publicKey: PK_OLD,
+        network: NETWORKS.PUBLIC,
+      }),
+    );
+
+    expect(mockSyncAccountFiatTotal).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: PK_OLD, hasError: true }),
+    );
+  });
+
+  // The error is only worth writing once the request has actually settled.
+  it("still waits for an in-flight fetch before syncing an error", () => {
+    mockBalancesState = {
+      ...mockBalancesState,
+      fetchedPublicKey: null,
+      fetchedNetwork: null,
+      error: "Failed to fetch balances",
+      isLoading: true,
+    };
+
+    renderHook(() =>
+      useSyncAccountsFiatTotals({
+        publicKey: PK_OLD,
+        network: NETWORKS.PUBLIC,
+      }),
+    );
+
+    expect(mockSyncAccountFiatTotal).not.toHaveBeenCalled();
+  });
+
   it("skips the sync while a balances fetch is in flight", () => {
     // Mid-fetch, the account stamp is already updated (written with the raw
     // balances) but pricedBalances hasn't caught up yet.

--- a/src/components/BalancesList.tsx
+++ b/src/components/BalancesList.tsx
@@ -179,7 +179,7 @@ export const BalancesList: React.FC<BalancesListProps> = ({
         <Spinner
           testID="balances-list-spinner"
           size="large"
-          color={THEME.colors.secondary}
+          color={themeColors.foreground.primary}
         />
       </SpinnerWrapper>
     );

--- a/src/components/CollectiblesGrid.tsx
+++ b/src/components/CollectiblesGrid.tsx
@@ -129,7 +129,7 @@ export const CollectiblesGrid: React.FC<CollectiblesGridProps> = React.memo(
           <Spinner
             testID="collectibles-grid-spinner"
             size="large"
-            color={themeColors.secondary}
+            color={themeColors.foreground.primary}
           />
         </View>
       );

--- a/src/components/screens/HomeScreen/AccountItemRow.tsx
+++ b/src/components/screens/HomeScreen/AccountItemRow.tsx
@@ -1,10 +1,10 @@
-import { BigNumber } from "bignumber.js";
 import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { DEFAULT_PRESS_DELAY } from "config/constants";
 import { Account } from "config/types";
-import { formatFiatAmount } from "helpers/formatAmount";
+import { AccountFiatTotal } from "ducks/accountsFiatTotals";
+import { getTotalUsdLabel } from "helpers/balances";
 import { truncateAddress } from "helpers/stellar";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
@@ -23,13 +23,12 @@ interface AccountItemRowProps {
   isAccountSwitching: boolean;
   isSwitchingToThisAccount: boolean;
   /**
-   * Account's total USD value. `undefined` means not fetched yet; `null`
-   * means unavailable (fetch failed or fiat-less network). Both render a
-   * spinner while `isLoadingFiatTotal` (a failed row shows it during its
-   * retry) and fall back to a zero total once loading settles, matching the
-   * Home screen's always-visible fiat balance.
+   * The account's total USD value, already resolved to what should be shown —
+   * an amount, "$0.00" or "--" — by {@link getTotalUsdLabel} in the accounts
+   * fiat totals store. `undefined` means not fetched yet, which renders a
+   * spinner while `isLoadingFiatTotal` and a zero total once loading settles.
    */
-  fiatTotal?: BigNumber | null;
+  fiatTotal?: AccountFiatTotal;
   isLoadingFiatTotal?: boolean;
   testID?: string;
 }
@@ -56,10 +55,23 @@ const AccountItemRow: React.FC<AccountItemRowProps> = ({
   const truncatedPublicKey = truncateAddress(account.publicKey);
   const showSelectedBadge =
     isSwitchingToThisAccount || (isSelected && !isAccountSwitching);
-  // Covers both never-fetched (undefined) and failed (null) totals: a
-  // failed row is retried by the next cycle, and showing the spinner
-  // during the retry beats asserting a confident $0.00.
-  const isTotalLoading = fiatTotal == null && isLoadingFiatTotal;
+  // Spins only while a fetch is actually in flight for a row that has no
+  // successful value: never fetched, or failed and now being retried. Once a
+  // cycle settles, a failed row shows "--" rather than spinning forever, and a
+  // row that already has a total keeps showing it across refreshes.
+  const isTotalLoading =
+    isLoadingFiatTotal && (fiatTotal == null || fiatTotal.hasError);
+  // No entry yet (idle before the first cycle) means nothing is known about
+  // this account, so route that through the same helper rather than hardcoding
+  // a second zero string.
+  const fiatTotalLabel =
+    fiatTotal?.label ??
+    getTotalUsdLabel({
+      hasError: false,
+      hasPriceFeed: false,
+      isFunded: false,
+      hasPrices: false,
+    });
 
   // Announce what the row shows — name, imported marker and USD total (only
   // once one is actually displayed, never a placeholder $0.00 mid-load).
@@ -68,7 +80,7 @@ const AccountItemRow: React.FC<AccountItemRowProps> = ({
   const rowAccessibilityLabel = [
     account.name,
     account.importedFromSecretKey ? t("home.account.imported") : null,
-    isTotalLoading ? null : formatFiatAmount(fiatTotal ?? "0"),
+    isTotalLoading ? null : fiatTotalLabel,
   ]
     .filter(Boolean)
     .join(", ");
@@ -90,7 +102,7 @@ const AccountItemRow: React.FC<AccountItemRowProps> = ({
 
     return (
       <Text md medium primary testID={testID ? `${testID}-total` : undefined}>
-        {formatFiatAmount(fiatTotal ?? "0")}
+        {fiatTotalLabel}
       </Text>
     );
   };

--- a/src/components/screens/HomeScreen/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen/HomeScreen.tsx
@@ -97,7 +97,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = React.memo(
 
     const { t } = useAppTranslation();
 
-    const { formattedBalance, hasFiatTotal } = useTotalBalance();
+    const { totalLabel, hasFiatTotal } = useTotalBalance();
     const {
       balances,
       isFunded,
@@ -361,7 +361,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = React.memo(
               />
             ) : (
               <Display lg medium>
-                {formattedBalance}
+                {totalLabel}
               </Display>
             )}
           </View>

--- a/src/components/screens/HomeScreen/ManageAccountBottomSheet.tsx
+++ b/src/components/screens/HomeScreen/ManageAccountBottomSheet.tsx
@@ -1,10 +1,10 @@
-import { BigNumber } from "bignumber.js";
 import { DefaultListFooter } from "components/DefaultListFooter";
 import AccountItemRow from "components/screens/HomeScreen/AccountItemRow";
 import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { Account } from "config/types";
+import { AccountFiatTotal } from "ducks/accountsFiatTotals";
 import { ActiveAccount } from "ducks/auth";
 import { truncateAddress } from "helpers/stellar";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -23,7 +23,7 @@ interface ManageAccountBottomSheetProps {
   handleSelectAccount: (publicKey: string) => Promise<void>;
   isAccountSwitching: boolean;
   switchingToPublicKey: string | null;
-  fiatTotals: Record<string, BigNumber | null>;
+  fiatTotals: Record<string, AccountFiatTotal>;
   isLoadingFiatTotals: boolean;
 }
 

--- a/src/ducks/accountsFiatTotals.ts
+++ b/src/ducks/accountsFiatTotals.ts
@@ -7,6 +7,7 @@ import { useRemoteConfigStore } from "ducks/remoteConfig";
 import {
   getTokenIdentifier,
   getTokenIdentifiersFromBalances,
+  getTotalUsdLabel,
 } from "helpers/balances";
 import { isMainnet } from "helpers/networks";
 import { fetchBalances } from "services/backend";
@@ -41,23 +42,43 @@ interface SyncAccountFiatTotalParams {
   publicKey: string;
   network: NETWORKS;
   pricedBalances: PricedBalanceMap;
+  /** Whether the active account is funded, from the balances store. */
+  isFunded: boolean;
+  /** Whether the active account's balances fetch failed. */
+  hasError: boolean;
+}
+
+/**
+ * One account's entry in the wallets list.
+ *
+ * The label is the finished display string rather than a number, because the
+ * choice between "$1,234.56", "$0.00" and "--" needs inputs (funded state,
+ * whether anything priced, whether the fetch failed) that only the fetch cycle
+ * holds — see {@link getTotalUsdLabel}. `hasError` is kept alongside so a
+ * failed account is retried by the next trigger instead of being treated as
+ * successfully fetched.
+ */
+export interface AccountFiatTotal {
+  label: string;
+  hasError: boolean;
 }
 
 /**
  * State for the accounts fiat totals store
  *
  * @interface AccountsFiatTotalsState
- * @property {Record<string, BigNumber | null>} fiatTotals - USD total keyed by
- *   publicKey. `null` means the account's balances couldn't be fetched; a
- *   missing key means the account hasn't been fetched yet. The active
- *   account's entry is maintained by `syncAccountFiatTotal`, not fetched.
+ * @property {Record<string, AccountFiatTotal>} fiatTotals - Display entry keyed
+ *   by publicKey. A missing key means the account hasn't been fetched yet (the
+ *   row spinner covers that); a present entry always carries a label to show,
+ *   "--" included. The active account's entry is maintained by
+ *   `syncAccountFiatTotal`, not fetched.
  * @property {boolean} isLoading - Whether a fetch cycle is in flight
  * @property {number | null} lastUpdatedAt - Timestamp of the last completed fetch
  * @property {NETWORKS | null} lastNetwork - Network the current totals belong to
  * @property {Function} fetchAccountsFiatTotals - Fetches USD totals for the given accounts
  */
 interface AccountsFiatTotalsState {
-  fiatTotals: Record<string, BigNumber | null>;
+  fiatTotals: Record<string, AccountFiatTotal>;
   isLoading: boolean;
   lastUpdatedAt: number | null;
   lastNetwork: NETWORKS | null;
@@ -76,22 +97,32 @@ interface AccountsFiatTotalsState {
 /**
  * Sums the USD value of every priced token in an account's balances.
  * Tokens without a known price (custom tokens, LP shares, price fetch
- * failures) contribute zero, so an unfunded account totals $0.00.
+ * failures) contribute zero.
+ *
+ * Also reports how many tokens actually priced, which is what separates a
+ * genuine zero from a total that couldn't be read: a funded account where
+ * nothing priced sums to zero, but that zero is not a fact about its worth.
  */
 const computeFiatTotal = (
   balances: BalanceMap,
   prices: TokenPricesMap,
-): BigNumber =>
-  Object.values(balances).reduce((total, balance) => {
-    const identifier = getTokenIdentifier(balance);
-    const currentPrice = identifier ? prices[identifier]?.currentPrice : null;
+): { total: BigNumber; pricedCount: number } =>
+  Object.values(balances).reduce(
+    (acc, balance) => {
+      const identifier = getTokenIdentifier(balance);
+      const currentPrice = identifier ? prices[identifier]?.currentPrice : null;
 
-    if (!currentPrice) {
-      return total;
-    }
+      if (!currentPrice) {
+        return acc;
+      }
 
-    return total.plus(balance.total.multipliedBy(currentPrice));
-  }, new BigNumber(0));
+      return {
+        total: acc.total.plus(balance.total.multipliedBy(currentPrice)),
+        pricedCount: acc.pricedCount + 1,
+      };
+    },
+    { total: new BigNumber(0), pricedCount: 0 },
+  );
 
 /**
  * Accounts Fiat Totals Store
@@ -136,7 +167,27 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
       }) => {
         if (!isMainnet(network)) {
           get().resetAccountsFiatTotals();
-          set({ lastNetwork: network });
+
+          // No feed here, so nothing is fetched and every account's total is a
+          // known zero. Filled in so the row never has to infer a missing
+          // entry (and never shows "--" on a network that simply has no
+          // prices).
+          const noFeedLabel = getTotalUsdLabel({
+            hasError: false,
+            hasPriceFeed: false,
+            isFunded: false,
+            hasPrices: false,
+          });
+
+          set({
+            lastNetwork: network,
+            fiatTotals: Object.fromEntries(
+              publicKeys.map((publicKey) => [
+                publicKey,
+                { label: noFeedLabel, hasError: false },
+              ]),
+            ),
+          });
           return;
         }
 
@@ -159,10 +210,11 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
         const isFresh =
           lastUpdatedAt !== null &&
           Date.now() - lastUpdatedAt < ACCOUNTS_FIAT_TOTALS_TTL_MS;
-        // Failed (null) entries don't count as fetched, so a reopen within the
-        // TTL retries them instead of leaving rows blank until it expires.
+        // Failed entries don't count as fetched, so a reopen within the TTL
+        // retries them instead of leaving rows on "--" until it expires.
         const hasAllAccounts = keysToFetch.every(
-          (publicKey) => fiatTotals[publicKey] != null,
+          (publicKey) =>
+            fiatTotals[publicKey] != null && !fiatTotals[publicKey].hasError,
         );
 
         if (!forceRefresh && isSameNetwork && isFresh && hasAllAccounts) {
@@ -223,25 +275,29 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
                   // both v1 and v2, so those balances would contribute $0
                   // to the total either way — the extension's wallets list
                   // makes the same trade-off.
-                  const { balances } = await fetchBalances({
+                  const { balances, isFunded } = await fetchBalances({
                     publicKey,
                     network,
                     shouldSkipScan: true,
                   });
 
-                  return { publicKey, balances: balances ?? {} };
+                  return {
+                    publicKey,
+                    balances: balances ?? {},
+                    isFunded: isFunded ?? false,
+                  };
                 } catch (error) {
                   // One account failing shouldn't blank out the whole list —
-                  // its row falls back to a zero total. Warn (not error): a
-                  // per-account fetch failing is an expected offline/backend
-                  // hiccup, logged as forensic context.
+                  // its row shows "--" and the next trigger retries it. Warn
+                  // (not error): a per-account fetch failing is an expected
+                  // offline/backend hiccup, logged as forensic context.
                   logger.warn(
                     "fetchAccountsFiatTotals",
                     "Failed to fetch balances for account",
                     { publicKey, error },
                   );
 
-                  return { publicKey, balances: null };
+                  return { publicKey, balances: null, isFunded: false };
                 }
               }),
             );
@@ -287,12 +343,27 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
 
             const prices = usePricesStore.getState().pricesByNetwork[network];
 
-            const batchTotals: Record<string, BigNumber | null> = {};
-            results.forEach(({ publicKey, balances }) => {
-              batchTotals[publicKey] =
-                balances === null
-                  ? null
-                  : computeFiatTotal(balances, prices ?? {});
+            // The label is decided here rather than in the row because this is
+            // the only place that knows all of it: whether the fetch failed,
+            // whether the account is funded, and whether anything priced.
+            const batchTotals: Record<string, AccountFiatTotal> = {};
+            results.forEach(({ publicKey, balances, isFunded }) => {
+              const hasError = balances === null;
+              const { total, pricedCount } = balances
+                ? computeFiatTotal(balances, prices ?? {})
+                : { total: new BigNumber(0), pricedCount: 0 };
+
+              batchTotals[publicKey] = {
+                label: getTotalUsdLabel({
+                  hasError,
+                  // Past the guard above, so the network prices tokens.
+                  hasPriceFeed: isMainnet(network),
+                  isFunded,
+                  hasPrices: pricedCount > 0,
+                  totalUsd: total,
+                }),
+                hasError,
+              };
             });
 
             set({ fiatTotals: { ...get().fiatTotals, ...batchTotals } });
@@ -338,7 +409,13 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
        * other rows refresh on the TTL'd triggers instead (sheet open,
        * pull-to-refresh, account switch).
        */
-      syncAccountFiatTotal: ({ publicKey, network, pricedBalances }) => {
+      syncAccountFiatTotal: ({
+        publicKey,
+        network,
+        pricedBalances,
+        isFunded,
+        hasError,
+      }) => {
         // Fiat totals are mainnet-only, and this gate is not redundant with
         // the unpriced-balances one below: right after a switch to another
         // network, the balances store still briefly holds the previous
@@ -350,16 +427,22 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
         }
 
         const entries = Object.values(pricedBalances);
+        const hasPrices = entries.some((balance) => balance.fiatTotal != null);
+        // Distinguishes "quotes failed" from "quotes still in flight" — both
+        // leave the map unpriced, but only the former is a real "--".
+        const pricesError = usePricesStore.getState().error;
 
-        // An empty map is indistinguishable from the transient cleared state
-        // during an account switch, and balances without fiat values are just
-        // prices that haven't loaded yet — syncing either would write a bogus
-        // zero over a real total.
-        if (
-          entries.length === 0 ||
-          !entries.some((balance) => balance.fiatTotal != null)
-        ) {
-          return;
+        // A failed fetch and an unfunded account are both decided without
+        // prices, so they're written straight through. Everything else needs
+        // to guard against transient states:
+        if (!hasError && isFunded) {
+          // An empty map is indistinguishable from the transient cleared
+          // state during an account switch, and an unpriced map with no price
+          // error is just quotes that haven't landed yet — syncing either
+          // would replace a real label with a placeholder.
+          if (entries.length === 0 || (!hasPrices && !pricesError)) {
+            return;
+          }
         }
 
         const total = entries.reduce(
@@ -367,13 +450,25 @@ export const useAccountsFiatTotalsStore = create<AccountsFiatTotalsState>(
           new BigNumber(0),
         );
 
+        // Same helper as the fetch cycle and the Home header, so the active
+        // account's row can't disagree with the balance shown above it.
+        const label = getTotalUsdLabel({
+          hasError,
+          hasPriceFeed: isMainnet(network),
+          isFunded,
+          hasPrices,
+          totalUsd: total,
+        });
+
         const current = get().fiatTotals[publicKey];
 
-        if (current?.isEqualTo(total)) {
+        if (current?.label === label && current.hasError === hasError) {
           return;
         }
 
-        set({ fiatTotals: { ...get().fiatTotals, [publicKey]: total } });
+        set({
+          fiatTotals: { ...get().fiatTotals, [publicKey]: { label, hasError } },
+        });
       },
 
       resetAccountsFiatTotals: () => {

--- a/src/helpers/balances.ts
+++ b/src/helpers/balances.ts
@@ -17,6 +17,7 @@ import {
   NonNativeToken,
   Token,
 } from "config/types";
+import { formatFiatAmount, NO_FIAT_VALUE } from "helpers/formatAmount";
 
 interface GetTokenPriceFromBalanceParams {
   prices: TokenPricesMap;
@@ -402,32 +403,6 @@ export const calculateSpendableAmount = ({
 };
 
 /**
- * Checks if a balance carries an explicit `decimals` field — the marker for
- * a Soroban / custom token, regardless of whether that value is zero. Classic
- * Stellar balances don't have this field and rely on the protocol's fixed
- * 7-decimal precision instead.
- *
- * Note: `decimals === 0` is a legitimate value for a custom token that uses
- * integer-only units (no fractional part), and must still discriminate as
- * "has decimals" so downstream logic doesn't fall back to the classic default.
- *
- * @param {Balance | PricedBalance} balance - The balance to check
- * @returns {boolean} True when the balance has a non-negative `decimals` field
- *
- * @example
- * if (hasDecimals(balance)) {
- *   // Use decimal-aware formatting
- *   const formatted = formatSorobanTokenAmount(amount, balance.decimals);
- * }
- */
-export const hasDecimals = (
-  balance: Balance | PricedBalance,
-): balance is Balance & { decimals: number } =>
-  "decimals" in balance &&
-  typeof balance.decimals === "number" &&
-  balance.decimals >= 0;
-
-/**
  * Validates if an amount exceeds the spendable balance
  *
  * @param {IsAmountSpendableParams} params - Object containing amount, balance, subentry count, and transaction fee
@@ -562,4 +537,58 @@ export const getIssuerFromIdentifier = (
   const [_, issuer] = identifier.split(delimeter);
   /* eslint-enable */
   return issuer;
+};
+
+interface GetTotalUsdLabelParams {
+  /** Balances failed to load for the account. */
+  hasError: boolean;
+  /** Whether the network prices tokens at all (mainnet-only today). */
+  hasPriceFeed: boolean;
+  isFunded: boolean;
+  /**
+   * Whether any of the account's own held tokens resolved to a price. False
+   * when the price fetch failed or returned nothing for them — which is what
+   * separates a genuine zero from a total that could not be read.
+   */
+  hasPrices: boolean;
+  /** Omit where no total was computed; the branches that ignore it win. */
+  totalUsd?: BigNumber;
+}
+
+/**
+ * Picks what to show for an account's total USD value.
+ *
+ * Zero and "no value" are different answers. Zero is a fact when there is
+ * nothing to value; the placeholder means the total could not be determined.
+ *
+ * This is the single place that decision is made, so the Home header and every
+ * wallets-list row always agree. Ported from the extension's `getTotalUsdLabel`
+ * to keep both clients on one rule.
+ */
+export const getTotalUsdLabel = ({
+  hasError,
+  hasPriceFeed,
+  isFunded,
+  hasPrices,
+  totalUsd,
+}: GetTotalUsdLabelParams): string => {
+  // Balances are unknown, so any figure would be a claim rather than a total.
+  if (hasError) {
+    return NO_FIAT_VALUE;
+  }
+
+  // Nothing to value: the network prices no tokens, or the account holds
+  // none. "$0.00" here is a real zero, not a stand-in for a total that could
+  // not be read.
+  if (!hasPriceFeed || !isFunded) {
+    return formatFiatAmount("0");
+  }
+
+  // A funded account on a network that prices tokens, yet nothing priced —
+  // the total exists but could not be read.
+  if (!hasPrices) {
+    return NO_FIAT_VALUE;
+  }
+
+  return formatFiatAmount(totalUsd ?? "0");
 };

--- a/src/helpers/formatAmount.ts
+++ b/src/helpers/formatAmount.ts
@@ -1,7 +1,6 @@
 import BigNumber from "bignumber.js";
 import { DEFAULT_DECIMALS, MIN_TRANSACTION_FEE } from "config/constants";
 import { Balance, PricedBalance } from "config/types";
-import { hasDecimals } from "helpers/balances";
 import { formatTokenForDisplay as formatSorobanTokenAmount } from "helpers/soroban";
 import { getNumberFormatSettings } from "react-native-localize";
 
@@ -258,6 +257,16 @@ export const formatFiatAmount = (amount: string | BigNumber) => {
 
   return `$${formattedAmount}`;
 };
+
+/**
+ * Stands in for a fiat value that could not be determined — an unpriced token,
+ * or a total that could not be read.
+ *
+ * Distinct from "$0.00", which asserts a known zero. Prefer that wherever the
+ * absence of value is a fact rather than a gap: an unfunded account, or a
+ * network that prices no tokens.
+ */
+export const NO_FIAT_VALUE = "--";
 
 /**
  * Formats a numeric value as a percentage with sign indicator
@@ -805,6 +814,32 @@ export const getPerOperationBaseFeeStroops = (
     xlmToStroop(totalFeeXlm).idiv(operationCount),
     xlmToStroop(MIN_TRANSACTION_FEE),
   ).toFixed(0);
+
+/**
+ * Checks if a balance carries an explicit `decimals` field — the marker for
+ * a Soroban / custom token, regardless of whether that value is zero. Classic
+ * Stellar balances don't have this field and rely on the protocol's fixed
+ * 7-decimal precision instead.
+ *
+ * Note: `decimals === 0` is a legitimate value for a custom token that uses
+ * integer-only units (no fractional part), and must still discriminate as
+ * "has decimals" so downstream logic doesn't fall back to the classic default.
+ *
+ * @param {Balance | PricedBalance} balance - The balance to check
+ * @returns {boolean} True when the balance has a non-negative `decimals` field
+ *
+ * @example
+ * if (hasDecimals(balance)) {
+ *   // Use decimal-aware formatting
+ *   const formatted = formatSorobanTokenAmount(amount, balance.decimals);
+ * }
+ */
+export const hasDecimals = (
+  balance: Balance | PricedBalance,
+): balance is Balance & { decimals: number } =>
+  "decimals" in balance &&
+  typeof balance.decimals === "number" &&
+  balance.decimals >= 0;
 
 /**
  * Formats a balance amount for display, handling custom tokens with decimals

--- a/src/hooks/useSyncAccountsFiatTotals.ts
+++ b/src/hooks/useSyncAccountsFiatTotals.ts
@@ -37,17 +37,21 @@ export const useSyncAccountsFiatTotals = ({
       return;
     }
 
+    const hasError = balancesError != null;
     // Right after an account (or network) switch, the balances snapshot
     // still belongs to the PREVIOUS account for a moment — syncing then
     // would write the old account's total under the new key. Only sync when
     // the snapshot provably matches: same account/network stamp and no
     // fetch in flight (the stamp is written with the raw balances, before
     // pricedBalances catches up).
-    if (
-      fetchedPublicKey !== publicKey ||
-      fetchedNetwork !== network ||
-      isLoadingBalances
-    ) {
+    const snapshotMatches =
+      fetchedPublicKey === publicKey && fetchedNetwork === network;
+
+    // A failed fetch is never stamped, so requiring the stamp would drop the
+    // error and leave this row on a confident "$0.00" while the Home header
+    // shows "--" for the same account. The failure label doesn't read the
+    // snapshot at all, so syncing it without that proof is safe.
+    if (isLoadingBalances || (!snapshotMatches && !hasError)) {
       return;
     }
 
@@ -56,7 +60,7 @@ export const useSyncAccountsFiatTotals = ({
       network,
       pricedBalances,
       isFunded,
-      hasError: balancesError != null,
+      hasError,
     });
   }, [
     publicKey,

--- a/src/hooks/useSyncAccountsFiatTotals.ts
+++ b/src/hooks/useSyncAccountsFiatTotals.ts
@@ -24,6 +24,10 @@ export const useSyncAccountsFiatTotals = ({
   const fetchedPublicKey = useBalancesStore((state) => state.fetchedPublicKey);
   const fetchedNetwork = useBalancesStore((state) => state.fetchedNetwork);
   const isLoadingBalances = useBalancesStore((state) => state.isLoading);
+  // Funded state and the fetch error decide between "$0.00" and "--" for the
+  // active account's row, the same way they do for the Home header.
+  const isFunded = useBalancesStore((state) => state.isFunded);
+  const balancesError = useBalancesStore((state) => state.error);
   const syncAccountFiatTotal = useAccountsFiatTotalsStore(
     (state) => state.syncAccountFiatTotal,
   );
@@ -47,7 +51,13 @@ export const useSyncAccountsFiatTotals = ({
       return;
     }
 
-    syncAccountFiatTotal({ publicKey, network, pricedBalances });
+    syncAccountFiatTotal({
+      publicKey,
+      network,
+      pricedBalances,
+      isFunded,
+      hasError: balancesError != null,
+    });
   }, [
     publicKey,
     network,
@@ -55,6 +65,8 @@ export const useSyncAccountsFiatTotals = ({
     fetchedPublicKey,
     fetchedNetwork,
     isLoadingBalances,
+    isFunded,
+    balancesError,
     syncAccountFiatTotal,
   ]);
 };

--- a/src/hooks/useTokenFiatConverter/index.ts
+++ b/src/hooks/useTokenFiatConverter/index.ts
@@ -1,8 +1,10 @@
 import BigNumber from "bignumber.js";
 import { CLASSIC_TOKEN_MAX_AMOUNT, DEFAULT_DECIMALS } from "config/constants";
 import { PricedBalance } from "config/types";
-import { hasDecimals } from "helpers/balances";
-import { formatBigNumberForDisplay } from "helpers/formatAmount";
+import {
+  formatBigNumberForDisplay,
+  hasDecimals,
+} from "helpers/formatAmount";
 import { recordUserActivity } from "helpers/userActivity";
 import {
   createTokenFiatConverterReducer,

--- a/src/hooks/useTotalBalance.ts
+++ b/src/hooks/useTotalBalance.ts
@@ -1,10 +1,21 @@
 import { BigNumber } from "bignumber.js";
+import { useAuthenticationStore } from "ducks/auth";
 import { useBalancesStore } from "ducks/balances";
+import { getTotalUsdLabel } from "helpers/balances";
 import { formatFiatAmount } from "helpers/formatAmount";
+import { isMainnet } from "helpers/networks";
 import { useMemo } from "react";
 
 interface TotalBalance {
   formattedBalance: string;
+  /**
+   * What the Home header should actually show: an amount, "$0.00" or "--".
+   * Unlike `formattedBalance` (a bare sum, which reads as a confident $0.00
+   * when prices are missing), this routes through {@link getTotalUsdLabel} —
+   * the same rule the wallets-list rows use, so the header and the active
+   * account's row always agree.
+   */
+  totalLabel: string;
   rawBalance: BigNumber;
   /**
    * Whether any held asset is actually priced. False on e.g. testnet (fiat
@@ -23,6 +34,9 @@ interface TotalBalance {
  */
 export const useTotalBalance = (): TotalBalance => {
   const pricedBalances = useBalancesStore((state) => state.pricedBalances);
+  const isFunded = useBalancesStore((state) => state.isFunded);
+  const balancesError = useBalancesStore((state) => state.error);
+  const network = useAuthenticationStore((state) => state.network);
 
   // Create a key that only changes when fiatTotal values change
   const fiatTotalsKey = Object.values(pricedBalances)
@@ -44,9 +58,16 @@ export const useTotalBalance = (): TotalBalance => {
 
     return {
       formattedBalance: formatFiatAmount(rawBalance),
+      totalLabel: getTotalUsdLabel({
+        hasError: balancesError != null,
+        hasPriceFeed: isMainnet(network),
+        isFunded,
+        hasPrices: hasFiatTotal,
+        totalUsd: rawBalance,
+      }),
       rawBalance,
       hasFiatTotal,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fiatTotalsKey]);
+  }, [fiatTotalsKey, isFunded, balancesError, network]);
 };

--- a/src/hooks/useTotalBalance.ts
+++ b/src/hooks/useTotalBalance.ts
@@ -2,18 +2,16 @@ import { BigNumber } from "bignumber.js";
 import { useAuthenticationStore } from "ducks/auth";
 import { useBalancesStore } from "ducks/balances";
 import { getTotalUsdLabel } from "helpers/balances";
-import { formatFiatAmount } from "helpers/formatAmount";
 import { isMainnet } from "helpers/networks";
 import { useMemo } from "react";
 
 interface TotalBalance {
-  formattedBalance: string;
   /**
    * What the Home header should actually show: an amount, "$0.00" or "--".
-   * Unlike `formattedBalance` (a bare sum, which reads as a confident $0.00
-   * when prices are missing), this routes through {@link getTotalUsdLabel} —
-   * the same rule the wallets-list rows use, so the header and the active
-   * account's row always agree.
+   * Routed through {@link getTotalUsdLabel} rather than formatting the bare
+   * sum, which reads as a confident $0.00 when prices are missing. Same rule
+   * the wallets-list rows use, so the header and the active account's row
+   * always agree.
    */
   totalLabel: string;
   rawBalance: BigNumber;
@@ -57,7 +55,6 @@ export const useTotalBalance = (): TotalBalance => {
     );
 
     return {
-      formattedBalance: formatFiatAmount(rawBalance),
       totalLabel: getTotalUsdLabel({
         hasError: balancesError != null,
         hasPriceFeed: isMainnet(network),


### PR DESCRIPTION
Ports the extension's `$0.00` vs `--` rule to mobile, so both clients say the same thing about an account's total USD value.

Follows the behavior agreed in stellar/freighter#2960 — see [this comment](https://github.com/stellar/freighter/pull/2960#issuecomment-5299485841) for the rule and the extension screenshots.

## The rule

One helper decides it: **`getTotalUsdLabel`** in [`src/helpers/balances.ts`](src/helpers/balances.ts), ported from the extension's helper of the same name (`NO_FIAT_VALUE` lives in [`helpers/formatAmount.ts`](src/helpers/formatAmount.ts), mirroring the extension's split).

| Case | Shows |
| --- | --- |
| Balances failed to load | `--` |
| Funded, priced network, but nothing priced | `--` |
| Network prices no tokens (testnet/futurenet) | `$0.00` |
| Unfunded account | `$0.00` |
| Anything else | the total — a genuine `$0.00` included |

`$0.00` asserts a known zero; `--` means the total couldn't be determined. Both the Home header and every wallets-list row call the same helper, so the two can't disagree.

Tests: new `getTotalUsdLabel` suite mirrors the extension's case-for-case, plus updated coverage for the wallets list and Home header.

## Screenshots

### Mainnet happy path (all priced)

<img width="1629" height="926" alt="Screenshot 2026-08-18 at 08 32 02" src="https://github.com/user-attachments/assets/c7346f2f-57e4-415b-8111-0fed155c525d" />

### Mainnet with prices erroring

<img width="1609" height="921" alt="Screenshot 2026-08-18 at 08 32 37" src="https://github.com/user-attachments/assets/bd67950b-a4e5-4b5d-9554-0c68e7f4eae2" />

### Mainnet for unfunded account

<img height="500" alt="Screenshot 2026-08-18 at 08 33 42" src="https://github.com/user-attachments/assets/aa27ff7f-9868-43f4-a71a-a5d664589943" />

### Testnet in all cases

Always the same UI regardless of prices erroring, since we use no prices there.

<img width="1622" height="922" alt="Screenshot 2026-08-18 at 08 33 07" src="https://github.com/user-attachments/assets/0d9f7cd7-f11e-49d8-a334-b7abd1dfcaf0" />
