### PR TITLE
fix(walletKit): block CAP-71 auth entries bound to a non-wallet address

### DIFF
--- a/__tests__/helpers/stellar.test.ts
+++ b/__tests__/helpers/stellar.test.ts
@@ -75,6 +75,9 @@ jest.mock("@stellar/stellar-sdk", () => {
 
 jest.mock("helpers/soroban", () => ({
   isContractId: jest.fn(),
+  // Real implementation: validateAuthEntryAddress (exercised via signAuthEntry's
+  // defense-in-depth check) needs arm-agnostic address stringification to work.
+  addressToString: jest.requireActual("helpers/soroban").addressToString,
 }));
 
 jest.mock("config/logger", () => ({

--- a/__tests__/helpers/walletKitValidation.test.ts
+++ b/__tests__/helpers/walletKitValidation.test.ts
@@ -623,7 +623,7 @@ describe("validateAuthEntryAddress", () => {
     }
   });
 
-  it("passes a contract-bound address through (cannot match a wallet key)", () => {
+  it("rejects a contract-bound address (delegated auth is not supported — freighter-mobile#894)", () => {
     const preimage = xdr.HashIdPreimage.fromXDR(
       buildTestWithAddressPreimage(
         Networks.TESTNET,
@@ -633,7 +633,12 @@ describe("validateAuthEntryAddress", () => {
       "base64",
     );
     const result = validateAuthEntryAddress(preimage, OTHER_WALLET_ADDRESS);
-    expect(result.valid).toBe(true);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errorKey).toBe(
+        ValidationErrorKeys.AUTH_ENTRY_ADDRESS_MISMATCH,
+      );
+    }
   });
 
   it("returns invalid for a non-Soroban-authorization preimage", () => {

--- a/src/helpers/walletKitValidation.ts
+++ b/src/helpers/walletKitValidation.ts
@@ -2,7 +2,8 @@
  * Shared validation helpers for WalletKit sign requests.
  * Used by both WalletKitProvider (pre-UI validation) and walletKitUtil (approval-time validation).
  */
-import { hash, StrKey, xdr } from "@stellar/stellar-sdk";
+import { hash, xdr } from "@stellar/stellar-sdk";
+import { addressToString } from "helpers/soroban";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Error Keys (full i18n translation key paths)
@@ -170,12 +171,17 @@ export function validateAuthEntryNetwork(
 
 /**
  * Validates that a CAP-71 (ADDRESS_V2) preimage is bound to the active wallet
- * account. The withAddress preimage embeds the signer address; if it is an
- * account address that differs from the wallet, signing would produce a
- * signature bound to someone else — reject it.
+ * account. The withAddress preimage embeds the address the signature is bound
+ * to; if it differs from the wallet, signing would produce an authorization on
+ * behalf of someone else — reject it, whatever the address arm.
  *
- * Legacy preimages (no bound address) and contract-bound addresses (which a
- * wallet account key can't match — e.g. delegate/contract signers) pass through.
+ * Only legacy preimages (which carry no bound address) pass through. Under
+ * CAP-71-01 a delegate signs a payload bound to the DELEGATOR's address, so a
+ * non-matching bound address — including a contract-bound one — is precisely
+ * the shape of a delegated-authorization request, not evidence the check is
+ * inapplicable. Freighter Mobile does not support delegated signing (tracked
+ * in stellar/freighter-mobile#894) — reject it the same way the browser
+ * extension does, rather than signing it silently.
  */
 export function validateAuthEntryAddress(
   preimage: xdr.HashIdPreimage,
@@ -191,14 +197,14 @@ export function validateAuthEntryAddress(
     return { valid: true, value: true };
   }
 
-  // Only enforce for account-type bound addresses.
-  if (normalized.address.switch().name !== "scAddressTypeAccount") {
-    return { valid: true, value: true };
+  let boundAddress: string;
+  try {
+    boundAddress = addressToString(normalized.address);
+  } catch {
+    // Unrenderable address arm — fail closed rather than let it through.
+    return { valid: false, errorKey: ValidationErrorKeys.INVALID_AUTH_ENTRY };
   }
 
-  const boundAddress = StrKey.encodeEd25519PublicKey(
-    normalized.address.accountId().ed25519(),
-  );
   if (boundAddress !== walletPublicKey) {
     return {
       valid: false,


### PR DESCRIPTION
resolves https://github.com/stellar/wallet-eng-monorepo/issues/59