### PR TITLE
feat(swap): default the You receive token to USDC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     activesupport (7.2.3)
       base64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.8)
+    CFPropertyList (3.0.9)
     abbrev (0.1.2)
     activesupport (7.2.3)
       base64

--- a/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
+++ b/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
@@ -368,6 +368,113 @@ describe("SwapAmountScreen", () => {
     expect(mockSetDestinationToken).toHaveBeenCalledWith(null);
   });
 
+  describe("default destination (USDC) seeding", () => {
+    // The auth store defaults to PUBLIC in tests, so the seeded default is
+    // mainnet USDC (Circle issuer).
+    const MAINNET_USDC_ID =
+      "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+    it("seeds USDC as the destination when none is set", () => {
+      setSwapStoreState({ destinationToken: null });
+
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: MAINNET_USDC_ID,
+          tokenCode: "USDC",
+          // The fixture balances hold a different USDC issuer, so the
+          // default is unheld and needs a trustline.
+          requiresTrustline: true,
+        }),
+      );
+    });
+
+    it("seeds native XLM instead when the swap starts from the default USDC", () => {
+      setSwapStoreState({ destinationToken: null });
+      const route = {
+        key: "swap-amount",
+        name: SWAP_ROUTES.SWAP_AMOUNT_SCREEN,
+        params: { tokenId: MAINNET_USDC_ID, tokenSymbol: "USDC" },
+      } as unknown as Props["route"];
+
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={route} />,
+      );
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "XLM",
+          tokenCode: "XLM",
+          requiresTrustline: false,
+        }),
+      );
+    });
+
+    it("derives requiresTrustline=false when the account already holds the default", () => {
+      setSwapStoreState({ destinationToken: null });
+      (useBalancesList as jest.Mock).mockImplementation(() => ({
+        balanceItems: [
+          ...mockBalances,
+          { ...mockBalances[1], id: MAINNET_USDC_ID },
+        ],
+        scanResults: {},
+        isLoading: false,
+        error: null,
+        noBalances: false,
+        isRefreshing: false,
+        isFunded: true,
+        handleRefresh: jest.fn(),
+      }));
+
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: MAINNET_USDC_ID,
+          requiresTrustline: false,
+        }),
+      );
+    });
+
+    it("does not seed while balances have not hydrated", () => {
+      setSwapStoreState({ destinationToken: null });
+      (useBalancesList as jest.Mock).mockImplementation(() => ({
+        balanceItems: [],
+        scanResults: {},
+        isLoading: true,
+        error: null,
+        noBalances: false,
+        isRefreshing: false,
+        isFunded: true,
+        handleRefresh: jest.fn(),
+      }));
+
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).not.toHaveBeenCalledWith(
+        expect.objectContaining({ tokenCode: "USDC" }),
+      );
+    });
+
+    it("does not override an existing destination", () => {
+      // Default store state carries a picked FTT destination.
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).not.toHaveBeenCalledWith(
+        expect.objectContaining({ tokenCode: "USDC" }),
+      );
+    });
+  });
+
   it("renders security warnings for malicious states", () => {
     mockBalancesListReturn({
       "USDC-GBDQOFC6SKCNBHPLZ7NXQ6MCKFIYUUFVOWYGNWQCXC2F4AYZ27EUWYWH": {

--- a/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
+++ b/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
@@ -164,10 +164,14 @@ jest.mock("ducks/swap", () => ({
 }));
 
 const setSwapStoreState = (patch: Partial<SwapStoreState>): void => {
-  (useSwapStore as unknown as jest.Mock).mockImplementation(() => ({
-    ...makeDefaultSwapState(),
-    ...patch,
-  }));
+  const state = { ...makeDefaultSwapState(), ...patch };
+  const mock = useSwapStore as unknown as jest.Mock & {
+    getState: () => SwapStoreState;
+  };
+  mock.mockImplementation(() => state);
+  // The scan-stamping callback reads the destination synchronously via
+  // useSwapStore.getState(), so mirror the hook-call state there too.
+  mock.getState = () => state;
 };
 
 jest.mock("ducks/transactionBuilder", () => ({
@@ -583,16 +587,15 @@ describe("SwapAmountScreen", () => {
           }),
       );
 
-      const { rerender } = renderWithProviders(
+      renderWithProviders(
         <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
       );
 
       // The user picks FTT (the default swap-store fixture) before the scan
-      // resolves.
+      // resolves. The picker writes to the store synchronously; deliberately
+      // no rerender here, so the hook's render state still lags the store —
+      // the callback must read the store, not render state, to see the pick.
       setSwapStoreState({});
-      rerender(
-        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
-      );
 
       await act(async () => {
         resolveScan({ result_type: "Benign" });
@@ -619,9 +622,10 @@ describe("SwapAmountScreen", () => {
       );
 
       // The store applies the seeded descriptor, then the user leaves the
-      // screen before the scan resolves. Unmount runs resetSwap, so a late
-      // write here would repopulate the reset store and break the next
-      // visit's seeding.
+      // screen before the scan resolves. Unmount runs resetSwap, which
+      // nulls the store destination (simulated below, since the mocked
+      // store doesn't mutate) — a late write would repopulate the reset
+      // store and break the next visit's seeding.
       const seededDescriptor = mockSetDestinationToken.mock.calls.at(
         -1,
       )?.[0] as Record<string, unknown>;
@@ -635,6 +639,8 @@ describe("SwapAmountScreen", () => {
       act(() => {
         unmount();
       });
+      expect(mockResetSwap).toHaveBeenCalled();
+      setSwapStoreState({ destinationToken: null });
 
       await act(async () => {
         resolveScan({ result_type: "Benign" });

--- a/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
+++ b/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
@@ -212,6 +212,14 @@ jest.mock("components/screens/SwapScreen/hooks/useSwapTransaction", () => ({
 }));
 jest.mock("hooks/useBalancesList");
 
+// Single-token scan used to stamp the seeded default destination with a real
+// securityLevel. Controllable per-test; defaults to Benign in beforeEach.
+const mockScanToken = jest.fn();
+jest.mock("services/blockaid/api", () => ({
+  ...jest.requireActual("services/blockaid/api"),
+  scanToken: (...args: unknown[]) => mockScanToken(...args),
+}));
+
 // The default-destination seeding effect reads the raw balances map and its
 // fetched stamps straight from the balances store (useBalancesList is mocked
 // above and doesn't carry them). Tests drive them through these holders; the
@@ -383,6 +391,8 @@ describe("SwapAmountScreen", () => {
     setSwapStoreState({});
     mockBalancesListReturn();
     hydrateBalancesStore();
+    mockScanToken.mockReset();
+    mockScanToken.mockResolvedValue({ result_type: "Benign" });
   });
 
   it("initializes source token from route params", () => {
@@ -514,6 +524,140 @@ describe("SwapAmountScreen", () => {
           requiresTrustline: true,
         }),
       );
+    });
+
+    it("kicks off a token scan for a non-held seeded default and stamps the result", async () => {
+      setSwapStoreState({ destinationToken: null });
+      let resolveScan!: (value: unknown) => void;
+      mockScanToken.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveScan = resolve;
+          }),
+      );
+
+      const { rerender } = renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockScanToken).toHaveBeenCalledWith({
+        tokenCode: "USDC",
+        tokenIssuer: MAINNET_USDC_ID.split(":")[1],
+        network: NETWORKS.PUBLIC,
+      });
+
+      // Simulate the store applying the seeded descriptor, so the scan
+      // callback sees the still-untouched default as the current selection.
+      const seededDescriptor = mockSetDestinationToken.mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>;
+      setSwapStoreState({
+        destinationToken:
+          seededDescriptor as SwapStoreState["destinationToken"],
+      });
+      rerender(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      await act(async () => {
+        resolveScan({ result_type: "Benign" });
+        await Promise.resolve();
+      });
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: MAINNET_USDC_ID,
+          securityLevel: "SAFE",
+          securityWarnings: [],
+        }),
+      );
+    });
+
+    it("does not stamp the scan result when the user picked another token meanwhile", async () => {
+      setSwapStoreState({ destinationToken: null });
+      let resolveScan!: (value: unknown) => void;
+      mockScanToken.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveScan = resolve;
+          }),
+      );
+
+      const { rerender } = renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      // The user picks FTT (the default swap-store fixture) before the scan
+      // resolves.
+      setSwapStoreState({});
+      rerender(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      await act(async () => {
+        resolveScan({ result_type: "Benign" });
+        await Promise.resolve();
+      });
+
+      expect(mockSetDestinationToken).not.toHaveBeenCalledWith(
+        expect.objectContaining({ securityLevel: expect.anything() }),
+      );
+    });
+
+    it("does not write the scan result into the store after unmount", async () => {
+      setSwapStoreState({ destinationToken: null });
+      let resolveScan!: (value: unknown) => void;
+      mockScanToken.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveScan = resolve;
+          }),
+      );
+
+      const { rerender, unmount } = renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      // The store applies the seeded descriptor, then the user leaves the
+      // screen before the scan resolves. Unmount runs resetSwap, so a late
+      // write here would repopulate the reset store and break the next
+      // visit's seeding.
+      const seededDescriptor = mockSetDestinationToken.mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>;
+      setSwapStoreState({
+        destinationToken:
+          seededDescriptor as SwapStoreState["destinationToken"],
+      });
+      rerender(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+      act(() => {
+        unmount();
+      });
+
+      await act(async () => {
+        resolveScan({ result_type: "Benign" });
+        await Promise.resolve();
+      });
+
+      expect(mockSetDestinationToken).not.toHaveBeenCalledWith(
+        expect.objectContaining({ securityLevel: expect.anything() }),
+      );
+    });
+
+    it("does not scan when the account already holds the default", () => {
+      setSwapStoreState({ destinationToken: null });
+      hydrateBalancesStore([MAINNET_USDC_ID]);
+
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({ id: MAINNET_USDC_ID }),
+      );
+      expect(mockScanToken).not.toHaveBeenCalled();
     });
 
     it("does not override an existing destination", () => {

--- a/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
+++ b/__tests__/components/screens/SwapScreen/SwapAmountScreen.test.tsx
@@ -212,6 +212,35 @@ jest.mock("components/screens/SwapScreen/hooks/useSwapTransaction", () => ({
 }));
 jest.mock("hooks/useBalancesList");
 
+// The default-destination seeding effect reads the raw balances map and its
+// fetched stamps straight from the balances store (useBalancesList is mocked
+// above and doesn't carry them). Tests drive them through these holders; the
+// global beforeEach resets to "hydrated for the test account on PUBLIC".
+let mockRawBalances: Record<string, unknown> = {};
+let mockFetchedPublicKey: string | null = null;
+let mockFetchedNetwork: NETWORKS | null = null;
+jest.mock("ducks/balances", () => ({
+  useBalancesStore: (selector?: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      balances: mockRawBalances,
+      fetchedPublicKey: mockFetchedPublicKey,
+      fetchedNetwork: mockFetchedNetwork,
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+// Stamp the balances store as hydrated for the test account ("abc", per the
+// useGetActiveAccount mock) on PUBLIC, holding the fixture balances plus any
+// extra token ids.
+const hydrateBalancesStore = (extraIds: string[] = []) => {
+  mockRawBalances = Object.fromEntries(
+    [...mockBalances.map((b) => b.id), ...extraIds].map((id) => [id, {}]),
+  );
+  mockFetchedPublicKey = "abc";
+  mockFetchedNetwork = NETWORKS.PUBLIC;
+};
+
 jest.mock("@react-navigation/elements", () => ({
   useHeaderHeight: () => 0,
 }));
@@ -353,6 +382,7 @@ describe("SwapAmountScreen", () => {
     mockSaveSwapFee.mockClear();
     setSwapStoreState({});
     mockBalancesListReturn();
+    hydrateBalancesStore();
   });
 
   it("initializes source token from route params", () => {
@@ -415,19 +445,7 @@ describe("SwapAmountScreen", () => {
 
     it("derives requiresTrustline=false when the account already holds the default", () => {
       setSwapStoreState({ destinationToken: null });
-      (useBalancesList as jest.Mock).mockImplementation(() => ({
-        balanceItems: [
-          ...mockBalances,
-          { ...mockBalances[1], id: MAINNET_USDC_ID },
-        ],
-        scanResults: {},
-        isLoading: false,
-        error: null,
-        noBalances: false,
-        isRefreshing: false,
-        isFunded: true,
-        handleRefresh: jest.fn(),
-      }));
+      hydrateBalancesStore([MAINNET_USDC_ID]);
 
       renderWithProviders(
         <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
@@ -441,18 +459,37 @@ describe("SwapAmountScreen", () => {
       );
     });
 
-    it("does not seed while balances have not hydrated", () => {
+    it("does not seed before a snapshot for this account/network lands, then seeds once it does", () => {
       setSwapStoreState({ destinationToken: null });
-      (useBalancesList as jest.Mock).mockImplementation(() => ({
-        balanceItems: [],
-        scanResults: {},
-        isLoading: true,
-        error: null,
-        noBalances: false,
-        isRefreshing: false,
-        isFunded: true,
-        handleRefresh: jest.fn(),
-      }));
+      mockRawBalances = {};
+      mockFetchedPublicKey = null;
+      mockFetchedNetwork = null;
+
+      const { rerender } = renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).not.toHaveBeenCalledWith(
+        expect.objectContaining({ tokenCode: "USDC" }),
+      );
+
+      hydrateBalancesStore();
+      rerender(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: MAINNET_USDC_ID,
+          tokenCode: "USDC",
+          requiresTrustline: true,
+        }),
+      );
+    });
+
+    it("does not seed from a stale snapshot left over from another network", () => {
+      setSwapStoreState({ destinationToken: null });
+      mockFetchedNetwork = NETWORKS.TESTNET;
 
       renderWithProviders(
         <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
@@ -460,6 +497,22 @@ describe("SwapAmountScreen", () => {
 
       expect(mockSetDestinationToken).not.toHaveBeenCalledWith(
         expect.objectContaining({ tokenCode: "USDC" }),
+      );
+    });
+
+    it("seeds even when the hydrated snapshot is empty (unfunded account)", () => {
+      setSwapStoreState({ destinationToken: null });
+      mockRawBalances = {};
+
+      renderWithProviders(
+        <SwapAmountScreen navigation={makeNavigation()} route={makeRoute()} />,
+      );
+
+      expect(mockSetDestinationToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: MAINNET_USDC_ID,
+          requiresTrustline: true,
+        }),
       );
     });
 

--- a/e2e/flows/transactions/SwapClassicToken.yaml
+++ b/e2e/flows/transactions/SwapClassicToken.yaml
@@ -52,9 +52,13 @@ tags:
 - tapOn:
     id: token-option-XLM
 
-# Select "to" (Receive) token (USDC). No destination chosen yet → choose pill.
+# Select "to" (Receive) token (USDC). The Receive side is pre-seeded with the
+# network's USDC once balances hydrate, so the pill renders as
+# swap-receive-pill; match the empty-state choose pill too in case seeding
+# hasn't landed yet. Still go through the picker (rather than trusting the
+# seeded default) so the flow keeps exercising destination selection.
 - tapOn:
-    id: swap-receive-choose-pill
+    id: "swap-receive-pill|swap-receive-choose-pill"
 # Wait for the token picker, then select USDC
 - extendedWaitUntil:
     visible:

--- a/src/components/AmountCard.tsx
+++ b/src/components/AmountCard.tsx
@@ -194,7 +194,8 @@ const PickerChip: React.FC<{
         // proportionally to this larger icon; with size="sm" (16×16) the
         // badge nearly covers the whole icon. Chip height stays 32px
         // because the `<Text md>` lineHeight (24) already dominates the
-        // row.
+        // row (which is also why the icon-less empty state below keeps the
+        // same height).
         <TokenIconWithBadge
           token={token}
           size="md"
@@ -204,13 +205,10 @@ const PickerChip: React.FC<{
           // already shown as the adjacent label, so one initial reads cleaner.
           singleLetterFallback
         />
-      ) : (
-        // Empty-state affordance: a Plus-in-circle to signal "tap to add a
-        // token" when no token has been picked yet.
-        <View className="w-[20px] h-[20px] rounded-full items-center justify-center bg-gray-3">
-          <Icon.Plus size={16} themeColor="gray" />
-        </View>
-      )}
+      ) : // No empty-state icon: the label ("Select a token") plus chevron is
+      // the whole affordance, per the #940 design note (the old
+      // Plus-in-circle was dropped alongside the destination defaulting).
+      null}
       <Text md medium>
         {label ?? fallbackLabel ?? ""}
       </Text>

--- a/src/components/AmountCard.tsx
+++ b/src/components/AmountCard.tsx
@@ -194,8 +194,7 @@ const PickerChip: React.FC<{
         // proportionally to this larger icon; with size="sm" (16×16) the
         // badge nearly covers the whole icon. Chip height stays 32px
         // because the `<Text md>` lineHeight (24) already dominates the
-        // row (which is also why the icon-less empty state below keeps the
-        // same height).
+        // row.
         <TokenIconWithBadge
           token={token}
           size="md"
@@ -205,10 +204,7 @@ const PickerChip: React.FC<{
           // already shown as the adjacent label, so one initial reads cleaner.
           singleLetterFallback
         />
-      ) : // No empty-state icon: the label ("Select a token") plus chevron is
-      // the whole affordance, per the #940 design note (the old
-      // Plus-in-circle was dropped alongside the destination defaulting).
-      null}
+      ) : null}
       <Text md medium>
         {label ?? fallbackLabel ?? ""}
       </Text>

--- a/src/components/screens/SwapScreen/hooks/index.ts
+++ b/src/components/screens/SwapScreen/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useDefaultSwapDestination } from "./useDefaultSwapDestination";
 export { useSwapAmountError, SWAP_TOAST_IDS } from "./useSwapAmountError";
 export { useSwapBalances } from "./useSwapBalances";
 export { useSwapCtaState, type SwapCtaState } from "./useSwapCtaState";

--- a/src/components/screens/SwapScreen/hooks/useDefaultSwapDestination.ts
+++ b/src/components/screens/SwapScreen/hooks/useDefaultSwapDestination.ts
@@ -1,0 +1,148 @@
+import { DestinationTokenDescriptor } from "components/screens/SwapScreen/helpers/types";
+import {
+  DEFAULT_DECIMALS,
+  DEFAULT_SWAP_DEST_TOKEN_ID,
+  NATIVE_TOKEN_CODE,
+  NETWORKS,
+} from "config/constants";
+import { TokenTypeWithCustomToken } from "config/types";
+import { useBalancesStore } from "ducks/balances";
+import { useEffect, useRef } from "react";
+import { scanToken } from "services/blockaid/api";
+import {
+  assessTokenSecurity,
+  extractSecurityWarnings,
+} from "services/blockaid/helper";
+
+/**
+ * Seeds the swap destination with the network's default token (#940), or
+ * native XLM when the swap already starts from the default. Seeds once per
+ * mount and never overrides a destination the user picked or cleared.
+ *
+ * - Waits for a balances snapshot stamped for the active account/network
+ *   (a network switch keeps the stale snapshot around) and derives
+ *   `requiresTrustline` from the raw balances map, which is written in the
+ *   same store update as the stamps.
+ * - Stamps a non-held default with its own Blockaid scan once it resolves;
+ *   without a securityLevel the review flow would treat it as "unable to
+ *   scan". Scan failure (Blockaid only covers mainnet) leaves it unstamped
+ *   and the standard unable-to-scan flow applies.
+ *
+ * Call it AFTER the effect that initializes the source token from route
+ * params, so seeding observes the destination that effect just cleared.
+ */
+export const useDefaultSwapDestination = ({
+  network,
+  publicKey,
+  swapFromTokenId,
+  destinationTokenDescriptor,
+  setDestinationToken,
+}: {
+  network: NETWORKS;
+  publicKey: string | undefined;
+  swapFromTokenId: string | undefined;
+  destinationTokenDescriptor: DestinationTokenDescriptor | null;
+  setDestinationToken: (descriptor: DestinationTokenDescriptor | null) => void;
+}): void => {
+  const rawBalances = useBalancesStore((state) => state.balances);
+  const balancesFetchedPublicKey = useBalancesStore(
+    (state) => state.fetchedPublicKey,
+  );
+  const balancesFetchedNetwork = useBalancesStore(
+    (state) => state.fetchedNetwork,
+  );
+
+  // Keep a ref with the latest destination so the scan callback below can
+  // check what's selected NOW, not what was selected when the scan started.
+  // Cleared on unmount.
+  const destinationDescriptorRef = useRef<DestinationTokenDescriptor | null>(
+    destinationTokenDescriptor,
+  );
+  useEffect(() => {
+    destinationDescriptorRef.current = destinationTokenDescriptor;
+    return () => {
+      destinationDescriptorRef.current = null;
+    };
+  }, [destinationTokenDescriptor]);
+
+  const hasSeededDefaultDestination = useRef(false);
+  useEffect(() => {
+    if (hasSeededDefaultDestination.current) {
+      return;
+    }
+    const defaultTokenId = DEFAULT_SWAP_DEST_TOKEN_ID[network];
+    if (!defaultTokenId || destinationTokenDescriptor) {
+      hasSeededDefaultDestination.current = true;
+      return;
+    }
+    if (
+      !publicKey ||
+      balancesFetchedPublicKey !== publicKey ||
+      balancesFetchedNetwork !== network
+    ) {
+      return;
+    }
+    hasSeededDefaultDestination.current = true;
+
+    if (swapFromTokenId === defaultTokenId) {
+      setDestinationToken({
+        id: NATIVE_TOKEN_CODE,
+        tokenCode: NATIVE_TOKEN_CODE,
+        decimals: DEFAULT_DECIMALS,
+        tokenType: TokenTypeWithCustomToken.NATIVE,
+        requiresTrustline: false,
+      });
+      return;
+    }
+
+    const isDefaultHeld = defaultTokenId in rawBalances;
+    const [defaultTokenCode, defaultTokenIssuer] = defaultTokenId.split(":");
+    setDestinationToken({
+      id: defaultTokenId,
+      tokenCode: defaultTokenCode,
+      issuer: defaultTokenIssuer,
+      decimals: DEFAULT_DECIMALS,
+      tokenType: TokenTypeWithCustomToken.CREDIT_ALPHANUM4,
+      requiresTrustline: !isDefaultHeld,
+    });
+
+    if (isDefaultHeld) {
+      // Already-held tokens get their security signal from the held-balances
+      // bulk scan, so there's nothing to attach here.
+      return;
+    }
+
+    scanToken({
+      tokenCode: defaultTokenCode,
+      tokenIssuer: defaultTokenIssuer,
+      network,
+    })
+      .then((scanResult) => {
+        const { current } = destinationDescriptorRef;
+        // Only update if the destination is still our seeded default and
+        // nothing has stamped it yet. If the user picked another token in
+        // the meantime, that one brought its own scan result.
+        if (current?.id !== defaultTokenId || current.securityLevel) {
+          return;
+        }
+        setDestinationToken({
+          ...current,
+          securityLevel: assessTokenSecurity(scanResult).level,
+          securityWarnings: extractSecurityWarnings(scanResult),
+        });
+      })
+      .catch(() => {
+        // If scan failed, leave the descriptor unstamped so the regular
+        // unable-to-scan warning flow takes over.
+      });
+  }, [
+    network,
+    destinationTokenDescriptor,
+    rawBalances,
+    balancesFetchedPublicKey,
+    balancesFetchedNetwork,
+    publicKey,
+    swapFromTokenId,
+    setDestinationToken,
+  ]);
+};

--- a/src/components/screens/SwapScreen/hooks/useDefaultSwapDestination.ts
+++ b/src/components/screens/SwapScreen/hooks/useDefaultSwapDestination.ts
@@ -7,6 +7,7 @@ import {
 } from "config/constants";
 import { TokenTypeWithCustomToken } from "config/types";
 import { useBalancesStore } from "ducks/balances";
+import { useSwapStore } from "ducks/swap";
 import { useEffect, useRef } from "react";
 import { scanToken } from "services/blockaid/api";
 import {
@@ -51,19 +52,6 @@ export const useDefaultSwapDestination = ({
   const balancesFetchedNetwork = useBalancesStore(
     (state) => state.fetchedNetwork,
   );
-
-  // Keep a ref with the latest destination so the scan callback below can
-  // check what's selected NOW, not what was selected when the scan started.
-  // Cleared on unmount.
-  const destinationDescriptorRef = useRef<DestinationTokenDescriptor | null>(
-    destinationTokenDescriptor,
-  );
-  useEffect(() => {
-    destinationDescriptorRef.current = destinationTokenDescriptor;
-    return () => {
-      destinationDescriptorRef.current = null;
-    };
-  }, [destinationTokenDescriptor]);
 
   const hasSeededDefaultDestination = useRef(false);
   useEffect(() => {
@@ -118,10 +106,14 @@ export const useDefaultSwapDestination = ({
       network,
     })
       .then((scanResult) => {
-        const { current } = destinationDescriptorRef;
-        // Only update if the destination is still our seeded default and
-        // nothing has stamped it yet. If the user picked another token in
-        // the meantime, that one brought its own scan result.
+        // Read the destination synchronously from the store: render state
+        // (props or a render-synced ref) can lag a store write from the
+        // picker, and resetSwap on unmount nulls it before a late scan
+        // resolves. Only update if the destination is still our seeded
+        // default and nothing has stamped it yet. If the user picked
+        // another token in the meantime, that one brought its own scan
+        // result.
+        const current = useSwapStore.getState().destinationToken;
         if (current?.id !== defaultTokenId || current.securityLevel) {
           return;
         }

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -26,6 +26,7 @@ import {
 } from "components/screens/SwapScreen/helpers";
 import {
   SWAP_TOAST_IDS,
+  useDefaultSwapDestination,
   useSwapAmountError,
   useSwapBalances,
   useSwapCtaState,
@@ -49,19 +50,13 @@ import { AnalyticsEvent, SwapPickerEntrypoint } from "config/analyticsConfig";
 import {
   BASE_RESERVE,
   DEFAULT_DECIMALS,
-  DEFAULT_SWAP_DEST_TOKEN_ID,
   isNativeAssetId,
-  NATIVE_TOKEN_CODE,
   TransactionContext,
 } from "config/constants";
 import { logger } from "config/logger";
 import { SWAP_ROUTES, SwapStackParamList } from "config/routes";
-import {
-  FormattedSearchTokenRecord,
-  TokenTypeWithCustomToken,
-} from "config/types";
+import { FormattedSearchTokenRecord } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
-import { useBalancesStore } from "ducks/balances";
 import { useDebugStore } from "ducks/debug";
 import { descriptorAsPathBalance, useSwapStore } from "ducks/swap";
 import { useSwapSettingsStore } from "ducks/swapSettings";
@@ -94,13 +89,8 @@ import {
   View,
 } from "react-native";
 import { analytics } from "services/analytics";
-import { scanToken } from "services/blockaid/api";
 import { SecurityContext, SecurityLevel } from "services/blockaid/constants";
-import {
-  assessTokenSecurity,
-  assessTransactionSecurity,
-  extractSecurityWarnings,
-} from "services/blockaid/helper";
+import { assessTransactionSecurity } from "services/blockaid/helper";
 
 type SwapAmountScreenProps = NativeStackScreenProps<
   SwapStackParamList,
@@ -404,113 +394,19 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
     setDestinationToken,
   ]);
 
-  const rawBalances = useBalancesStore((state) => state.balances);
-  const balancesFetchedPublicKey = useBalancesStore(
-    (state) => state.fetchedPublicKey,
-  );
-  const balancesFetchedNetwork = useBalancesStore(
-    (state) => state.fetchedNetwork,
-  );
-
-  // Keep a ref with the latest destination so the scan callback below can
-  // check what's selected NOW, not what was selected when the scan started.
-  // Cleared on unmount: the screen's cleanup resets the swap store, and a
-  // scan resolving after that must not see the old descriptor here and
-  // write it back into the reset store.
-  const destinationDescriptorRef = useRef(destinationTokenDescriptor);
-  useEffect(() => {
-    destinationDescriptorRef.current = destinationTokenDescriptor;
-    return () => {
-      destinationDescriptorRef.current = null;
-    };
-  }, [destinationTokenDescriptor]);
-
-  const hasSeededDefaultDestination = useRef(false);
-  useEffect(() => {
-    if (hasSeededDefaultDestination.current) {
-      return;
-    }
-    const defaultTokenId = DEFAULT_SWAP_DEST_TOKEN_ID[network];
-    if (!defaultTokenId || destinationTokenDescriptor) {
-      hasSeededDefaultDestination.current = true;
-      return;
-    }
-    if (
-      !account?.publicKey ||
-      balancesFetchedPublicKey !== account.publicKey ||
-      balancesFetchedNetwork !== network
-    ) {
-      return;
-    }
-    hasSeededDefaultDestination.current = true;
-
-    if (swapFromTokenId === defaultTokenId) {
-      setDestinationToken({
-        id: NATIVE_TOKEN_CODE,
-        tokenCode: NATIVE_TOKEN_CODE,
-        decimals: DEFAULT_DECIMALS,
-        tokenType: TokenTypeWithCustomToken.NATIVE,
-        requiresTrustline: false,
-      });
-      return;
-    }
-
-    const isDefaultHeld = defaultTokenId in rawBalances;
-    const [defaultTokenCode, defaultTokenIssuer] = defaultTokenId.split(":");
-    setDestinationToken({
-      id: defaultTokenId,
-      tokenCode: defaultTokenCode,
-      issuer: defaultTokenIssuer,
-      decimals: DEFAULT_DECIMALS,
-      tokenType: TokenTypeWithCustomToken.CREDIT_ALPHANUM4,
-      requiresTrustline: !isDefaultHeld,
-    });
-
-    if (isDefaultHeld) {
-      // Already-held tokens get their security signal from the held-balances
-      // bulk scan, so there's nothing to attach here.
-      return;
-    }
-
-    // A non-held destination needs a Blockaid security signal: the review
-    // flow treats a descriptor without a securityLevel as "unable to scan"
-    // and presents the security warning sheet. Descriptors from the picker
-    // get their level from the discovery-time bulk scan, but a
-    // programmatically seeded one has no such source, so fetch its own
-    // scan and attach the result when it lands.
-    scanToken({
-      tokenCode: defaultTokenCode,
-      tokenIssuer: defaultTokenIssuer,
-      network,
-    })
-      .then((scanResult) => {
-        const { current } = destinationDescriptorRef;
-        // Only update if the destination is still our seeded default and
-        // nothing has stamped it yet. If the user picked another token in
-        // the meantime, that one brought its own scan result.
-        if (current?.id !== defaultTokenId || current.securityLevel) {
-          return;
-        }
-        setDestinationToken({
-          ...current,
-          securityLevel: assessTokenSecurity(scanResult).level,
-          securityWarnings: extractSecurityWarnings(scanResult),
-        });
-      })
-      .catch(() => {
-        // If scan failed, leave the descriptor unstamped so the regular
-        // unable-to-scan warning flow takes over.
-      });
-  }, [
+  // Seeds the Receive side with the network's default token (USDC, or XLM
+  // when swapping from USDC) once a balances snapshot for this
+  // account/network lands, and stamps a non-held default with its own
+  // Blockaid scan. See the hook for the full rationale. Called after the
+  // source-init effect above so it observes the destination that effect
+  // just cleared.
+  useDefaultSwapDestination({
     network,
-    destinationTokenDescriptor,
-    rawBalances,
-    balancesFetchedPublicKey,
-    balancesFetchedNetwork,
-    account?.publicKey,
+    publicKey: account?.publicKey,
     swapFromTokenId,
+    destinationTokenDescriptor,
     setDestinationToken,
-  ]);
+  });
 
   // The network fee auto-refreshes every 30s and is paid in XLM, so a fee
   // bump would shrink an XLM source's spendable and flash "Insufficient

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -94,8 +94,13 @@ import {
   View,
 } from "react-native";
 import { analytics } from "services/analytics";
+import { scanToken } from "services/blockaid/api";
 import { SecurityContext, SecurityLevel } from "services/blockaid/constants";
-import { assessTransactionSecurity } from "services/blockaid/helper";
+import {
+  assessTokenSecurity,
+  assessTransactionSecurity,
+  extractSecurityWarnings,
+} from "services/blockaid/helper";
 
 type SwapAmountScreenProps = NativeStackScreenProps<
   SwapStackParamList,
@@ -407,6 +412,19 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
     (state) => state.fetchedNetwork,
   );
 
+  // Keep a ref with the latest destination so the scan callback below can
+  // check what's selected NOW, not what was selected when the scan started.
+  // Cleared on unmount: the screen's cleanup resets the swap store, and a
+  // scan resolving after that must not see the old descriptor here and
+  // write it back into the reset store.
+  const destinationDescriptorRef = useRef(destinationTokenDescriptor);
+  useEffect(() => {
+    destinationDescriptorRef.current = destinationTokenDescriptor;
+    return () => {
+      destinationDescriptorRef.current = null;
+    };
+  }, [destinationTokenDescriptor]);
+
   const hasSeededDefaultDestination = useRef(false);
   useEffect(() => {
     if (hasSeededDefaultDestination.current) {
@@ -437,6 +455,7 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
       return;
     }
 
+    const isDefaultHeld = defaultTokenId in rawBalances;
     const [defaultTokenCode, defaultTokenIssuer] = defaultTokenId.split(":");
     setDestinationToken({
       id: defaultTokenId,
@@ -444,8 +463,44 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
       issuer: defaultTokenIssuer,
       decimals: DEFAULT_DECIMALS,
       tokenType: TokenTypeWithCustomToken.CREDIT_ALPHANUM4,
-      requiresTrustline: !(defaultTokenId in rawBalances),
+      requiresTrustline: !isDefaultHeld,
     });
+
+    if (isDefaultHeld) {
+      // Already-held tokens get their security signal from the held-balances
+      // bulk scan, so there's nothing to attach here.
+      return;
+    }
+
+    // A non-held destination needs a Blockaid security signal: the review
+    // flow treats a descriptor without a securityLevel as "unable to scan"
+    // and presents the security warning sheet. Descriptors from the picker
+    // get their level from the discovery-time bulk scan, but a
+    // programmatically seeded one has no such source, so fetch its own
+    // scan and attach the result when it lands.
+    scanToken({
+      tokenCode: defaultTokenCode,
+      tokenIssuer: defaultTokenIssuer,
+      network,
+    })
+      .then((scanResult) => {
+        const { current } = destinationDescriptorRef;
+        // Only update if the destination is still our seeded default and
+        // nothing has stamped it yet. If the user picked another token in
+        // the meantime, that one brought its own scan result.
+        if (current?.id !== defaultTokenId || current.securityLevel) {
+          return;
+        }
+        setDestinationToken({
+          ...current,
+          securityLevel: assessTokenSecurity(scanResult).level,
+          securityWarnings: extractSecurityWarnings(scanResult),
+        });
+      })
+      .catch(() => {
+        // If scan failed, leave the descriptor unstamped so the regular
+        // unable-to-scan warning flow takes over.
+      });
   }, [
     network,
     destinationTokenDescriptor,

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -61,6 +61,7 @@ import {
   TokenTypeWithCustomToken,
 } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
+import { useBalancesStore } from "ducks/balances";
 import { useDebugStore } from "ducks/debug";
 import { descriptorAsPathBalance, useSwapStore } from "ducks/swap";
 import { useSwapSettingsStore } from "ducks/swapSettings";
@@ -398,13 +399,14 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
     setDestinationToken,
   ]);
 
-  // Default the destination to the network's USDC (#940) — or native XLM when
-  // the swap starts from USDC itself (the token-details entry), so the two
-  // sides never collide. Applies regardless of whether the account holds the
-  // default; requiresTrustline is derived from actual holdings, which is why
-  // seeding waits for balances to hydrate. Seeded once per mount (declared
-  // after the source effect above so it runs after the destination clear) and
-  // never re-seeds a destination the user picked or cleared themselves.
+  const rawBalances = useBalancesStore((state) => state.balances);
+  const balancesFetchedPublicKey = useBalancesStore(
+    (state) => state.fetchedPublicKey,
+  );
+  const balancesFetchedNetwork = useBalancesStore(
+    (state) => state.fetchedNetwork,
+  );
+
   const hasSeededDefaultDestination = useRef(false);
   useEffect(() => {
     if (hasSeededDefaultDestination.current) {
@@ -412,12 +414,14 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
     }
     const defaultTokenId = DEFAULT_SWAP_DEST_TOKEN_ID[network];
     if (!defaultTokenId || destinationTokenDescriptor) {
-      // No default on this network, or a destination already exists (e.g.
-      // returning from the picker before balances hydrated).
       hasSeededDefaultDestination.current = true;
       return;
     }
-    if (balanceItems.length === 0) {
+    if (
+      !account?.publicKey ||
+      balancesFetchedPublicKey !== account.publicKey ||
+      balancesFetchedNetwork !== network
+    ) {
       return;
     }
     hasSeededDefaultDestination.current = true;
@@ -440,19 +444,15 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
       issuer: defaultTokenIssuer,
       decimals: DEFAULT_DECIMALS,
       tokenType: TokenTypeWithCustomToken.CREDIT_ALPHANUM4,
-      // Derived from holdings: an already-held default must not build a
-      // redundant changeTrust (doubled fee, false reserve preflight).
-      requiresTrustline: !balanceItems.some(
-        (item) => item.id === defaultTokenId,
-      ),
-      // iconUrl intentionally omitted: mainnet USDC renders via the bundled
-      // logo special case in TokenIcon; other networks resolve through the
-      // icons store like held tokens.
+      requiresTrustline: !(defaultTokenId in rawBalances),
     });
   }, [
     network,
     destinationTokenDescriptor,
-    balanceItems,
+    rawBalances,
+    balancesFetchedPublicKey,
+    balancesFetchedNetwork,
+    account?.publicKey,
     swapFromTokenId,
     setDestinationToken,
   ]);

--- a/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
+++ b/src/components/screens/SwapScreen/screens/SwapAmountScreen.tsx
@@ -49,12 +49,17 @@ import { AnalyticsEvent, SwapPickerEntrypoint } from "config/analyticsConfig";
 import {
   BASE_RESERVE,
   DEFAULT_DECIMALS,
+  DEFAULT_SWAP_DEST_TOKEN_ID,
   isNativeAssetId,
+  NATIVE_TOKEN_CODE,
   TransactionContext,
 } from "config/constants";
 import { logger } from "config/logger";
 import { SWAP_ROUTES, SwapStackParamList } from "config/routes";
-import { FormattedSearchTokenRecord } from "config/types";
+import {
+  FormattedSearchTokenRecord,
+  TokenTypeWithCustomToken,
+} from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
 import { useDebugStore } from "ducks/debug";
 import { descriptorAsPathBalance, useSwapStore } from "ducks/swap";
@@ -390,6 +395,65 @@ const SwapAmountScreen: React.FC<SwapAmountScreenProps> = ({
     swapFromTokenId,
     swapFromTokenSymbol,
     setSourceToken,
+    setDestinationToken,
+  ]);
+
+  // Default the destination to the network's USDC (#940) — or native XLM when
+  // the swap starts from USDC itself (the token-details entry), so the two
+  // sides never collide. Applies regardless of whether the account holds the
+  // default; requiresTrustline is derived from actual holdings, which is why
+  // seeding waits for balances to hydrate. Seeded once per mount (declared
+  // after the source effect above so it runs after the destination clear) and
+  // never re-seeds a destination the user picked or cleared themselves.
+  const hasSeededDefaultDestination = useRef(false);
+  useEffect(() => {
+    if (hasSeededDefaultDestination.current) {
+      return;
+    }
+    const defaultTokenId = DEFAULT_SWAP_DEST_TOKEN_ID[network];
+    if (!defaultTokenId || destinationTokenDescriptor) {
+      // No default on this network, or a destination already exists (e.g.
+      // returning from the picker before balances hydrated).
+      hasSeededDefaultDestination.current = true;
+      return;
+    }
+    if (balanceItems.length === 0) {
+      return;
+    }
+    hasSeededDefaultDestination.current = true;
+
+    if (swapFromTokenId === defaultTokenId) {
+      setDestinationToken({
+        id: NATIVE_TOKEN_CODE,
+        tokenCode: NATIVE_TOKEN_CODE,
+        decimals: DEFAULT_DECIMALS,
+        tokenType: TokenTypeWithCustomToken.NATIVE,
+        requiresTrustline: false,
+      });
+      return;
+    }
+
+    const [defaultTokenCode, defaultTokenIssuer] = defaultTokenId.split(":");
+    setDestinationToken({
+      id: defaultTokenId,
+      tokenCode: defaultTokenCode,
+      issuer: defaultTokenIssuer,
+      decimals: DEFAULT_DECIMALS,
+      tokenType: TokenTypeWithCustomToken.CREDIT_ALPHANUM4,
+      // Derived from holdings: an already-held default must not build a
+      // redundant changeTrust (doubled fee, false reserve preflight).
+      requiresTrustline: !balanceItems.some(
+        (item) => item.id === defaultTokenId,
+      ),
+      // iconUrl intentionally omitted: mainnet USDC renders via the bundled
+      // logo special case in TokenIcon; other networks resolve through the
+      // icons store like held tokens.
+    });
+  }, [
+    network,
+    destinationTokenDescriptor,
+    balanceItems,
+    swapFromTokenId,
     setDestinationToken,
   ]);
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -65,6 +65,9 @@ export const CIRCLE_USDC_ISSUER =
 export const USDC_CODE = "USDC";
 export const CIRCLE_USDC_CONTRACT =
   "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+// Circle's testnet USDC issuer (home_domain centre.io), matching the extension
+export const CIRCLE_USDC_TESTNET_ISSUER =
+  "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 // Slippage constants
 export const DEFAULT_SLIPPAGE = 2;
@@ -332,6 +335,17 @@ export const DEFAULT_NETWORKS: Array<NetworkDetails> = [
   PUBLIC_NETWORK_DETAILS,
   TESTNET_NETWORK_DETAILS,
 ];
+
+/**
+ * Default swap destination ("You receive") per network, as a token id
+ * (CODE:ISSUER). Only networks listed here get a default; on others the
+ * picker starts empty. Mirrors the extension's DEFAULT_SWAP_DEST_CANONICAL
+ * (freighter#2914) — keep the issuers in sync across platforms.
+ */
+export const DEFAULT_SWAP_DEST_TOKEN_ID: Partial<Record<NETWORKS, string>> = {
+  [NETWORKS.PUBLIC]: `${USDC_CODE}:${CIRCLE_USDC_ISSUER}`,
+  [NETWORKS.TESTNET]: `${USDC_CODE}:${CIRCLE_USDC_TESTNET_ISSUER}`,
+};
 
 export const STELLAR_EXPERT_URL = "https://stellar.expert/explorer";
 export const STELLAR_EXPERT_API_URL = "https://api.stellar.expert/explorer";


### PR DESCRIPTION
### What

- `config/constants.ts`: `DEFAULT_SWAP_DEST_TOKEN_ID` per-network map + Circle's testnet issuer
- `SwapAmountScreen.tsx`: 
    - Sets the default destination token once per mount, after balances for the active account/network have loaded; trustline status comes from those same balances, so existing consumers need no changes.
    - For a default token the user doesn't hold, attaches a real Blockaid scan result when it resolves, so mainnet users see a proper verdict at Review instead of "unable to scan". Failed scans or non-mainnet leave it unscanned.
- `AmountCard.tsx`: removed the `+` icon from the empty picker chip per the design note 

### Why

Closes [#940](https://github.com/stellar/freighter-mobile/issues/940). Mobile port of the swap flow's **You receive** field defaults to the network's USDC, or native XLM when the swap starts from USDC itself (token-details entry). 

### Known limitations

N/A

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [x] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This PR updates existing JSDocs when applicable.
- [ ] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.


### Simulation
1. Swap xlm will have usdc as default dest with trustline adding notice

https://github.com/user-attachments/assets/d1b0b983-9594-4473-afed-f9f2cb8dd8ee

2.  Swap usdc will have xlm as default dest

https://github.com/user-attachments/assets/86138160-5c83-4770-b55f-51b57049e0ab

3. "+" icon is removed when displaying "Select Text"
<img width="444" height="915" alt="plus icon is removed" src="https://github.com/user-attachments/assets/77ae2779-74b2-4c4d-a8e3-b3121a9eac36" />

4. In android

https://github.com/user-attachments/assets/60898efd-de38-4abc-838d-6c72f56d8dfd


