### PR TITLE
fix(walletkit): let the dApp request payload scroll on Android

### DIFF
--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1247,11 +1247,19 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         }
       />
 
-      {/* Bottom sheet for dApp transaction requests */}
+      {/* Bottom sheet for dApp transaction requests.
+
+          sign_message and sign_auth_entry render the payload in a capped,
+          inner-scrolling box. The sheet wraps its content in a pan gesture and
+          on Android that pan cancels the nested ScrollView's scroll, so
+          dragging the payload moves the whole sheet instead of scrolling the
+          text. Disabling the content pan for those requests leaves the drag
+          handle (and the Cancel button) to dismiss the sheet. */}
       <BottomSheet
         modalRef={dappRequestBottomSheetModalRef}
         handleCloseModal={handleClearDappRequest}
         analyticsEvent={AnalyticsEvent.VIEW_SIGN_DAPP_TRANSACTION}
+        enableContentPanningGesture={!isNonTransactionRequest}
         bottomSheetModalProps={{
           onDismiss: handleClearDappRequest,
           enableDynamicSizing: true,


### PR DESCRIPTION
## TL;DR

**Android only.** When a dApp asks us to sign a long message (or a long auth entry), the payload box is supposed to scroll on its own so the user can read the whole thing. On Android it didn't: dragging the payload dragged the entire bottom sheet down instead of scrolling the text, so anything past the first few lines was unreadable. iOS was never affected.

The sheet wraps its content in a drag-to-dismiss gesture that, on Android, wins over any scrollable nested inside it. This turns that content-drag gesture off for the two request types that render a scrollable payload — sign message and sign auth entry — so the payload scrolls. The sheet can still be dismissed by dragging the handle, tapping the backdrop, or hitting Cancel. Transaction requests have no scrollable payload and keep drag-to-dismiss anywhere on the sheet.

### Before fix

https://github.com/user-attachments/assets/ebe4814c-e28f-49b1-8973-156bf3e433fc

### After fix

https://github.com/user-attachments/assets/505f7505-9202-48be-8a67-11718197ec37

<img width="350" alt="Screenshot 2026-08-19 at 17 25 16" src="https://github.com/user-attachments/assets/7f538b66-733d-4095-8573-b419c524c432" />

#### iOS still works

https://github.com/user-attachments/assets/e6a7ec4f-2564-4f0d-90bc-c2036bccef53

### Known limitations

On the sign message and sign auth entry sheets you can no longer swipe the sheet body to dismiss — the drag handle at the top is the swipe target (backdrop tap and the Cancel button are unchanged). Other request types are untouched.

<details>
<summary>Implementation details (for agents)</summary>

**What changed:** one prop, in one place.

https://github.com/stellar/freighter-mobile/blob/a8758eaf91f1b42dc8baafe29df2070db4572bb6/src/providers/WalletKitProvider.tsx#L1250-L1263

`isNonTransactionRequest` is already exactly `sign_message || sign_auth_entry`, which is precisely the set of request types whose content renders a capped, inner-scrolling `ScrollView`:

https://github.com/stellar/freighter-mobile/blob/a8758eaf91f1b42dc8baafe29df2070db4572bb6/src/components/screens/WalletKit/DappMessageDisplay.tsx#L73-L84

https://github.com/stellar/freighter-mobile/blob/a8758eaf91f1b42dc8baafe29df2070db4572bb6/src/components/screens/WalletKit/DappSignAuthEntryBottomSheetContent.tsx#L147-L161

**Root cause:** those are plain `react-native` `ScrollView`s inside a sheet rendered in `BottomSheetView` mode. `@gorhom/bottom-sheet` wraps all sheet content in a `Gesture.Pan()` (`BottomSheetDraggableView.tsx`, `.enabled(enableContentPanningGesture)`). The library's own scrollables opt into that pan via `Gesture.Native().simultaneousWithExternalGesture(draggableGesture)` **plus** scroll-offset tracking (`createBottomSheetScrollableComponent` / `useScrollableSetter`), so the sheet only drags once the scrollable is at the top. A plain `ScrollView` does neither — the sheet has no idea it exists.

On Android, RNGH's `GestureHandlerOrchestrator.makeActive` cancels the nested native scroll as soon as the ancestor pan activates, which is the reported symptom. On iOS, UIKit recognizer arbitration lets the inner `UIScrollView` win, so it worked there. The library ships a platform-specific `ScrollableContainer.android.tsx` for exactly this asymmetry.

**Why this fix works deterministically:** with `enableContentPanningGesture={false}` gorhom builds the gesture as `Gesture.Pan().enabled(false)`, so the handler never activates and the orchestrator never reaches `makeActive` — nothing competes with the native scroll. The drag handle has its own separate `Gesture.Pan()` in `BottomSheetHandleContainer`, gated by `enableHandlePanningGesture`, which this PR does not touch — so handle drag-to-dismiss is unaffected.

**Two alternatives considered and rejected:**

1. *Swap in `BottomSheetScrollView`.* Unsafe here: it writes its content height into the sheet's `animatedLayoutState.contentHeight` (`useBottomSheetContentSizeSetter`), which the parent `BottomSheetView` also writes. With `enableDynamicSizing: true` the two fight and mis-size the sheet; it also clobbers `animatedScrollableState.type`.
2. *`disallowInterruption` on the inner scroll alone.* `NativeViewGestureHandler.shouldBeCancelledBy` returns `!disallowInterruption`, so the scroll survives — but the pan still activates, and the sheet and the text would both move. Blocking the pan requires the `waitFor` (`requireExternalGestureToFail`) relation, which would mean plumbing a gesture ref from this provider down three component levels.

**Verification:** `yarn lint:ts`, eslint and prettier clean; full Jest suite green via the pre-commit hook (2970 passed, 222 suites). The Android gesture behavior itself is manual-only — Jest can't exercise RNGH's native arbitration — hence the before/after videos above. No regression test was added: the only meaningful assertion is a prop check that would require mocking this 1349-line provider and its ~20 hooks.

**Follow-up / out of scope:** `DappAuthEntryDisplay`'s raw-XDR fallback `ScrollView` is nested inside `DappAuthEntryDetailsBottomSheet`'s `BottomSheetScrollView`, where the competing gesture is the outer scrollable's native gesture rather than the content pan — so this fix does not apply to it. It's only reachable when XDR parsing fails.

https://github.com/stellar/freighter-mobile/blob/a8758eaf91f1b42dc8baafe29df2070db4572bb6/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx#L296-L305

</details>