### PR TITLE
feat(send): verify assembled collectible transfer matches intent before signing

### DIFF
--- a/__tests__/services/transactionService.test.ts
+++ b/__tests__/services/transactionService.test.ts
@@ -48,6 +48,11 @@ jest.mock("services/backend", () => ({
   checkContractSupportsMuxed: jest.fn().mockResolvedValue(false),
 }));
 
+// Prepared-transaction verification parses real XDR; these suites exercise
+// fee/plumbing behaviour with placeholder XDR, so stub it out here. The
+// verification itself is covered in verifyPreparedTransaction.test.ts.
+jest.mock("services/verifyPreparedTransaction");
+
 describe("buildSendCollectibleTransaction", () => {
   const mockSenderKeypair = Keypair.random();
   const mockRecipientKeypair = Keypair.random();

--- a/__tests__/services/verifyPreparedTransaction.test.ts
+++ b/__tests__/services/verifyPreparedTransaction.test.ts
@@ -103,6 +103,23 @@ const addressCredentialsAuth = () =>
     rootInvocation: rootTransferInvocation(),
   });
 
+// A source-account auth entry whose root invocation is an unrelated contract
+// call (a token transfer to the attacker) with no sub-invocations.
+const unrelatedRootAuth = () =>
+  new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
+    rootInvocation: authorizedInvocation(SAC, "transfer", [
+      new Address(SOURCE).toScVal(),
+      new Address(ATTACKER).toScVal(),
+      xdr.ScVal.scvI128(
+        new xdr.Int128Parts({
+          hi: xdr.Int64.fromString("0"),
+          lo: xdr.Uint64.fromString("99884944477"),
+        }),
+      ),
+    ]),
+  });
+
 // Rebuild the transaction the way an assembling backend does: reuse the invoked
 // host function verbatim (or tamper with it), set a fee, and attach auth entries.
 const buildPreparedXdr = (
@@ -111,7 +128,8 @@ const buildPreparedXdr = (
   {
     tamperFunc = false,
     fee = BASE_FEE,
-  }: { tamperFunc?: boolean; fee?: string } = {},
+    opSource,
+  }: { tamperFunc?: boolean; fee?: string; opSource?: string } = {},
 ): string => {
   const built = TransactionBuilder.fromXDR(builtXdr, NETWORK) as Transaction;
   const builtOp = built.operations[0];
@@ -130,7 +148,9 @@ const buildPreparedXdr = (
     : builtOp.func;
 
   return newBuilder(fee)
-    .addOperation(Operation.invokeHostFunction({ func, auth }))
+    .addOperation(
+      Operation.invokeHostFunction({ func, auth, source: opSource }),
+    )
     .setTimeout(0)
     .build()
     .toXDR();
@@ -212,5 +232,32 @@ describe("verifyFlatTransferPreparedTransaction", () => {
     const preparedXdr = buildPreparedXdr(builtXdr, [addressCredentialsAuth()]);
 
     expect(() => verify(builtXdr, preparedXdr)).toThrow(/source-account/);
+  });
+
+  it("rejects a source-account auth entry whose root is an unrelated call", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, [unrelatedRootAuth()]);
+
+    expect(() => verify(builtXdr, preparedXdr)).toThrow(/authorization root/);
+  });
+
+  it("rejects a changed operation source", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, [sourceAccountAuth([])], {
+      opSource: ATTACKER,
+    });
+
+    expect(() => verify(builtXdr, preparedXdr)).toThrow(/operation source/);
+  });
+
+  it("rejects a non-finite simulated resource fee (fee ceiling cannot fail open)", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, [sourceAccountAuth([])], {
+      fee: "100000000",
+    });
+
+    expect(() => verify(builtXdr, preparedXdr, "Infinity")).toThrow(
+      /resource fee/,
+    );
   });
 });

--- a/__tests__/services/verifyPreparedTransaction.test.ts
+++ b/__tests__/services/verifyPreparedTransaction.test.ts
@@ -1,0 +1,216 @@
+import {
+  Account,
+  Address,
+  BASE_FEE,
+  Contract,
+  Networks,
+  Operation,
+  StrKey,
+  Transaction,
+  TransactionBuilder,
+  TimeoutInfinite,
+  xdr,
+} from "@stellar/stellar-sdk";
+import {
+  verifyFlatTransferPreparedTransaction,
+  PreparedTransactionMismatchError,
+} from "services/verifyPreparedTransaction";
+
+const NETWORK = Networks.TESTNET;
+
+const SOURCE = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 3));
+const DESTINATION = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 2));
+const ATTACKER = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 9));
+const COLLECTION = StrKey.encodeContract(Buffer.alloc(32, 1));
+const SAC = StrKey.encodeContract(Buffer.alloc(32, 7));
+const TOKEN_ID = 1;
+
+const newBuilder = (fee = BASE_FEE) =>
+  new TransactionBuilder(new Account(SOURCE, "0"), {
+    fee,
+    networkPassphrase: NETWORK,
+  });
+
+// A flat collectible transfer built with no authorization entries.
+const buildFlatTransferXdr = (): string => {
+  const params = [
+    new Address(SOURCE).toScVal(),
+    new Address(DESTINATION).toScVal(),
+    xdr.ScVal.scvU32(TOKEN_ID),
+  ];
+  return newBuilder()
+    .addOperation(new Contract(COLLECTION).call("transfer", ...params))
+    .setTimeout(TimeoutInfinite)
+    .build()
+    .toXDR();
+};
+
+const invokeContractArgs = (
+  contractId: string,
+  fn: string,
+  args: xdr.ScVal[],
+) =>
+  new xdr.InvokeContractArgs({
+    contractAddress: new Address(contractId).toScAddress(),
+    functionName: fn,
+    args,
+  });
+
+const authorizedInvocation = (
+  contractId: string,
+  fn: string,
+  args: xdr.ScVal[],
+  subInvocations: xdr.SorobanAuthorizedInvocation[] = [],
+) =>
+  new xdr.SorobanAuthorizedInvocation({
+    function:
+      xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        invokeContractArgs(contractId, fn, args),
+      ),
+    subInvocations,
+  });
+
+const rootTransferInvocation = (
+  subInvocations: xdr.SorobanAuthorizedInvocation[] = [],
+) =>
+  authorizedInvocation(
+    COLLECTION,
+    "transfer",
+    [
+      new Address(SOURCE).toScVal(),
+      new Address(DESTINATION).toScVal(),
+      xdr.ScVal.scvU32(TOKEN_ID),
+    ],
+    subInvocations,
+  );
+
+const sourceAccountAuth = (subInvocations: xdr.SorobanAuthorizedInvocation[]) =>
+  new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
+    rootInvocation: rootTransferInvocation(subInvocations),
+  });
+
+const addressCredentialsAuth = () =>
+  new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
+      new xdr.SorobanAddressCredentials({
+        address: new Address(ATTACKER).toScAddress(),
+        nonce: xdr.Int64.fromString("0"),
+        signatureExpirationLedger: 0,
+        signature: xdr.ScVal.scvVoid(),
+      }),
+    ),
+    rootInvocation: rootTransferInvocation(),
+  });
+
+// Rebuild the transaction the way an assembling backend does: reuse the invoked
+// host function verbatim (or tamper with it), set a fee, and attach auth entries.
+const buildPreparedXdr = (
+  builtXdr: string,
+  auth: xdr.SorobanAuthorizationEntry[],
+  {
+    tamperFunc = false,
+    fee = BASE_FEE,
+  }: { tamperFunc?: boolean; fee?: string } = {},
+): string => {
+  const built = TransactionBuilder.fromXDR(builtXdr, NETWORK) as Transaction;
+  const builtOp = built.operations[0];
+  if (builtOp.type !== "invokeHostFunction") {
+    throw new Error("test setup: expected invokeHostFunction");
+  }
+
+  const func = tamperFunc
+    ? xdr.HostFunction.hostFunctionTypeInvokeContract(
+        invokeContractArgs(COLLECTION, "transfer", [
+          new Address(SOURCE).toScVal(),
+          new Address(ATTACKER).toScVal(),
+          xdr.ScVal.scvU32(TOKEN_ID),
+        ]),
+      )
+    : builtOp.func;
+
+  return newBuilder(fee)
+    .addOperation(Operation.invokeHostFunction({ func, auth }))
+    .setTimeout(0)
+    .build()
+    .toXDR();
+};
+
+const verify = (builtXdr: string, preparedXdr: string, maxResourceFee = "0") =>
+  verifyFlatTransferPreparedTransaction({
+    builtTransactionXdr: builtXdr,
+    preparedTransactionXdr: preparedXdr,
+    networkPassphrase: NETWORK,
+    maxResourceFee,
+  });
+
+describe("verifyFlatTransferPreparedTransaction", () => {
+  it("accepts an honest flat transfer (source-account auth, no sub-invocations)", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, [sourceAccountAuth([])]);
+
+    expect(() => verify(builtXdr, preparedXdr)).not.toThrow();
+  });
+
+  it("accepts a transfer with no auth entries at all", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, []);
+
+    expect(() => verify(builtXdr, preparedXdr)).not.toThrow();
+  });
+
+  it("accepts a fee raised by up to the simulated resource fee", () => {
+    const builtXdr = buildFlatTransferXdr(); // fee = BASE_FEE (100)
+    const preparedXdr = buildPreparedXdr(builtXdr, [sourceAccountAuth([])], {
+      fee: "600",
+    });
+
+    expect(() => verify(builtXdr, preparedXdr, "500")).not.toThrow();
+  });
+
+  it("rejects sub-invocations injected under the source-account entry", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const drain = authorizedInvocation(SAC, "transfer", [
+      new Address(SOURCE).toScVal(),
+      new Address(ATTACKER).toScVal(),
+      xdr.ScVal.scvI128(
+        new xdr.Int128Parts({
+          hi: xdr.Int64.fromString("0"),
+          lo: xdr.Uint64.fromString("99884944477"),
+        }),
+      ),
+    ]);
+    const preparedXdr = buildPreparedXdr(builtXdr, [
+      sourceAccountAuth([drain]),
+    ]);
+
+    expect(() => verify(builtXdr, preparedXdr)).toThrow(
+      PreparedTransactionMismatchError,
+    );
+  });
+
+  it("rejects a tampered invoked host function (different arguments)", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, [sourceAccountAuth([])], {
+      tamperFunc: true,
+    });
+
+    expect(() => verify(builtXdr, preparedXdr)).toThrow(/host function/);
+  });
+
+  it("rejects a fee larger than the built fee plus the simulated resource fee", () => {
+    const builtXdr = buildFlatTransferXdr(); // fee = BASE_FEE (100)
+    const preparedXdr = buildPreparedXdr(builtXdr, [sourceAccountAuth([])], {
+      fee: "100000000",
+    });
+
+    expect(() => verify(builtXdr, preparedXdr, "500")).toThrow(/fee/);
+  });
+
+  it("rejects non-source-account (address) credentials", () => {
+    const builtXdr = buildFlatTransferXdr();
+    const preparedXdr = buildPreparedXdr(builtXdr, [addressCredentialsAuth()]);
+
+    expect(() => verify(builtXdr, preparedXdr)).toThrow(/source-account/);
+  });
+});

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -42,6 +42,7 @@ import { analytics } from "services/analytics";
 import { SimulationTransactionType } from "services/analytics/types";
 import { simulateTokenTransfer, simulateTransaction } from "services/backend";
 import { buildChangeTrustOperation, stellarSdkServer } from "services/stellar";
+import { verifyFlatTransferPreparedTransaction } from "services/verifyPreparedTransaction";
 
 export interface BuildPaymentTransactionParams {
   tokenAmount: string;
@@ -850,6 +851,18 @@ export const simulateCollectibleTransfer = async ({
       xdr: transactionXdr,
       network_url: networkDetails.sorobanRpcUrl,
       network_passphrase: networkDetails.networkPassphrase,
+    });
+
+    // The backend derives this transaction's authorization entries, fee, and
+    // resource data from simulating the target contract, not from what the
+    // wallet built. Confirm the assembled transaction still matches the flat
+    // transfer we intended before it can be signed, so no additional
+    // authorization or fee can ride along on the user's source-account signature.
+    verifyFlatTransferPreparedTransaction({
+      builtTransactionXdr: transactionXdr,
+      preparedTransactionXdr: result.preparedTransaction,
+      networkPassphrase: networkDetails.networkPassphrase,
+      maxResourceFee: result.simulationResponse?.minResourceFee ?? "0",
     });
 
     return {

--- a/src/services/verifyPreparedTransaction.ts
+++ b/src/services/verifyPreparedTransaction.ts
@@ -106,6 +106,16 @@ export const verifyFlatTransferPreparedTransaction = ({
     );
   }
 
+  // The operation source determines the source-account credential identity, so it
+  // is part of the wallet's intent and must not be changed during assembly. The
+  // wallet builds the operation with no explicit source (it inherits the tx
+  // source), so both must be undefined here.
+  if (builtOp.source !== preparedOp.source) {
+    throw new PreparedTransactionMismatchError(
+      "operation source does not match the transaction the wallet built",
+    );
+  }
+
   // Every other envelope field must be identical to what the wallet built. Only
   // fee, sorobanData (ext), and the operation's auth are allowed to change during
   // assembly, and those are checked separately below.
@@ -130,16 +140,30 @@ export const verifyFlatTransferPreparedTransaction = ({
 
   // The fee may only be raised by the simulated resource fee that the user was
   // shown. A larger fee means the signed envelope authorizes spending more than
-  // the review screen displayed.
-  const maxFee = new BigNumber(built.fee).plus(maxResourceFee || "0");
+  // the review screen displayed. Validate the resource fee first: a non-finite
+  // or negative value would otherwise make the ceiling non-finite and pass any
+  // fee.
+  const resourceFee = new BigNumber(maxResourceFee || "0");
+  if (
+    !resourceFee.isFinite() ||
+    !resourceFee.isInteger() ||
+    resourceFee.isNegative()
+  ) {
+    throw new PreparedTransactionMismatchError(
+      "simulated resource fee is not a valid non-negative integer",
+    );
+  }
+  const maxFee = new BigNumber(built.fee).plus(resourceFee);
   if (new BigNumber(prepared.fee).isGreaterThan(maxFee)) {
     throw new PreparedTransactionMismatchError(
       "fee exceeds the built fee plus the simulated resource fee",
     );
   }
 
-  // Every auth entry must be covered by the plain source-account signature and
-  // must not authorize anything beneath the root invocation.
+  // Every auth entry must be covered by the plain source-account signature, must
+  // authorize exactly the transfer we invoked (not some other contract call), and
+  // must not authorize anything beneath that root invocation.
+  const intendedCall = builtOp.func.invokeContract().toXDR("base64");
   const auths = preparedOp.auth || [];
   auths.forEach((auth) => {
     if (
@@ -148,6 +172,21 @@ export const verifyFlatTransferPreparedTransaction = ({
     ) {
       throw new PreparedTransactionMismatchError(
         "authorization entry is not source-account credentials",
+      );
+    }
+
+    const rootFunction = auth.rootInvocation().function();
+    if (
+      rootFunction.switch() !==
+      xdr.SorobanAuthorizedFunctionType.sorobanAuthorizedFunctionTypeContractFn()
+    ) {
+      throw new PreparedTransactionMismatchError(
+        "authorization root is not a contract-function call",
+      );
+    }
+    if (rootFunction.contractFn().toXDR("base64") !== intendedCall) {
+      throw new PreparedTransactionMismatchError(
+        "authorization root does not match the invoked transfer",
       );
     }
 

--- a/src/services/verifyPreparedTransaction.ts
+++ b/src/services/verifyPreparedTransaction.ts
@@ -1,0 +1,160 @@
+import { Transaction, TransactionBuilder, xdr } from "@stellar/stellar-sdk";
+import { BigNumber } from "bignumber.js";
+
+/**
+ * Thrown when an assembled transaction does not match the transaction the wallet
+ * built. Callers must treat this as "do not sign".
+ */
+export class PreparedTransactionMismatchError extends Error {
+  constructor(reason: string) {
+    super(`Prepared transaction failed verification: ${reason}`);
+    this.name = "PreparedTransactionMismatchError";
+  }
+}
+
+const parsePlainTransaction = (
+  transactionXdr: string,
+  networkPassphrase: string,
+  label: string,
+): Transaction => {
+  const tx = TransactionBuilder.fromXDR(transactionXdr, networkPassphrase);
+  if (!(tx instanceof Transaction)) {
+    throw new PreparedTransactionMismatchError(
+      `${label} is a fee-bump, not a plain transaction`,
+    );
+  }
+  return tx;
+};
+
+const requireInvokeHostFunctionOp = (tx: Transaction) => {
+  if (tx.operations.length !== 1) {
+    throw new PreparedTransactionMismatchError(
+      `expected exactly 1 operation, got ${tx.operations.length}`,
+    );
+  }
+  const op = tx.operations[0];
+  if (op.type !== "invokeHostFunction") {
+    throw new PreparedTransactionMismatchError(
+      "operation is not invokeHostFunction",
+    );
+  }
+  return op;
+};
+
+// Decode a transaction to its XDR body so individual fields can be compared
+// without depending on SDK accessor shapes.
+const txBody = (transactionXdr: string): xdr.Transaction =>
+  xdr.TransactionEnvelope.fromXDR(transactionXdr, "base64").v1().tx();
+
+/**
+ * Verify that a backend-assembled `preparedTransactionXdr` still matches the flat
+ * Soroban transfer the wallet built, before it is signed.
+ *
+ * When the wallet builds a transfer with no authorization entries and delegates
+ * simulation and assembly to a backend, the authorization entries, resource fee,
+ * and Soroban resource data are derived from simulating the target contract
+ * rather than constructed by the wallet. The wallet is the only party that knows
+ * the intended call, so it must confirm the assembled transaction still matches
+ * that intent before signing.
+ *
+ * Assembly is only allowed to change three things: the transaction `fee` (raising
+ * it by at most the simulated resource fee), the Soroban resource data
+ * (`ext` / sorobanData), and the operation's authorization entries. Everything
+ * else must be identical to what the wallet built. Concretely we refuse to sign
+ * when:
+ *  - the operation set is not the single invokeHostFunction we built, or its host
+ *    function (contract, function, args) is not byte-identical, or
+ *  - any other envelope field (source, sequence, memo, preconditions) differs, or
+ *  - the fee exceeds the built fee plus the simulated resource fee, or
+ *  - any auth entry is not source-account credentials, or authorizes
+ *    sub-invocations below the root.
+ *
+ * A flat transfer never legitimately needs sub-invocations. Flows that do (e.g.
+ * swaps) must not use this helper — they need effect-bounded verification.
+ */
+export const verifyFlatTransferPreparedTransaction = ({
+  builtTransactionXdr,
+  preparedTransactionXdr,
+  networkPassphrase,
+  maxResourceFee,
+}: {
+  builtTransactionXdr: string;
+  preparedTransactionXdr: string;
+  networkPassphrase: string;
+  // The resource fee reported by simulation and shown to the user, in stroops.
+  maxResourceFee: string;
+}): void => {
+  const built = parsePlainTransaction(
+    builtTransactionXdr,
+    networkPassphrase,
+    "built transaction",
+  );
+  const prepared = parsePlainTransaction(
+    preparedTransactionXdr,
+    networkPassphrase,
+    "prepared transaction",
+  );
+
+  const builtOp = requireInvokeHostFunctionOp(built);
+  const preparedOp = requireInvokeHostFunctionOp(prepared);
+
+  // The invoked host function — contract, function name, and arguments — must be
+  // exactly what the wallet constructed.
+  if (builtOp.func.toXDR("base64") !== preparedOp.func.toXDR("base64")) {
+    throw new PreparedTransactionMismatchError(
+      "invoked host function does not match the transaction the wallet built",
+    );
+  }
+
+  // Every other envelope field must be identical to what the wallet built. Only
+  // fee, sorobanData (ext), and the operation's auth are allowed to change during
+  // assembly, and those are checked separately below.
+  const builtBody = txBody(builtTransactionXdr);
+  const preparedBody = txBody(preparedTransactionXdr);
+  const envelopeFields: [
+    string,
+    (tx: xdr.Transaction) => { toXDR(format: "base64"): string },
+  ][] = [
+    ["source account", (tx) => tx.sourceAccount()],
+    ["sequence number", (tx) => tx.seqNum()],
+    ["memo", (tx) => tx.memo()],
+    ["preconditions", (tx) => tx.cond()],
+  ];
+  envelopeFields.forEach(([label, get]) => {
+    if (get(builtBody).toXDR("base64") !== get(preparedBody).toXDR("base64")) {
+      throw new PreparedTransactionMismatchError(
+        `${label} does not match the transaction the wallet built`,
+      );
+    }
+  });
+
+  // The fee may only be raised by the simulated resource fee that the user was
+  // shown. A larger fee means the signed envelope authorizes spending more than
+  // the review screen displayed.
+  const maxFee = new BigNumber(built.fee).plus(maxResourceFee || "0");
+  if (new BigNumber(prepared.fee).isGreaterThan(maxFee)) {
+    throw new PreparedTransactionMismatchError(
+      "fee exceeds the built fee plus the simulated resource fee",
+    );
+  }
+
+  // Every auth entry must be covered by the plain source-account signature and
+  // must not authorize anything beneath the root invocation.
+  const auths = preparedOp.auth || [];
+  auths.forEach((auth) => {
+    if (
+      auth.credentials().switch() !==
+      xdr.SorobanCredentialsType.sorobanCredentialsSourceAccount()
+    ) {
+      throw new PreparedTransactionMismatchError(
+        "authorization entry is not source-account credentials",
+      );
+    }
+
+    if (auth.rootInvocation().subInvocations().length > 0) {
+      throw new PreparedTransactionMismatchError(
+        "authorization entry authorizes sub-invocations",
+      );
+    }
+  });
+};


### PR DESCRIPTION
### What

- Add `verifyFlatTransferPreparedTransaction` that verifies the assembled transaction:
  - has exactly one `invokeHostFunction` operation whose host function is byte-identical to the one the wallet built,
  - has every other envelope field (source, sequence, memo, preconditions) unchanged,
  - does not raise the fee beyond the simulated resource fee shown to the user,
  - and has authorization entries that all use source-account credentials with no sub-invocations.

### Why

The collectible send flow builds a Soroban transfer with no authorization entries and delegates simulation and assembly to the backend. The authorization entries, fee, and Soroban resource data on the returned transaction are therefore derived from simulating the target contract, not built by the wallet.

The wallet is the only party that knows the call it intended, so it should confirm the assembled transaction still matches that intent before signing, rather than adopting the returned bytes verbatim.

### Known limitations

To fix this we can't just copy paste auth-entry guard onto /simulate-tx in the freighter-backend, due to Soroswap flow, which also calls this endpoint and legitimately produces sub-invocations.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
