### PR TITLE
chore(deps): migrate to @stellar/stellar-sdk 17.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Mobile.
 
 ### Prerequisites
 
-- **Node.js** >= 22: [nodejs.org](https://nodejs.org/) or `nvm install 22`
+- **Node.js** >= 22.12: [nodejs.org](https://nodejs.org/) or `nvm install 22`
+  (`@stellar/stellar-sdk` 17 needs 22.12+ to load its ESM-only dependencies)
 - **Yarn** 4.10.0: `corepack enable && corepack prepare yarn@4.10.0 --activate`
 - **Ruby** >= 3.1.4: [rbenv](https://github.com/rbenv/rbenv) or
   [rvm](https://rvm.io/)

--- a/__tests__/components/screens/SignTransactionDetails/components/Operations.test.tsx
+++ b/__tests__/components/screens/SignTransactionDetails/components/Operations.test.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
   Account,
+  Address,
   Asset,
   BASE_FEE,
   Networks,
@@ -422,5 +423,109 @@ describe("SignTransactionDetails > Operations: asset issuer disclosure", () => {
 
     expect(await findByText(label("tokenCode"), {}, FIND)).toBeTruthy();
     expect(await findByText(label("tokenIssuer"), {}, FIND)).toBeTruthy();
+  });
+});
+
+describe("SignTransactionDetails > Operations: contract creation executables", () => {
+  // KeyVal labels come from i18next's bare `t` (not react-i18next's hook), which
+  // is not initialised here, so these assertions target rendered values.
+  const OWNER_CONTRACT =
+    "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+
+  it("renders the wasm hash for a wasm executable and no external-executable note", async () => {
+    const ops = operationsFor(
+      Operation.createCustomContract({
+        address: new Address(SOURCE),
+        wasmHash: Buffer.alloc(32, 9),
+        salt: Buffer.alloc(32, 1),
+      }),
+    );
+
+    const { findByText, queryByTestId, queryByText } = render(
+      <Operations operations={ops} />,
+    );
+
+    expect(await findByText("contractExecutableWasm", {}, FIND)).toBeTruthy();
+    expect(
+      await findByText(truncateAddress("09".repeat(32)), {}, FIND),
+    ).toBeTruthy();
+    expect(queryByTestId("ExternalExecutableNote")).toBeNull();
+    expect(queryByText(truncateAddress(OWNER_CONTRACT))).toBeNull();
+  });
+
+  it("renders owner, tag and the note for a CAP-85 external executable (Protocol 28), and no wasm hash", async () => {
+    const ops = operationsFor(
+      Operation.createCustomContract({
+        address: new Address(SOURCE),
+        externalRef: { owner: OWNER_CONTRACT, tag: "token-v2" },
+        salt: Buffer.alloc(32, 1),
+      }),
+    );
+
+    const { findByText, findByTestId, queryByText } = render(
+      <Operations operations={ops} />,
+    );
+
+    expect(
+      await findByText("contractExecutableExternalRef", {}, FIND),
+    ).toBeTruthy();
+    expect(
+      await findByText(truncateAddress(OWNER_CONTRACT), {}, FIND),
+    ).toBeTruthy();
+    expect(await findByText("token-v2", {}, FIND)).toBeTruthy();
+    expect(await findByTestId("ExternalExecutableNote", {}, FIND)).toBeTruthy();
+    // An external reference deliberately carries no wasm hash.
+    expect(queryByText("contractExecutableWasm")).toBeNull();
+  });
+});
+
+describe("SignTransactionDetails > Operations: hash-based signer keys", () => {
+  // SDK 17 decodes revokeSignerSponsorship signer hashes to hex *strings* but
+  // setOptions signer hashes to Uint8Arrays; both must render as the same
+  // uppercase hex (and never re-hex the string or throw).
+  const HASH_HEX = "ab".repeat(32);
+  const HASH_UPPER = HASH_HEX.toUpperCase();
+
+  it("revokeSignerSponsorship with a sha256Hash signer renders the hash as uppercase hex", async () => {
+    const ops = operationsFor(
+      Operation.revokeSignerSponsorship({
+        account: SOURCE,
+        signer: { sha256Hash: HASH_HEX },
+      }),
+    );
+
+    const { findByText, queryByText } = render(<Operations operations={ops} />);
+
+    expect(await findByText(HASH_UPPER, {}, FIND)).toBeTruthy();
+    // the old Buffer.from(<hex string>) path rendered the hex of the ASCII
+    expect(queryByText(Buffer.from(HASH_HEX).toString("hex"))).toBeNull();
+  });
+
+  it("revokeSignerSponsorship with a preAuthTx signer renders the hash as uppercase hex", async () => {
+    const ops = operationsFor(
+      Operation.revokeSignerSponsorship({
+        account: SOURCE,
+        signer: { preAuthTx: HASH_HEX },
+      }),
+    );
+
+    const { findByText } = render(<Operations operations={ops} />);
+
+    expect(await findByText(HASH_UPPER, {}, FIND)).toBeTruthy();
+  });
+
+  it("setOptions with a sha256Hash signer (decoded as bytes) renders the same uppercase hex", async () => {
+    const ops = operationsFor(
+      Operation.setOptions({
+        signer: { sha256Hash: Buffer.from(HASH_HEX, "hex"), weight: 1 },
+      }),
+    );
+
+    const { findByText } = render(<Operations operations={ops} />);
+
+    // setOptions renders its signer through the truncating hash row
+    expect(
+      await findByText(truncateAddress(HASH_UPPER), {}, FIND),
+    ).toBeTruthy();
   });
 });

--- a/__tests__/components/screens/WalletKit/DappAuthEntryDisplay.test.tsx
+++ b/__tests__/components/screens/WalletKit/DappAuthEntryDisplay.test.tsx
@@ -1,0 +1,98 @@
+import { Address, hash, Networks, xdr } from "@stellar/stellar-sdk";
+import { DappAuthEntryDisplay } from "components/screens/WalletKit/DappAuthEntryDisplay";
+import { renderWithProviders } from "helpers/testUtils";
+import React from "react";
+
+jest.mock("hooks/useAppTranslation", () => ({
+  __esModule: true,
+  default: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("hooks/useClipboard", () => ({
+  useClipboard: () => ({ copyToClipboard: jest.fn() }),
+}));
+
+const OWNER_CONTRACT =
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+const DEPLOYER = "GDVEU3DD4KOFECV66VIHWEZOYX4ZKR3WV27L464SIIPOU2IUI3JCZA57";
+
+/** Wraps a create-contract invocation in a legacy Soroban auth preimage. */
+const buildEntryXdr = (
+  executable: xdr.ContractExecutable,
+  contractIdPreimage: xdr.ContractIdPreimage,
+) => {
+  const invocation = new xdr.SorobanAuthorizedInvocation({
+    function:
+      xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractHostFn(
+        new xdr.CreateContractArgs({ contractIdPreimage, executable }),
+      ),
+    subInvocations: [],
+  });
+  return xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
+    new xdr.HashIdPreimageSorobanAuthorization({
+      networkId: new xdr.Hash(hash(Buffer.from(Networks.TESTNET))),
+      nonce: BigInt(1),
+      signatureExpirationLedger: 1000,
+      invocation,
+    }),
+  ).toXdr("base64");
+};
+
+const addressPreimage = xdr.ContractIdPreimage.contractIdPreimageFromAddress(
+  new xdr.ContractIdPreimageFromAddress({
+    address: new Address(DEPLOYER).toScAddress(),
+    salt: new xdr.Uint256Bytes(Buffer.alloc(32, 7)),
+  }),
+);
+
+describe("DappAuthEntryDisplay", () => {
+  it("renders a CAP-85 external-executable creation with its owner, tag and note (Protocol 28)", () => {
+    const entryXdr = buildEntryXdr(
+      xdr.ContractExecutable.contractExecutableExternalRef(
+        new xdr.ContractExecutableExternalRef({
+          executableOwner: new Address(OWNER_CONTRACT).toScAddress(),
+          tag: "token-v2",
+        }),
+      ),
+      addressPreimage,
+    );
+
+    const { getByText, getByTestId, queryByText } = renderWithProviders(
+      <DappAuthEntryDisplay entryXdr={entryXdr} expandAll />,
+    );
+
+    expect(
+      getByText("signTransactionDetails.authorizations.contractCreation"),
+    ).toBeTruthy();
+    expect(
+      getByText("signTransactionDetails.authorizations.executableOwner"),
+    ).toBeTruthy();
+    expect(getByText("token-v2")).toBeTruthy();
+    expect(getByTestId("ExternalExecutableNote")).toBeTruthy();
+    // An external reference deliberately carries no wasm hash.
+    expect(
+      queryByText("signTransactionDetails.operations.executableWasmHash"),
+    ).toBeNull();
+  });
+
+  it("flags an invocation it cannot decode instead of crashing", () => {
+    // wasm executable + asset preimage is decodable XDR but an invalid pairing
+    const entryXdr = buildEntryXdr(
+      xdr.ContractExecutable.contractExecutableWasm(
+        new xdr.Hash(Buffer.alloc(32)),
+      ),
+      xdr.ContractIdPreimage.contractIdPreimageFromAsset(
+        xdr.Asset.assetTypeNative(),
+      ),
+    );
+
+    const { getByText, getByTestId } = renderWithProviders(
+      <DappAuthEntryDisplay entryXdr={entryXdr} expandAll />,
+    );
+
+    expect(
+      getByText("signTransactionDetails.authorizations.unrecognizedInvocation"),
+    ).toBeTruthy();
+    expect(getByTestId("UnrecognizedInvocationWarning")).toBeTruthy();
+  });
+});

--- a/__tests__/ducks/transactionBuilder.test.ts
+++ b/__tests__/ducks/transactionBuilder.test.ts
@@ -465,7 +465,7 @@ describe("transactionBuilder Duck", () => {
         transactionService.buildSendCollectibleTransaction as jest.Mock
       ).mockResolvedValue({
         xdr: mockBuiltXDR,
-        tx: { toXDR: () => mockBuiltXDR, sequence: "1" },
+        tx: { toXdr: () => mockBuiltXDR, sequence: "1" },
       });
       (
         transactionService.simulateCollectibleTransfer as jest.Mock

--- a/__tests__/helpers/soroban.test.ts
+++ b/__tests__/helpers/soroban.test.ts
@@ -1,4 +1,4 @@
-import { Address, xdr } from "@stellar/stellar-sdk";
+import { Address, Keypair, xdr } from "@stellar/stellar-sdk";
 import { BigNumber } from "bignumber.js";
 import {
   ClassicBalance,
@@ -10,6 +10,12 @@ import {
   computeTotalFeeXlm,
   getArgsForTokenInvocation,
   getAuthEntryBoundAddress,
+  getInvocationArgs,
+  getInvocationDetails,
+  INVOCATION_TYPE_EXTERNAL_REF,
+  INVOCATION_TYPE_UNRECOGNIZED,
+  INVOCATION_TYPE_WASM,
+  scValByType,
   SorobanTokenInterface,
   addressToString,
   isSorobanTransaction,
@@ -24,6 +30,10 @@ jest.mock("helpers/soroban", () => {
     isContractId: (address: string) => mockIsContractId(address),
   };
 });
+
+// A well-formed contract strkey used as an executable owner / address fixture.
+const OWNER_CONTRACT =
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 
 describe("soroban helpers", () => {
   describe("getArgsForTokenInvocation", () => {
@@ -44,8 +54,8 @@ describe("soroban helpers", () => {
         // Mock i128 amount for token transfer
         const mockAmount = xdr.ScVal.scvI128(
           new xdr.Int128Parts({
-            lo: xdr.Uint64.fromString("1000000"),
-            hi: xdr.Int64.fromString("0"),
+            lo: BigInt("1000000"),
+            hi: BigInt(0),
           }),
         );
 
@@ -106,8 +116,8 @@ describe("soroban helpers", () => {
         );
         const mockAmount = xdr.ScVal.scvI128(
           new xdr.Int128Parts({
-            lo: xdr.Uint64.fromString("1000000"),
-            hi: xdr.Int64.fromString("0"),
+            lo: BigInt("1000000"),
+            hi: BigInt(0),
           }),
         );
 
@@ -161,8 +171,8 @@ describe("soroban helpers", () => {
         );
         const mockAmount = xdr.ScVal.scvI128(
           new xdr.Int128Parts({
-            lo: xdr.Uint64.fromString("5000000"),
-            hi: xdr.Int64.fromString("0"),
+            lo: BigInt("5000000"),
+            hi: BigInt(0),
           }),
         );
         // Add a dummy third argument to satisfy the implementation
@@ -223,9 +233,9 @@ describe("soroban helpers", () => {
     });
 
     it("should convert contract address to string", () => {
-      // Buffer extends Uint8Array, which is compatible with the Hash type expected by stellar-sdk
+      // v17: ScAddress contract ids are xdr.ContractId wrappers, not raw bytes.
       const mockAddress = xdr.ScAddress.scAddressTypeContract(
-        Buffer.alloc(32, 1) as any,
+        new xdr.ContractId(Buffer.alloc(32, 1)),
       );
 
       const result = addressToString(mockAddress);
@@ -259,7 +269,7 @@ describe("soroban helpers", () => {
     const addressCreds = () =>
       new xdr.SorobanAddressCredentials({
         address: new Address(BOUND_ADDRESS).toScAddress(),
-        nonce: xdr.Int64.fromString("1") as xdr.Int64,
+        nonce: BigInt("1"),
         signatureExpirationLedger: 999999,
         signature: xdr.ScVal.scvVoid(),
       });
@@ -301,6 +311,223 @@ describe("soroban helpers", () => {
         ),
       );
       expect(getAuthEntryBoundAddress(entry)).toBe(BOUND_ADDRESS);
+    });
+  });
+
+  describe("getInvocationDetails", () => {
+    const deployer = Keypair.random().publicKey();
+
+    const buildCreateInvocation = (
+      executable: xdr.ContractExecutable,
+      constructorArgs?: xdr.ScVal[],
+    ) => {
+      const preimage = xdr.ContractIdPreimage.contractIdPreimageFromAddress(
+        new xdr.ContractIdPreimageFromAddress({
+          address: new Address(deployer).toScAddress(),
+          salt: new xdr.Uint256Bytes(Buffer.alloc(32, 7)),
+        }),
+      );
+      const fn = constructorArgs
+        ? xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractV2HostFn(
+            new xdr.CreateContractArgsV2({
+              contractIdPreimage: preimage,
+              executable,
+              constructorArgs,
+            }),
+          )
+        : xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractHostFn(
+            new xdr.CreateContractArgs({
+              contractIdPreimage: preimage,
+              executable,
+            }),
+          );
+      return new xdr.SorobanAuthorizedInvocation({
+        function: fn,
+        subInvocations: [],
+      });
+    };
+
+    it("describes a wasm contract creation", () => {
+      const invocation = buildCreateInvocation(
+        xdr.ContractExecutable.contractExecutableWasm(
+          new xdr.Hash(Buffer.alloc(32, 9)),
+        ),
+      );
+
+      const [details] = getInvocationDetails(invocation);
+
+      expect(details.type).toBe(INVOCATION_TYPE_WASM);
+      if (details.type !== INVOCATION_TYPE_WASM) throw new Error("unreachable");
+      expect(details.hash).toBe("09".repeat(32));
+      expect(details.salt).toBe("07".repeat(32));
+      expect(details.address).toBe(deployer);
+    });
+
+    it("describes a CAP-85 external-executable contract creation (Protocol 28)", () => {
+      const invocation = buildCreateInvocation(
+        xdr.ContractExecutable.contractExecutableExternalRef(
+          new xdr.ContractExecutableExternalRef({
+            executableOwner: new Address(OWNER_CONTRACT).toScAddress(),
+            tag: "token-v2",
+          }),
+        ),
+        [xdr.ScVal.scvU32(1)],
+      );
+
+      // Round-trip through XDR so the assertion covers the decode path a dapp
+      // request actually takes.
+      const decoded = xdr.SorobanAuthorizedInvocation.fromXdr(
+        invocation.toXdr("base64"),
+        "base64",
+      );
+      const [details] = getInvocationDetails(decoded);
+
+      expect(details.type).toBe(INVOCATION_TYPE_EXTERNAL_REF);
+      if (details.type !== INVOCATION_TYPE_EXTERNAL_REF) {
+        throw new Error("unreachable");
+      }
+      expect(details.owner).toBe(OWNER_CONTRACT);
+      expect(details.tag).toBe("token-v2");
+      expect(details.salt).toBe("07".repeat(32));
+      expect(details.address).toBe(deployer);
+      expect(details.args).toHaveLength(1);
+    });
+
+    it("omits address/salt for an external-executable creation whose preimage is not the address arm", () => {
+      // The preimage arm is independent of the executable arm in XDR; the
+      // reference itself is still described.
+      const invocation = new xdr.SorobanAuthorizedInvocation({
+        function:
+          xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractHostFn(
+            new xdr.CreateContractArgs({
+              contractIdPreimage:
+                xdr.ContractIdPreimage.contractIdPreimageFromAsset(
+                  xdr.Asset.assetTypeNative(),
+                ),
+              executable: xdr.ContractExecutable.contractExecutableExternalRef(
+                new xdr.ContractExecutableExternalRef({
+                  executableOwner: new Address(OWNER_CONTRACT).toScAddress(),
+                  tag: "v2",
+                }),
+              ),
+            }),
+          ),
+        subInvocations: [],
+      });
+
+      expect(getInvocationArgs(invocation)).toEqual({
+        type: INVOCATION_TYPE_EXTERNAL_REF,
+        owner: OWNER_CONTRACT,
+        tag: "v2",
+      });
+    });
+
+    it("explains which executable/preimage pairing was invalid when it throws", () => {
+      const assetPreimage = xdr.ContractIdPreimage.contractIdPreimageFromAsset(
+        xdr.Asset.assetTypeNative(),
+      );
+      const addressPreimage =
+        xdr.ContractIdPreimage.contractIdPreimageFromAddress(
+          new xdr.ContractIdPreimageFromAddress({
+            address: new Address(deployer).toScAddress(),
+            salt: new xdr.Uint256Bytes(Buffer.alloc(32)),
+          }),
+        );
+      const build = (
+        executable: xdr.ContractExecutable,
+        contractIdPreimage: xdr.ContractIdPreimage,
+      ) =>
+        new xdr.SorobanAuthorizedInvocation({
+          function:
+            xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractHostFn(
+              new xdr.CreateContractArgs({ contractIdPreimage, executable }),
+            ),
+          subInvocations: [],
+        });
+
+      // wasm code must be deployed from an address, never derived from an asset
+      expect(() =>
+        getInvocationArgs(
+          build(
+            xdr.ContractExecutable.contractExecutableWasm(
+              new xdr.Hash(Buffer.alloc(32)),
+            ),
+            assetPreimage,
+          ),
+        ),
+      ).toThrow(/wasm executable.*contractIdPreimageFromAsset/);
+
+      // and a SAC is only ever derived from an asset
+      expect(() =>
+        getInvocationArgs(
+          build(
+            xdr.ContractExecutable.contractExecutableStellarAsset(),
+            addressPreimage,
+          ),
+        ),
+      ).toThrow(/Stellar asset executable.*contractIdPreimageFromAddress/);
+    });
+
+    it("marks an invocation it cannot parse as unrecognized instead of throwing", () => {
+      // A wasm executable paired with an asset preimage is decodable XDR but a
+      // nonsensical combination -- the kind of thing a future protocol arm or a
+      // hostile dApp could produce. It must not crash the review UI.
+      const invocation = new xdr.SorobanAuthorizedInvocation({
+        function:
+          xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractHostFn(
+            new xdr.CreateContractArgs({
+              contractIdPreimage:
+                xdr.ContractIdPreimage.contractIdPreimageFromAsset(
+                  xdr.Asset.assetTypeNative(),
+                ),
+              executable: xdr.ContractExecutable.contractExecutableWasm(
+                new xdr.Hash(Buffer.alloc(32)),
+              ),
+            }),
+          ),
+        subInvocations: [],
+      });
+
+      expect(getInvocationDetails(invocation)).toEqual([
+        { type: INVOCATION_TYPE_UNRECOGNIZED },
+      ]);
+    });
+  });
+
+  describe("scValByType", () => {
+    it("decodes a CAP-85 executable tag like a string", () => {
+      expect(scValByType(xdr.ScVal.scvExecutableTag("token-v2"))).toBe(
+        "token-v2",
+      );
+    });
+
+    it("hex-encodes string payloads that are not valid UTF-8", () => {
+      expect(
+        scValByType(xdr.ScVal.scvString(new Uint8Array([0xff, 0xfe]))),
+      ).toBe("fffe");
+    });
+
+    it("hex-encodes bytes", () => {
+      expect(scValByType(xdr.ScVal.scvBytes(new Uint8Array([1, 2, 255])))).toBe(
+        "0102ff",
+      );
+    });
+
+    it("returns a strkey for account and contract addresses", () => {
+      const account = Keypair.random().publicKey();
+      expect(
+        scValByType(xdr.ScVal.scvAddress(new Address(account).toScAddress())),
+      ).toBe(account);
+      expect(
+        scValByType(
+          xdr.ScVal.scvAddress(new Address(OWNER_CONTRACT).toScAddress()),
+        ),
+      ).toBe(OWNER_CONTRACT);
+    });
+
+    it("stringifies integers", () => {
+      expect(scValByType(xdr.ScVal.scvU32(7))).toBe("7");
+      expect(scValByType(xdr.ScVal.scvI64(BigInt("-5")))).toBe("-5");
     });
   });
 

--- a/__tests__/helpers/soroban.test.ts
+++ b/__tests__/helpers/soroban.test.ts
@@ -393,9 +393,31 @@ describe("soroban helpers", () => {
       expect(details.args).toHaveLength(1);
     });
 
-    it("omits address/salt for an external-executable creation whose preimage is not the address arm", () => {
-      // The preimage arm is independent of the executable arm in XDR; the
-      // reference itself is still described.
+    it("renders a non-UTF-8 external-executable tag in its reversible SEP-51 form", () => {
+      // Two distinct binary tags must not collapse to the same replacement
+      // characters: the tag decides which executable runs.
+      const invocation = buildCreateInvocation(
+        xdr.ContractExecutable.contractExecutableExternalRef(
+          new xdr.ContractExecutableExternalRef({
+            executableOwner: new Address(OWNER_CONTRACT).toScAddress(),
+            tag: new Uint8Array([0xff, 0xfe]),
+          }),
+        ),
+      );
+
+      const [details] = getInvocationDetails(invocation);
+
+      expect(details.type).toBe(INVOCATION_TYPE_EXTERNAL_REF);
+      if (details.type !== INVOCATION_TYPE_EXTERNAL_REF) {
+        throw new Error("unreachable");
+      }
+      expect(details.tag).toBe("\\xff\\xfe");
+    });
+
+    it("rejects an external-executable creation whose preimage is not the address arm", () => {
+      // Like the SDK's own invocation decoder: an external reference deploys
+      // from an address, so this pairing is invalid and must surface as
+      // unrecognized rather than as a normal contract creation.
       const invocation = new xdr.SorobanAuthorizedInvocation({
         function:
           xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeCreateContractHostFn(
@@ -415,11 +437,12 @@ describe("soroban helpers", () => {
         subInvocations: [],
       });
 
-      expect(getInvocationArgs(invocation)).toEqual({
-        type: INVOCATION_TYPE_EXTERNAL_REF,
-        owner: OWNER_CONTRACT,
-        tag: "v2",
-      });
+      expect(() => getInvocationArgs(invocation)).toThrow(
+        /external executable reference.*contractIdPreimageFromAsset/,
+      );
+      expect(getInvocationDetails(invocation)).toEqual([
+        { type: INVOCATION_TYPE_UNRECOGNIZED },
+      ]);
     });
 
     it("explains which executable/preimage pairing was invalid when it throws", () => {
@@ -499,6 +522,12 @@ describe("soroban helpers", () => {
       expect(scValByType(xdr.ScVal.scvExecutableTag("token-v2"))).toBe(
         "token-v2",
       );
+    });
+
+    it("keeps a non-UTF-8 executable tag distinguishable via its SEP-51 form", () => {
+      expect(
+        scValByType(xdr.ScVal.scvExecutableTag(new Uint8Array([0xff, 0xfe]))),
+      ).toBe("\\xff\\xfe");
     });
 
     it("hex-encodes string payloads that are not valid UTF-8", () => {

--- a/__tests__/helpers/stellar.test.ts
+++ b/__tests__/helpers/stellar.test.ts
@@ -23,6 +23,7 @@ import {
   signMessage,
   truncateAddress,
   truncateFedAddress,
+  formattedBuffer,
 } from "helpers/stellar";
 
 jest.mock("@stellar/stellar-sdk", () => {
@@ -47,7 +48,7 @@ jest.mock("@stellar/stellar-sdk", () => {
         sequenceNumber: () => account.sequenceNumber(),
         incrementSequenceNumber: jest.fn(),
         setId: jest.fn(),
-        toXDRObject: jest.fn(),
+        toXdrObject: jest.fn(),
         equals: jest.fn(),
       })),
       {
@@ -65,7 +66,7 @@ jest.mock("@stellar/stellar-sdk", () => {
             sequenceNumber: () => sequenceNum,
             incrementSequenceNumber: jest.fn(),
             setId: jest.fn(),
-            toXDRObject: jest.fn(),
+            toXdrObject: jest.fn(),
             equals: jest.fn(),
           })),
       },
@@ -305,6 +306,25 @@ describe("Stellar helpers", () => {
       expect(truncateAddress("")).toBe("");
       expect(truncateAddress(null as unknown as string)).toBe("");
       expect(truncateAddress(undefined as unknown as string)).toBe("");
+    });
+  });
+
+  describe("formattedBuffer", () => {
+    const bytes = new Uint8Array(32).fill(0xab);
+    const hex = "ab".repeat(32);
+
+    it("renders raw bytes as truncated uppercase hex", () => {
+      expect(formattedBuffer(bytes)).toBe(truncateAddress("AB".repeat(32)));
+    });
+
+    it("passes through a string that is already hex", () => {
+      // SDK 17's revokeSignerSponsorship arm hands us hex strings, not bytes,
+      // for sha256Hash / preAuthTx signer keys.
+      expect(formattedBuffer(hex)).toBe(truncateAddress("AB".repeat(32)));
+    });
+
+    it("renders bytes and their hex string identically", () => {
+      expect(formattedBuffer(hex)).toBe(formattedBuffer(bytes));
     });
   });
 
@@ -576,7 +596,8 @@ describe("Stellar helpers", () => {
         const message = "Hello, Stellar!";
         const encoded = encodeSep53Message(message);
 
-        expect(encoded).toBeInstanceOf(Buffer);
+        // v17: hash() returns a plain Uint8Array, not a Buffer.
+        expect(encoded).toBeInstanceOf(Uint8Array);
         expect(encoded.length).toBe(32); // SHA-256 hash is 32 bytes
       });
 
@@ -584,7 +605,8 @@ describe("Stellar helpers", () => {
         const message = "";
         const encoded = encodeSep53Message(message);
 
-        expect(encoded).toBeInstanceOf(Buffer);
+        // v17: hash() returns a plain Uint8Array, not a Buffer.
+        expect(encoded).toBeInstanceOf(Uint8Array);
         expect(encoded.length).toBe(32);
       });
 
@@ -592,7 +614,8 @@ describe("Stellar helpers", () => {
         const message = "Hello 世界! 🌟";
         const encoded = encodeSep53Message(message);
 
-        expect(encoded).toBeInstanceOf(Buffer);
+        // v17: hash() returns a plain Uint8Array, not a Buffer.
+        expect(encoded).toBeInstanceOf(Uint8Array);
         expect(encoded.length).toBe(32);
       });
 
@@ -764,11 +787,11 @@ describe("Stellar helpers", () => {
       return xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
         new xdr.HashIdPreimageSorobanAuthorization({
           networkId: hash(Buffer.from(network)),
-          nonce: xdr.Int64.fromString(nonce) as xdr.Int64,
+          nonce: BigInt(nonce),
           signatureExpirationLedger: 999999,
           invocation,
         }),
-      ).toXDR("base64");
+      ).toXdr("base64");
     };
 
     /**
@@ -797,12 +820,12 @@ describe("Stellar helpers", () => {
       return xdr.HashIdPreimage.envelopeTypeSorobanAuthorizationWithAddress(
         new xdr.HashIdPreimageSorobanAuthorizationWithAddress({
           networkId: hash(Buffer.from(network)),
-          nonce: xdr.Int64.fromString(nonce) as xdr.Int64,
+          nonce: BigInt(nonce),
           signatureExpirationLedger: 999999,
           address: new Address(address).toScAddress(),
           invocation,
         }),
-      ).toXDR("base64");
+      ).toXdr("base64");
     };
 
     describe("signAuthEntry", () => {

--- a/__tests__/helpers/stellarSdkV15.test.ts
+++ b/__tests__/helpers/stellarSdkV15.test.ts
@@ -45,8 +45,8 @@ describe("Stellar SDK v15 compatibility", () => {
         .setTimeout(30)
         .build();
 
-      const xdrString = tx.toXDR();
-      const restored = TransactionBuilder.fromXDR(
+      const xdrString = tx.toXdr();
+      const restored = TransactionBuilder.fromXdr(
         xdrString,
         networkPassphrase,
       ) as Transaction;
@@ -80,8 +80,8 @@ describe("Stellar SDK v15 compatibility", () => {
         networkPassphrase,
       );
 
-      const xdrString = feeBump.toXDR();
-      const restored = TransactionBuilder.fromXDR(xdrString, networkPassphrase);
+      const xdrString = feeBump.toXdr();
+      const restored = TransactionBuilder.fromXdr(xdrString, networkPassphrase);
 
       expect(restored).toBeInstanceOf(FeeBumpTransaction);
     });
@@ -107,7 +107,9 @@ describe("Stellar SDK v15 compatibility", () => {
       tx.sign(keypair);
       expect(tx.signatures.length).toBe(1);
 
-      const sigBytes = tx.signatures[0].signature();
+      // v17: DecoratedSignature.signature is an xdr.Signature wrapper — unwrap
+      // to bytes before checking the length.
+      const sigBytes = tx.signatures[0].signature.toBytes();
       expect(sigBytes.length).toBe(64);
     });
   });
@@ -159,9 +161,10 @@ describe("Stellar SDK v15 compatibility", () => {
   });
 
   describe("hash function", () => {
-    it("returns a 32-byte Buffer for network passphrase", () => {
+    it("returns 32 bytes for network passphrase", () => {
       const result = hash(Buffer.from(networkPassphrase));
-      expect(result).toBeInstanceOf(Buffer);
+      // v17: byte-returning APIs hand back a plain Uint8Array, not a Buffer.
+      expect(result).toBeInstanceOf(Uint8Array);
       expect(result.length).toBe(32);
     });
 
@@ -169,7 +172,7 @@ describe("Stellar SDK v15 compatibility", () => {
       const input = Buffer.from("test-input");
       const hash1 = hash(input);
       const hash2 = hash(input);
-      expect(hash1.toString("hex")).toBe(hash2.toString("hex"));
+      expect(xdr.encodeBytes(hash1, "hex")).toBe(xdr.encodeBytes(hash2, "hex"));
     });
   });
 
@@ -197,14 +200,14 @@ describe("Stellar SDK v15 compatibility", () => {
     it("constructs and reads an ScVal i128", () => {
       const scVal = xdr.ScVal.scvI128(
         new xdr.Int128Parts({
-          lo: xdr.Uint64.fromString("1000000"),
-          hi: xdr.Int64.fromString("0"),
+          lo: BigInt("1000000"),
+          hi: BigInt("0"),
         }),
       );
-      expect(scVal.switch().name).toBe("scvI128");
-      const parts = scVal.i128();
-      expect(parts.lo().toString()).toBe("1000000");
-      expect(parts.hi().toString()).toBe("0");
+      expect(scVal.type).toBe("scvI128");
+      const parts = xdr.expectUnionVariant(scVal, "scvI128").i128;
+      expect(parts.lo.toString()).toBe("1000000");
+      expect(parts.hi.toString()).toBe("0");
     });
 
     it("constructs an ScAddress for an account", () => {
@@ -213,7 +216,7 @@ describe("Stellar SDK v15 compatibility", () => {
           StrKey.decodeEd25519PublicKey(keypair.publicKey()),
         ),
       );
-      expect(scAddr.switch().name).toBe("scAddressTypeAccount");
+      expect(scAddr.type).toBe("scAddressTypeAccount");
     });
   });
 
@@ -240,7 +243,7 @@ describe("Stellar SDK v15 compatibility", () => {
       const credentials = xdr.SorobanCredentials.sorobanCredentialsAddressV2(
         new xdr.SorobanAddressCredentials({
           address: new Address(keypair.publicKey()).toScAddress(),
-          nonce: xdr.Int64.fromString("1") as xdr.Int64,
+          nonce: BigInt(1),
           signatureExpirationLedger: 999999,
           signature: xdr.ScVal.scvVoid(),
         }),
@@ -251,22 +254,27 @@ describe("Stellar SDK v15 compatibility", () => {
         rootInvocation: invocation,
       });
 
-      // The signing-review screens only read rootInvocation() and never
+      // The signing-review screens only read rootInvocation and never
       // switch on credentials — this locks that assumption for ADDRESS_V2.
-      const roundtripped = xdr.SorobanAuthorizationEntry.fromXDR(
-        entry.toXDR("base64"),
+      const roundtripped = xdr.SorobanAuthorizationEntry.fromXdr(
+        entry.toXdr("base64"),
         "base64",
       );
-      const root = roundtripped.rootInvocation();
+      const root = roundtripped.rootInvocation;
       expect(root).toBeInstanceOf(xdr.SorobanAuthorizedInvocation);
-      expect(root.function().contractFn().functionName().toString()).toBe(
-        "transfer",
-      );
+      expect(
+        xdr
+          .expectUnionVariant(
+            root.function,
+            "sorobanAuthorizedFunctionTypeContractFn",
+          )
+          .contractFn.functionName.toString(),
+      ).toBe("transfer");
 
       // walkInvocationTree (used by getInvocationDetails) traverses it fine
       const visited: string[] = [];
       walkInvocationTree(root, (node) => {
-        visited.push(node.function().switch().name);
+        visited.push(node.function.type);
         return true;
       });
       expect(visited.length).toBe(1);

--- a/__tests__/helpers/walletKitValidation.test.ts
+++ b/__tests__/helpers/walletKitValidation.test.ts
@@ -48,11 +48,11 @@ const buildTestPreimage = (
   xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
     new xdr.HashIdPreimageSorobanAuthorization({
       networkId: hash(Buffer.from(network)),
-      nonce: xdr.Int64.fromString(nonce) as xdr.Int64,
+      nonce: BigInt(nonce),
       signatureExpirationLedger: 999999,
       invocation: buildTestInvocation(),
     }),
-  ).toXDR("base64");
+  ).toXdr("base64");
 
 /**
  * Builds a base64 CAP-71 envelopeTypeSorobanAuthorizationWithAddress preimage,
@@ -66,22 +66,22 @@ const buildTestWithAddressPreimage = (
   xdr.HashIdPreimage.envelopeTypeSorobanAuthorizationWithAddress(
     new xdr.HashIdPreimageSorobanAuthorizationWithAddress({
       networkId: hash(Buffer.from(network)),
-      nonce: xdr.Int64.fromString(nonce) as xdr.Int64,
+      nonce: BigInt(nonce),
       signatureExpirationLedger: 999999,
       address: new Address(signerAddress).toScAddress(),
       invocation: buildTestInvocation(),
     }),
-  ).toXDR("base64");
+  ).toXdr("base64");
 
 /** Builds a real non-Soroban-authorization preimage (operation ID arm). */
 const buildNonSorobanPreimage = (): string =>
   xdr.HashIdPreimage.envelopeTypeOpId(
     new xdr.HashIdPreimageOperationId({
       sourceAccount: Keypair.fromPublicKey(TEST_SIGNER_ADDRESS).xdrAccountId(),
-      seqNum: xdr.Int64.fromString("1") as xdr.Int64,
+      seqNum: BigInt("1"),
       opNum: 0,
     }),
-  ).toXDR("base64");
+  ).toXdr("base64");
 
 // ─────────────────────────────────────────────────────────────────────────────
 // validateSignMessageContent
@@ -278,7 +278,7 @@ describe("parseAuthEntryPreimage", () => {
     const result = parseAuthEntryPreimage(preimageXdr);
     expect(result.valid).toBe(true);
     if (result.valid) {
-      expect(result.value.toXDR("base64")).toBe(preimageXdr);
+      expect(result.value.toXdr("base64")).toBe(preimageXdr);
     }
   });
 });
@@ -289,12 +289,15 @@ describe("parseAuthEntryPreimage", () => {
 
 describe("normalizeAuthPreimage", () => {
   it("normalizes a legacy sorobanAuthorization preimage without an address", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(buildTestPreimage(), "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(buildTestPreimage(), "base64");
     const normalized = normalizeAuthPreimage(preimage);
     expect(normalized).not.toBeNull();
     expect(normalized?.address).toBeUndefined();
+    // v17: networkId is an xdr.Hash wrapper; compare against a wrapped hash.
     expect(
-      normalized?.networkId.equals(hash(Buffer.from(Networks.TESTNET))),
+      normalized?.networkId.equals(
+        new xdr.Hash(hash(Buffer.from(Networks.TESTNET))),
+      ),
     ).toBe(true);
     expect(normalized?.invocation).toBeInstanceOf(
       xdr.SorobanAuthorizedInvocation,
@@ -302,7 +305,7 @@ describe("normalizeAuthPreimage", () => {
   });
 
   it("returns null for a non-Soroban-authorization preimage arm", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildNonSorobanPreimage(),
       "base64",
     );
@@ -319,7 +322,7 @@ describe("normalizeAuthPreimage", () => {
   });
 
   it("normalizes a CAP-71 sorobanAuthorizationWithAddress preimage and surfaces the address", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildTestWithAddressPreimage(),
       "base64",
     );
@@ -342,7 +345,7 @@ describe("normalizeAuthPreimage", () => {
 describe("validateAuthEntryNetwork", () => {
   it("returns valid when preimage networkId matches the wallet network", () => {
     const preimageXdr = buildTestPreimage(Networks.TESTNET);
-    const preimage = xdr.HashIdPreimage.fromXDR(preimageXdr, "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(preimageXdr, "base64");
     const result = validateAuthEntryNetwork(preimage, Networks.TESTNET);
     expect(result.valid).toBe(true);
     if (result.valid) {
@@ -352,7 +355,7 @@ describe("validateAuthEntryNetwork", () => {
 
   it("returns network mismatch error when preimage is for mainnet but wallet is on testnet", () => {
     const preimageXdr = buildTestPreimage(Networks.PUBLIC);
-    const preimage = xdr.HashIdPreimage.fromXDR(preimageXdr, "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(preimageXdr, "base64");
     const result = validateAuthEntryNetwork(preimage, Networks.TESTNET);
     expect(result.valid).toBe(false);
     if (!result.valid) {
@@ -364,7 +367,7 @@ describe("validateAuthEntryNetwork", () => {
 
   it("returns network mismatch error when preimage is for testnet but wallet is on mainnet", () => {
     const preimageXdr = buildTestPreimage(Networks.TESTNET);
-    const preimage = xdr.HashIdPreimage.fromXDR(preimageXdr, "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(preimageXdr, "base64");
     const result = validateAuthEntryNetwork(preimage, Networks.PUBLIC);
     expect(result.valid).toBe(false);
     if (!result.valid) {
@@ -376,7 +379,7 @@ describe("validateAuthEntryNetwork", () => {
 
   it("returns valid for mainnet preimage with mainnet passphrase", () => {
     const preimageXdr = buildTestPreimage(Networks.PUBLIC);
-    const preimage = xdr.HashIdPreimage.fromXDR(preimageXdr, "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(preimageXdr, "base64");
     const result = validateAuthEntryNetwork(preimage, Networks.PUBLIC);
     expect(result.valid).toBe(true);
   });
@@ -400,7 +403,7 @@ describe("validateAuthEntryNetwork", () => {
   });
 
   it("returns invalid auth entry error for a non-Soroban-authorization preimage arm", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildNonSorobanPreimage(),
       "base64",
     );
@@ -412,7 +415,7 @@ describe("validateAuthEntryNetwork", () => {
   });
 
   it("returns valid when a CAP-71 withAddress preimage networkId matches the wallet network", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildTestWithAddressPreimage(Networks.TESTNET),
       "base64",
     );
@@ -424,7 +427,7 @@ describe("validateAuthEntryNetwork", () => {
   });
 
   it("returns network mismatch error for a CAP-71 withAddress preimage on the wrong network", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildTestWithAddressPreimage(Networks.PUBLIC),
       "base64",
     );
@@ -541,7 +544,7 @@ describe("validateSignAuthEntry", () => {
     );
     expect(result.valid).toBe(true);
     if (result.valid) {
-      expect(result.value.toXDR("base64")).toBe(preimageXdr);
+      expect(result.value.toXdr("base64")).toBe(preimageXdr);
     }
   });
 
@@ -554,7 +557,7 @@ describe("validateSignAuthEntry", () => {
     );
     expect(result.valid).toBe(true);
     if (result.valid) {
-      expect(result.value.toXDR("base64")).toBe(preimageXdr);
+      expect(result.value.toXdr("base64")).toBe(preimageXdr);
     }
   });
 
@@ -595,13 +598,13 @@ describe("validateSignAuthEntry", () => {
 
 describe("validateAuthEntryAddress", () => {
   it("passes a legacy preimage through (no bound address to enforce)", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(buildTestPreimage(), "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(buildTestPreimage(), "base64");
     const result = validateAuthEntryAddress(preimage, OTHER_WALLET_ADDRESS);
     expect(result.valid).toBe(true);
   });
 
   it("returns valid when the bound address matches the wallet", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildTestWithAddressPreimage(Networks.TESTNET, "1", TEST_SIGNER_ADDRESS),
       "base64",
     );
@@ -610,7 +613,7 @@ describe("validateAuthEntryAddress", () => {
   });
 
   it("returns address mismatch when the bound account differs from the wallet", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildTestWithAddressPreimage(Networks.TESTNET, "1", TEST_SIGNER_ADDRESS),
       "base64",
     );
@@ -624,7 +627,7 @@ describe("validateAuthEntryAddress", () => {
   });
 
   it("rejects a contract-bound address (delegated auth is not supported — freighter-mobile#894)", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildTestWithAddressPreimage(
         Networks.TESTNET,
         "1",
@@ -642,7 +645,7 @@ describe("validateAuthEntryAddress", () => {
   });
 
   it("returns invalid for a non-Soroban-authorization preimage", () => {
-    const preimage = xdr.HashIdPreimage.fromXDR(
+    const preimage = xdr.HashIdPreimage.fromXdr(
       buildNonSorobanPreimage(),
       "base64",
     );

--- a/__tests__/hooks/useValidateTransactionMemo.test.tsx
+++ b/__tests__/hooks/useValidateTransactionMemo.test.tsx
@@ -31,7 +31,7 @@ jest.mock("config/logger", () => ({
 
 jest.mock("@stellar/stellar-sdk", () => ({
   TransactionBuilder: {
-    fromXDR: jest.fn((xdr: string) => {
+    fromXdr: jest.fn((xdr: string) => {
       if (
         xdr ===
         "AAAAAgAAAABlgrTOmQt826u8R+HKOeuICKO/worYIyYW8m9U0aSaZgAAAGQDeoz1AAAAvAAAAAEAAAAAAAAAAAAAAABo7RV7AAAAAAAAAAEAAAAAAAAAAQAAAABK9RdfXO7+12qzjvy5REcU2QEoutCIRI30uL/x3hfp5QAAAAAAAAAACePMNwAAAAAAAAAA"

--- a/__tests__/services/api.test.ts
+++ b/__tests__/services/api.test.ts
@@ -79,7 +79,7 @@ jest.mock("@stellar/stellar-sdk", () => ({
     },
   },
   TransactionBuilder: {
-    fromXDR: jest.fn(),
+    fromXdr: jest.fn(),
   },
 }));
 

--- a/__tests__/services/auth/buildAuthJwt.test.ts
+++ b/__tests__/services/auth/buildAuthJwt.test.ts
@@ -1,4 +1,4 @@
-import { Keypair } from "@stellar/stellar-sdk";
+import { Keypair, xdr } from "@stellar/stellar-sdk";
 import {
   ISS,
   JWT_LIFETIME_SECONDS,
@@ -54,7 +54,9 @@ describe("buildAuthJwt", () => {
     });
 
     it("has sub = raw public key hex", () => {
-      expect(payloadJson.sub).toBe(keypair.rawPublicKey().toString("hex"));
+      expect(payloadJson.sub).toBe(
+        xdr.encodeBytes(keypair.rawPublicKey(), "hex"),
+      );
     });
 
     it("has iss = 'freighter-mobile'", () => {

--- a/__tests__/services/auth/getAuthKeypair.test.ts
+++ b/__tests__/services/auth/getAuthKeypair.test.ts
@@ -1,3 +1,4 @@
+import { xdr } from "@stellar/stellar-sdk";
 import * as authDuck from "ducks/auth";
 import { clearAuthKeypairCache } from "services/auth/authKeypairCache";
 import { AUTH_KEYPAIR_VECTORS } from "services/auth/authKeypairVectors";
@@ -27,7 +28,7 @@ describe("getAuthKeypair", () => {
     const a = await getAuthKeypair();
     const b = await getAuthKeypair();
     expect(a).not.toBeNull();
-    expect(a!.rawPublicKey().toString("hex")).toBe(M.userId);
+    expect(xdr.encodeBytes(a!.rawPublicKey(), "hex")).toBe(M.userId);
     expect(b).toBe(a); // same cached instance
     expect(mockMnemonic).toHaveBeenCalledTimes(1);
   });
@@ -66,7 +67,7 @@ describe("getAuthKeypair", () => {
     clearAuthKeypairCache();
     mockMnemonic.mockResolvedValue(AUTH_KEYPAIR_VECTORS[1].mnemonic);
     const c = await getAuthKeypair();
-    expect(c!.rawPublicKey().toString("hex")).toBe(
+    expect(xdr.encodeBytes(c!.rawPublicKey(), "hex")).toBe(
       AUTH_KEYPAIR_VECTORS[1].userId,
     );
     expect(c).not.toBe(a);

--- a/__tests__/services/backend.test.ts
+++ b/__tests__/services/backend.test.ts
@@ -46,7 +46,7 @@ jest.mock("@stellar/stellar-sdk", () => {
   return {
     ...actual,
     TransactionBuilder: {
-      fromXDR: jest.fn((xdrString: string, networkPassphrase: string) => ({
+      fromXdr: jest.fn((xdrString: string, networkPassphrase: string) => ({
         xdrString,
         networkPassphrase,
         build: jest.fn(),

--- a/__tests__/services/buildPaymentTransactionContractTarget.test.ts
+++ b/__tests__/services/buildPaymentTransactionContractTarget.test.ts
@@ -7,6 +7,7 @@ import {
   Operation,
   Address,
   scValToNative,
+  xdr,
 } from "@stellar/stellar-sdk";
 import { BigNumber } from "bignumber.js";
 import { NETWORKS } from "config/constants";
@@ -87,15 +88,21 @@ const customTokenBalance = {
   tokenCode: "WETH",
 } as unknown as PricedBalance;
 
-const decodeInvocation = (xdr: string) => {
-  const tx = TransactionBuilder.fromXDR(xdr, Networks.TESTNET) as Transaction;
+const decodeInvocation = (xdrString: string) => {
+  const tx = TransactionBuilder.fromXdr(
+    xdrString,
+    Networks.TESTNET,
+  ) as Transaction;
   const op = tx.operations[0] as Operation.InvokeHostFunction;
-  const invoke = op.func.invokeContract();
+  const invoke = xdr.expectUnionVariant(
+    op.func,
+    "hostFunctionTypeInvokeContract",
+  ).invokeContract;
 
   return {
-    invokedContract: Address.fromScAddress(invoke.contractAddress()).toString(),
-    fnName: invoke.functionName().toString(),
-    args: invoke.args().map((arg) => scValToNative(arg)),
+    invokedContract: Address.fromScAddress(invoke.contractAddress).toString(),
+    fnName: invoke.functionName.toString(),
+    args: invoke.args.map((arg) => scValToNative(arg)),
   };
 };
 

--- a/__tests__/services/stellar.test.ts
+++ b/__tests__/services/stellar.test.ts
@@ -182,7 +182,7 @@ describe("buildChangeTrustOperation", () => {
 
   it("returns a changeTrust operation for the requested asset with no explicit limit", () => {
     const op = buildChangeTrustOperation({ tokenCode: "USDC", issuer: ISSUER });
-    const decoded = Operation.fromXDRObject(op);
+    const decoded = Operation.fromXdrObject(op);
 
     expect(decoded.type).toBe("changeTrust");
     expect((decoded as any).line).toBeInstanceOf(SdkToken);
@@ -200,7 +200,7 @@ describe("buildChangeTrustOperation", () => {
       issuer: ISSUER,
       isRemove: true,
     });
-    const decoded = Operation.fromXDRObject(op);
+    const decoded = Operation.fromXdrObject(op);
 
     expect(decoded.type).toBe("changeTrust");
     // The Stellar SDK normalizes the limit to 7 decimal places on decode.

--- a/__tests__/services/transactionService.test.ts
+++ b/__tests__/services/transactionService.test.ts
@@ -6,6 +6,7 @@ import {
   Address,
   Transaction,
   Operation,
+  xdr,
 } from "@stellar/stellar-sdk";
 import { NETWORKS, mapNetworkToNetworkDetails } from "config/constants";
 import { analytics } from "services/analytics";
@@ -76,7 +77,7 @@ describe("buildSendCollectibleTransaction", () => {
   it("should create transaction with correct sender address from parsed XDR", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
@@ -87,7 +88,7 @@ describe("buildSendCollectibleTransaction", () => {
   it("should include invoke host function operation with transfer call", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
@@ -99,7 +100,7 @@ describe("buildSendCollectibleTransaction", () => {
   it("should encode correct contract address in operation", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
@@ -107,10 +108,13 @@ describe("buildSendCollectibleTransaction", () => {
     const operation = parsedTx.operations[0] as Operation.InvokeHostFunction;
     const hostFunction = operation.func;
 
-    expect(hostFunction.switch().name).toBe("hostFunctionTypeInvokeContract");
+    expect(hostFunction.type).toBe("hostFunctionTypeInvokeContract");
 
-    const invokeContractArgs = hostFunction.invokeContract();
-    const contractAddress = invokeContractArgs.contractAddress();
+    const invokeContractArgs = xdr.expectUnionVariant(
+      hostFunction,
+      "hostFunctionTypeInvokeContract",
+    ).invokeContract;
+    const { contractAddress } = invokeContractArgs;
     const addressFromXdr = Address.fromScAddress(contractAddress);
 
     expect(addressFromXdr.toString()).toBe(mockCollectionAddress);
@@ -119,15 +123,18 @@ describe("buildSendCollectibleTransaction", () => {
   it("should call transfer function in the contract", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
 
     const operation = parsedTx.operations[0] as Operation.InvokeHostFunction;
     const hostFunction = operation.func;
-    const invokeContractArgs = hostFunction.invokeContract();
-    const functionName = invokeContractArgs.functionName().toString();
+    const invokeContractArgs = xdr.expectUnionVariant(
+      hostFunction,
+      "hostFunctionTypeInvokeContract",
+    ).invokeContract;
+    const functionName = invokeContractArgs.functionName.toString();
 
     expect(functionName).toBe("transfer");
   });
@@ -135,15 +142,18 @@ describe("buildSendCollectibleTransaction", () => {
   it("should encode correct transfer parameters: from, to, token_id", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
 
     const operation = parsedTx.operations[0] as Operation.InvokeHostFunction;
     const hostFunction = operation.func;
-    const invokeContractArgs = hostFunction.invokeContract();
-    const args = invokeContractArgs.args();
+    const invokeContractArgs = xdr.expectUnionVariant(
+      hostFunction,
+      "hostFunctionTypeInvokeContract",
+    ).invokeContract;
+    const { args } = invokeContractArgs;
 
     // Should have 3 arguments: from, to, token_id
     expect(args).toHaveLength(3);
@@ -158,8 +168,8 @@ describe("buildSendCollectibleTransaction", () => {
 
     // Third argument should be token_id as u32
     const tokenIdScVal = args[2];
-    expect(tokenIdScVal.switch().name).toBe("scvU32");
-    const tokenIdValue = tokenIdScVal.u32();
+    expect(tokenIdScVal.type).toBe("scvU32");
+    const tokenIdValue = xdr.expectUnionVariant(tokenIdScVal, "scvU32").u32;
     expect(tokenIdValue.toString()).toBe("12345");
   });
 
@@ -169,7 +179,7 @@ describe("buildSendCollectibleTransaction", () => {
 
     const result = await buildSendCollectibleTransaction(params);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
@@ -186,7 +196,7 @@ describe("buildSendCollectibleTransaction", () => {
 
     const result = await buildSendCollectibleTransaction(mainnetParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.PUBLIC,
     ) as Transaction;
@@ -241,7 +251,7 @@ describe("buildSendCollectibleTransaction", () => {
   it("should create transaction with correct sequence number", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
@@ -254,16 +264,16 @@ describe("buildSendCollectibleTransaction", () => {
   it("should create XDR that can be successfully parsed and rebuilt", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(result.xdr, Networks.TESTNET);
+    const parsedTx = TransactionBuilder.fromXdr(result.xdr, Networks.TESTNET);
 
-    const reExportedXdr = parsedTx.toXDR();
+    const reExportedXdr = parsedTx.toXdr();
     expect(reExportedXdr).toBe(result.xdr);
   });
 
   it("should set correct timebounds", async () => {
     const result = await buildSendCollectibleTransaction(baseParams);
 
-    const parsedTx = TransactionBuilder.fromXDR(
+    const parsedTx = TransactionBuilder.fromXdr(
       result.xdr,
       Networks.TESTNET,
     ) as Transaction;
@@ -482,7 +492,7 @@ describe("buildSwapTransaction — includeTrustline", () => {
   };
 
   it("prepends a changeTrust op when includeTrustline is provided", async () => {
-    const { xdr } = await buildSwapTransaction({
+    const { xdr: swapXdr } = await buildSwapTransaction({
       ...baseParams,
       includeTrustline: {
         tokenCode: "USDC",
@@ -490,7 +500,10 @@ describe("buildSwapTransaction — includeTrustline", () => {
       },
     });
 
-    const tx = TransactionBuilder.fromXDR(xdr, Networks.PUBLIC) as Transaction;
+    const tx = TransactionBuilder.fromXdr(
+      swapXdr,
+      Networks.PUBLIC,
+    ) as Transaction;
 
     expect(tx.operations).toHaveLength(2);
     expect(tx.operations[0].type).toBe("changeTrust");
@@ -510,9 +523,12 @@ describe("buildSwapTransaction — includeTrustline", () => {
   });
 
   it("builds a single pathPaymentStrictSend op when includeTrustline is omitted (regression)", async () => {
-    const { xdr } = await buildSwapTransaction(baseParams);
+    const { xdr: swapXdr } = await buildSwapTransaction(baseParams);
 
-    const tx = TransactionBuilder.fromXDR(xdr, Networks.PUBLIC) as Transaction;
+    const tx = TransactionBuilder.fromXdr(
+      swapXdr,
+      Networks.PUBLIC,
+    ) as Transaction;
 
     expect(tx.operations).toHaveLength(1);
     expect(tx.operations[0].type).toBe("pathPaymentStrictSend");

--- a/docs/walletconnect-rpc-methods.md
+++ b/docs/walletconnect-rpc-methods.md
@@ -280,26 +280,27 @@ specific contract invocation without submitting a transaction.
 **Building the `entryXdr` on your dApp**
 
 ```typescript
-import { xdr, Networks, hash, Keypair } from "@stellar/stellar-sdk";
+import {
+  buildAuthorizationEntryPreimage,
+  Networks,
+} from "@stellar/stellar-sdk";
 
 // Obtain the SorobanAuthorizationEntry from your contract simulation
 const simulationResult = await server.simulateTransaction(tx);
 const authEntry = simulationResult.result.auth[0]; // SorobanAuthorizationEntry
 
-// Build the HashIdPreimage — this is what the wallet will hash and sign
-const preimage = xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
-  new xdr.HashIdPreimageSorobanAuthorization({
-    networkId: hash(Buffer.from(Networks.PUBLIC)),
-    nonce: authEntry.credentials().address().nonce(),
-    signatureExpirationLedger: authEntry
-      .credentials()
-      .address()
-      .signatureExpirationLedger(),
-    invocation: authEntry.rootInvocation(),
-  }),
+// Build the HashIdPreimage — this is what the wallet will hash and sign.
+// As of stellar-sdk v17 simulation records CAP-71 ADDRESS_V2 credentials by
+// default, whose preimage is the address-bound
+// `envelopeTypeSorobanAuthorizationWithAddress` arm; let the SDK pick the
+// right arm off the entry instead of hand-rolling the legacy one.
+const preimage = buildAuthorizationEntryPreimage(
+  authEntry,
+  validUntilLedgerSeq,
+  Networks.PUBLIC,
 );
 
-const entryXdr = preimage.toXDR("base64");
+const entryXdr = preimage.toXdr("base64");
 
 // Send via WalletConnect
 const result = await walletKit.request({

--- a/docs/walletconnect-rpc-methods.md
+++ b/docs/walletconnect-rpc-methods.md
@@ -289,6 +289,10 @@ import {
 const simulationResult = await server.simulateTransaction(tx);
 const authEntry = simulationResult.result.auth[0]; // SorobanAuthorizationEntry
 
+// The signature is only valid until this ledger; give the user time to review.
+const { sequence } = await server.getLatestLedger();
+const validUntilLedgerSeq = sequence + 100;
+
 // Build the HashIdPreimage — this is what the wallet will hash and sign.
 // As of stellar-sdk v17 simulation records CAP-71 ADDRESS_V2 credentials by
 // default, whose preimage is the address-bound

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,11 +30,13 @@ module.exports = {
       "react-native-keyboard-controller",
       "react-native-qrcode-svg",
       "stellar-hd-wallet",
-      // v16 ships ESM-only deps (@noble/*, smol-toml, uint8array-extras,
-      // eventsource), some nested under the SDK; transform these so Jest can
-      // load the SDK's CJS build.
+      // v17's CJS build `require()`s ESM-only deps (@noble/*, @exodus/bytes,
+      // smol-toml, uint8array-extras, eventsource), some nested under the SDK.
+      // Node 22.12+ loads those natively, but Jest's CJS module registry does
+      // not, so babel has to transform them here.
       "@stellar/stellar-sdk",
       "@noble",
+      "@exodus/bytes",
       "smol-toml",
       "uint8array-extras",
       "eventsource",

--- a/metro.config.js
+++ b/metro.config.js
@@ -66,7 +66,7 @@ const config = {
 
       const resolved = context.resolveRequest(context, moduleName, platform);
 
-      // bignumber.js v11 (pulled in by @stellar/stellar-sdk 16.x) ships a valid
+      // bignumber.js v11 (pulled in by @stellar/stellar-sdk 16.x+) ships a valid
       // CommonJS entry at dist/bignumber.cjs, but its package.json "react-native"
       // field redirects it to dist/bignumber.js — a browser-globals UMD build
       // that sets no module.exports. Metro honors that field, so

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@shopify/react-native-skia": "2.2.21",
     "@stablelib/base64": "2.0.1",
     "@stablelib/utf8": "2.0.1",
-    "@stellar/stellar-sdk": "16.0.0",
+    "@stellar/stellar-sdk": "17.0.1",
     "@stellar/typescript-wallet-sdk-km": "3.0.0",
     "@tradle/react-native-http": "2.0.0",
     "@walletconnect/core": "2.23.1",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "typescript": "5.8.3"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "react-native": {
     "crypto": "react-native-crypto",

--- a/src/components/TransactionDetailsBottomSheet.tsx
+++ b/src/components/TransactionDetailsBottomSheet.tsx
@@ -99,7 +99,7 @@ const TransactionDetailsBottomSheet: React.FC<
     ],
   );
 
-  const transaction = TransactionBuilder.fromXDR(
+  const transaction = TransactionBuilder.fromXdr(
     transactionXDR as string,
     network,
   );

--- a/src/components/screens/SignTransactionDetails/components/KeyVal.tsx
+++ b/src/components/screens/SignTransactionDetails/components/KeyVal.tsx
@@ -583,7 +583,8 @@ export const ExecutableDetails = ({
             operationKey={t(
               "signTransactionDetails.authorizations.executableTag",
             )}
-            operationValue={externalRef.tag.toString()}
+            // SEP-51 form: reversible for non-UTF-8 bytes, plain text otherwise.
+            operationValue={externalRef.tag.toJson()}
           />
           <ExternalExecutableNote />
         </>

--- a/src/components/screens/SignTransactionDetails/components/KeyVal.tsx
+++ b/src/components/screens/SignTransactionDetails/components/KeyVal.tsx
@@ -527,11 +527,11 @@ export const ExternalExecutableNote = () => (
  * reference, and deliberately no wasm hash, because the owner can change the
  * code the reference resolves to after this transaction is signed.
  */
-export const ExecutableDetails = ({
-  executable,
-}: {
+interface ExecutableDetailsProps {
   executable: xdr.ContractExecutable;
-}) => {
+}
+
+export const ExecutableDetails = ({ executable }: ExecutableDetailsProps) => {
   const { copyToClipboard } = useClipboard();
 
   // v17: `wasmHash` is an xdr.Hash wrapper on the wasm arm only; render it as

--- a/src/components/screens/SignTransactionDetails/components/KeyVal.tsx
+++ b/src/components/screens/SignTransactionDetails/components/KeyVal.tsx
@@ -13,11 +13,16 @@ import {
 } from "@stellar/stellar-sdk";
 import Spinner from "components/Spinner";
 import Avatar from "components/sds/Avatar";
+import { Banner } from "components/sds/Banner";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { CLAIM_PREDICATES, mapNetworkToNetworkDetails } from "config/constants";
 import { useAuthenticationStore } from "ducks/auth";
-import { getCreateContractArgs, scValByType } from "helpers/soroban";
+import {
+  addressToString,
+  getCreateContractArgs,
+  scValByType,
+} from "helpers/soroban";
 import { truncateAddress } from "helpers/stellar";
 import { useClipboard } from "hooks/useClipboard";
 import useColors from "hooks/useColors";
@@ -36,12 +41,20 @@ type SignerKeyOptions = Extract<
   { type: "revokeSignerSponsorship" }
 >["signer"];
 
-// Signer hash fields (sha256Hash / preAuthTx) parse to a Buffer at runtime but
-// are typed `Buffer | string`; render either as an uppercase hex string.
-const signerKeyToHex = (value: Buffer | string): string =>
-  typeof value === "string"
+/**
+ * Renders a signer hash (sha256Hash / preAuthTx) as uppercase hex.
+ *
+ * Accepts a string as well as bytes because the SDK is inconsistent: the
+ * `revokeSponsorship` signer arm returns these fields as already-hex strings
+ * (`convertXdrSignerKeyToObject`), while `setOptions` returns real
+ * `Uint8Array`s. A string is passed through rather than re-encoded -- encoding
+ * it again would hex the ASCII of the hex.
+ */
+const signerKeyToHex = (value: Uint8Array | string): string =>
+  (typeof value === "string"
     ? value
-    : Buffer.from(value).toString("hex").toUpperCase();
+    : xdr.encodeBytes(value, "hex")
+  ).toUpperCase();
 
 interface KeyValueListItemProps {
   operationKey: string;
@@ -131,7 +144,7 @@ export const KeyValueInvokeHostFnArgs = ({
           </>
         )}
         {args.map((arg, index) => {
-          const xdrString = arg.toXDR().toString();
+          const xdrString = arg.toXdr("base64");
           const contextKey = `${contractId || "no-contract"}-${fnName || "no-fn"}`;
 
           return (
@@ -364,14 +377,14 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
     predicate,
     hideKey = false,
   }: ClaimPredicateValueProps): React.ReactNode => {
-    switch (predicate.switch().name) {
+    switch (predicate.type) {
       case "claimPredicateUnconditional": {
         return (
           <KeyValueListItem
             operationKey={
               hideKey ? "" : t("signTransactionDetails.operations.predicate")
             }
-            operationValue={CLAIM_PREDICATES[predicate.switch().name]}
+            operationValue={CLAIM_PREDICATES[predicate.type]}
           />
         );
       }
@@ -383,11 +396,11 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
               operationKey={
                 hideKey ? "" : t("signTransactionDetails.operations.predicate")
               }
-              operationValue={CLAIM_PREDICATES[predicate.switch().name]}
+              operationValue={CLAIM_PREDICATES[predicate.type]}
             />
-            {predicate
-              .andPredicates()
-              .map((p) => claimPredicateValue({ predicate: p, hideKey: true }))}
+            {predicate.andPredicates.map((p) =>
+              claimPredicateValue({ predicate: p, hideKey: true }),
+            )}
           </>
         );
       }
@@ -399,11 +412,11 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
               operationKey={
                 hideKey ? "" : t("signTransactionDetails.operations.predicate")
               }
-              operationValue={CLAIM_PREDICATES[predicate.switch().name]}
+              operationValue={CLAIM_PREDICATES[predicate.type]}
             />
             <KeyValueListItem
               operationKey=""
-              operationValue={predicate.absBefore().toString()}
+              operationValue={predicate.absBefore.toString()}
             />
           </>
         );
@@ -416,18 +429,18 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
               operationKey={
                 hideKey ? "" : t("signTransactionDetails.operations.predicate")
               }
-              operationValue={CLAIM_PREDICATES[predicate.switch().name]}
+              operationValue={CLAIM_PREDICATES[predicate.type]}
             />
             <KeyValueListItem
               operationKey=""
-              operationValue={predicate.relBefore().toString()}
+              operationValue={predicate.relBefore.toString()}
             />
           </>
         );
       }
 
       case "claimPredicateNot": {
-        const notPredicate = predicate.notPredicate();
+        const { notPredicate } = predicate;
 
         if (notPredicate) {
           return (
@@ -438,7 +451,7 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
                     ? ""
                     : t("signTransactionDetails.operations.predicate")
                 }
-                operationValue={CLAIM_PREDICATES[predicate.switch().name]}
+                operationValue={CLAIM_PREDICATES[predicate.type]}
               />
               {claimPredicateValue({ predicate: notPredicate, hideKey: true })}
             </>
@@ -455,11 +468,11 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
               operationKey={
                 hideKey ? "" : t("signTransactionDetails.operations.predicate")
               }
-              operationValue={CLAIM_PREDICATES[predicate.switch().name]}
+              operationValue={CLAIM_PREDICATES[predicate.type]}
             />
-            {predicate
-              .orPredicates()
-              .map((p) => claimPredicateValue({ predicate: p, hideKey: true }))}
+            {predicate.orPredicates.map((p) =>
+              claimPredicateValue({ predicate: p, hideKey: true }),
+            )}
           </>
         );
       }
@@ -473,7 +486,7 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
   return (
     <>
       {claimants.map((claimant, index) => (
-        <View key={claimant.destination + claimant.predicate.switch().name}>
+        <View key={claimant.destination + claimant.predicate.type}>
           <KeyValueWithPublicKey
             operationKey={t(
               "signTransactionDetails.operations.destinationWithNumber",
@@ -493,6 +506,92 @@ export const KeyValueClaimants = ({ claimants }: KeyValueClaimantsProps) => {
   );
 };
 
+/**
+ * Explains that a CAP-85 externally managed executable is not pinned by the
+ * transaction being signed: the owner can change the code the reference
+ * resolves to after this transaction is signed.
+ */
+export const ExternalExecutableNote = () => (
+  <Banner
+    variant="warning"
+    showChevron={false}
+    testID="ExternalExecutableNote"
+    text={t("signTransactionDetails.authorizations.executableNote")}
+  />
+);
+
+/**
+ * Renders the executable of a contract-creation host function. CAP-85
+ * (Protocol 28) adds a third arm whose code lives behind a reference into
+ * another contract's storage -- we show the owner and tag that identify the
+ * reference, and deliberately no wasm hash, because the owner can change the
+ * code the reference resolves to after this transaction is signed.
+ */
+export const ExecutableDetails = ({
+  executable,
+}: {
+  executable: xdr.ContractExecutable;
+}) => {
+  const { copyToClipboard } = useClipboard();
+
+  // v17: `wasmHash` is an xdr.Hash wrapper on the wasm arm only; render it as
+  // hex (Uint8Array.toString would give comma-joined decimals).
+  const wasmHash =
+    executable.type === "contractExecutableWasm"
+      ? xdr.encodeBytes(executable.wasmHash.toBytes(), "hex")
+      : null;
+  const externalRef =
+    executable.type === "contractExecutableExternalRef"
+      ? executable.externalRef
+      : null;
+  const externalRefOwner = externalRef
+    ? addressToString(externalRef.executableOwner)
+    : null;
+
+  return (
+    <>
+      <KeyValueListItem
+        operationKey={t("signTransactionDetails.operations.executableType")}
+        operationValue={executable.type}
+      />
+      {wasmHash && (
+        <KeyValueListItem
+          operationKey={t(
+            "signTransactionDetails.operations.executableWasmHash",
+          )}
+          operationValue={
+            <View className="flex-row items-center gap-[4px]">
+              <Text>{truncateAddress(wasmHash)}</Text>
+              <Icon.Copy01
+                size={14}
+                themeColor="gray"
+                onPress={() => copyToClipboard(wasmHash)}
+              />
+            </View>
+          }
+        />
+      )}
+      {externalRef && externalRefOwner && (
+        <>
+          <KeyValueWithPublicKey
+            operationKey={t(
+              "signTransactionDetails.authorizations.executableOwner",
+            )}
+            operationValue={externalRefOwner}
+          />
+          <KeyValueListItem
+            operationKey={t(
+              "signTransactionDetails.authorizations.executableTag",
+            )}
+            operationValue={externalRef.tag.toString()}
+          />
+          <ExternalExecutableNote />
+        </>
+      )}
+    </>
+  );
+};
+
 interface KeyValueInvokeHostFnProps {
   operation: Operation.InvokeHostFunction;
 }
@@ -504,25 +603,25 @@ export const KeyValueInvokeHostFn = ({
   const { copyToClipboard } = useClipboard();
 
   const renderDetails = () => {
-    switch (hostfn.switch()) {
-      case xdr.HostFunctionType.hostFunctionTypeCreateContractV2():
-      case xdr.HostFunctionType.hostFunctionTypeCreateContract(): {
+    switch (hostfn.type) {
+      case "hostFunctionTypeCreateContractV2":
+      case "hostFunctionTypeCreateContract": {
         const createContractArgs = getCreateContractArgs(hostfn);
         const preimage = createContractArgs.contractIdPreimage;
         const { executable } = createContractArgs;
         const createV2Args = createContractArgs.constructorArgs;
-        const executableType = executable.switch().name;
-        const wasmHash = executable.wasmHash();
 
-        if (preimage.switch().name === "contractIdPreimageFromAddress") {
-          const preimageFromAddress = preimage.fromAddress();
-          const address = preimageFromAddress.address();
-          const salt = preimageFromAddress.salt().toString("hex");
-          const addressType = address.switch();
+        if (preimage.type === "contractIdPreimageFromAddress") {
+          const preimageFromAddress = preimage.fromAddress;
+          const { address } = preimageFromAddress;
+          const salt = xdr.encodeBytes(
+            preimageFromAddress.salt.toBytes(),
+            "hex",
+          );
 
-          if (addressType.name === "scAddressTypeAccount") {
+          if (address.type === "scAddressTypeAccount") {
             const accountId = StrKey.encodeEd25519PublicKey(
-              address.accountId().ed25519(),
+              address.accountId.ed25519.toBytes(),
             );
 
             return (
@@ -552,31 +651,7 @@ export const KeyValueInvokeHostFn = ({
                     </View>
                   }
                 />
-                <KeyValueListItem
-                  operationKey={t(
-                    "signTransactionDetails.operations.executableType",
-                  )}
-                  operationValue={executableType}
-                />
-                {executable.wasmHash() && (
-                  <KeyValueListItem
-                    operationKey={t(
-                      "signTransactionDetails.operations.executableWasmHash",
-                    )}
-                    operationValue={
-                      <View className="flex-row items-center gap-[4px]">
-                        <Text>{truncateAddress(wasmHash.toString("hex"))}</Text>
-                        <Icon.Copy01
-                          size={14}
-                          themeColor="gray"
-                          onPress={() =>
-                            copyToClipboard(wasmHash.toString("hex"))
-                          }
-                        />
-                      </View>
-                    }
-                  />
-                )}
+                <ExecutableDetails executable={executable} />
               </>
             );
           }
@@ -608,39 +683,15 @@ export const KeyValueInvokeHostFn = ({
                   </View>
                 }
               />
-              <KeyValueListItem
-                operationKey={t(
-                  "signTransactionDetails.operations.executableType",
-                )}
-                operationValue={executableType}
-              />
-              {executable.wasmHash() && (
-                <KeyValueListItem
-                  operationKey={t(
-                    "signTransactionDetails.operations.executableWasmHash",
-                  )}
-                  operationValue={
-                    <View className="flex-row items-center gap-[4px]">
-                      <Text>{truncateAddress(wasmHash.toString("hex"))}</Text>
-                      <Icon.Copy01
-                        size={14}
-                        themeColor="gray"
-                        onPress={() =>
-                          copyToClipboard(wasmHash.toString("hex"))
-                        }
-                      />
-                    </View>
-                  }
-                />
-              )}
+              <ExecutableDetails executable={executable} />
               {createV2Args && <KeyValueInvokeHostFnArgs args={createV2Args} />}
             </>
           );
         }
 
         // contractIdPreimageFromAsset
-        const preimageFromAsset = preimage.fromAsset();
-        const preimageValue = preimageFromAsset.value();
+        const preimageFromAsset = preimage.fromAsset;
+        const preimageValue = preimageFromAsset.value;
 
         return (
           <>
@@ -650,16 +701,20 @@ export const KeyValueInvokeHostFn = ({
                 "signTransactionDetails.operations.createContract",
               )}
             />
-            {preimageFromAsset.switch().name === "assetTypeCreditAlphanum4" ||
-            preimageFromAsset.switch().name === "assetTypeCreditAlphanum12" ? (
+            {preimageFromAsset.type === "assetTypeCreditAlphanum4" ||
+            preimageFromAsset.type === "assetTypeCreditAlphanum12" ? (
               <>
                 <KeyValueListItem
                   operationKey={t(
                     "signTransactionDetails.operations.tokenCode",
                   )}
-                  operationValue={(preimageValue as xdr.AlphaNum12)
-                    .assetCode()
-                    .toString()}
+                  operationValue={
+                    // v17: BytesValue.toString() base64-encodes; toJson()
+                    // yields the trimmed ASCII asset code.
+                    (
+                      preimageValue as xdr.AlphaNum12
+                    ).assetCode.toJson() as string
+                  }
                 />
                 <KeyValueListItem
                   operationKey={t("signTransactionDetails.operations.issuer")}
@@ -668,9 +723,9 @@ export const KeyValueInvokeHostFn = ({
                       <Text>
                         {truncateAddress(
                           StrKey.encodeEd25519PublicKey(
-                            (preimageValue as xdr.AlphaNum12)
-                              .issuer()
-                              .ed25519(),
+                            (
+                              preimageValue as xdr.AlphaNum12
+                            ).issuer.ed25519.toBytes(),
                           ),
                         )}
                       </Text>
@@ -680,9 +735,9 @@ export const KeyValueInvokeHostFn = ({
                         onPress={() =>
                           copyToClipboard(
                             StrKey.encodeEd25519PublicKey(
-                              (preimageValue as xdr.AlphaNum12)
-                                .issuer()
-                                .ed25519(),
+                              (
+                                preimageValue as xdr.AlphaNum12
+                              ).issuer.ed25519.toBytes(),
                             ),
                           )
                         }
@@ -693,40 +748,18 @@ export const KeyValueInvokeHostFn = ({
               </>
             ) : null}
 
-            <KeyValueListItem
-              operationKey={t(
-                "signTransactionDetails.operations.executableType",
-              )}
-              operationValue={executableType}
-            />
-            {executable.wasmHash() && (
-              <KeyValueListItem
-                operationKey={t(
-                  "signTransactionDetails.operations.executableWasmHash",
-                )}
-                operationValue={
-                  <View className="flex-row items-center gap-[4px]">
-                    <Text>{truncateAddress(wasmHash.toString("hex"))}</Text>
-                    <Icon.Copy01
-                      size={14}
-                      themeColor="gray"
-                      onPress={() => copyToClipboard(wasmHash.toString("hex"))}
-                    />
-                  </View>
-                }
-              />
-            )}
+            <ExecutableDetails executable={executable} />
             {createV2Args && <KeyValueInvokeHostFnArgs args={createV2Args} />}
           </>
         );
       }
 
-      case xdr.HostFunctionType.hostFunctionTypeInvokeContract(): {
-        const invocation = hostfn.invokeContract();
+      case "hostFunctionTypeInvokeContract": {
+        const invocation = hostfn.invokeContract;
         const contractId = Address.fromScAddress(
-          invocation.contractAddress(),
+          invocation.contractAddress,
         ).toString();
-        const functionName = invocation.functionName().toString();
+        const functionName = invocation.functionName.toString();
 
         return (
           <>
@@ -757,7 +790,7 @@ export const KeyValueInvokeHostFn = ({
         );
       }
 
-      case xdr.HostFunctionType.hostFunctionTypeUploadContractWasm(): {
+      case "hostFunctionTypeUploadContractWasm": {
         return (
           <KeyValueListItem
             operationKey={t("signTransactionDetails.operations.type")}

--- a/src/components/screens/SignTransactionDetails/components/Operations.tsx
+++ b/src/components/screens/SignTransactionDetails/components/Operations.tsx
@@ -956,13 +956,13 @@ const RenderOperationByType = ({
     }
     case "invokeHostFunction": {
       const { func } = operation;
-      switch (func.switch()) {
-        case xdr.HostFunctionType.hostFunctionTypeInvokeContract(): {
-          const invocation = func.invokeContract();
+      switch (func.type) {
+        case "hostFunctionTypeInvokeContract": {
+          const invocation = func.invokeContract;
           const contractId = Address.fromScAddress(
-            invocation.contractAddress(),
+            invocation.contractAddress,
           ).toString();
-          const functionName = invocation.functionName().toString();
+          const functionName = invocation.functionName.toString();
 
           const items: ListItemProps[] = [
             {
@@ -995,7 +995,7 @@ const RenderOperationByType = ({
 
           return <List variant="secondary" items={items} />;
         }
-        case xdr.HostFunctionType.hostFunctionTypeUploadContractWasm(): {
+        case "hostFunctionTypeUploadContractWasm": {
           const items: ListItemProps[] = [
             {
               title: t("signTransactionDetails.operations.type"),
@@ -1010,8 +1010,8 @@ const RenderOperationByType = ({
 
           return <List variant="secondary" items={items} />;
         }
-        case xdr.HostFunctionType.hostFunctionTypeCreateContractV2():
-        case xdr.HostFunctionType.hostFunctionTypeCreateContract(): {
+        case "hostFunctionTypeCreateContractV2":
+        case "hostFunctionTypeCreateContract": {
           // Fall back to existing detailed component for complex create contract rendering
           return <KeyValueInvokeHostFn operation={operation} />;
         }
@@ -1248,9 +1248,9 @@ const RenderOperationArgsByType = ({
       const { func } = operation;
 
       const renderDetails = () => {
-        switch (func.switch()) {
-          case xdr.HostFunctionType.hostFunctionTypeCreateContractV2():
-          case xdr.HostFunctionType.hostFunctionTypeCreateContract(): {
+        switch (func.type) {
+          case "hostFunctionTypeCreateContractV2":
+          case "hostFunctionTypeCreateContract": {
             const createContractArgs = getCreateContractArgs(func);
             const createV2Args = createContractArgs.constructorArgs;
 
@@ -1264,13 +1264,13 @@ const RenderOperationArgsByType = ({
             );
           }
 
-          case xdr.HostFunctionType.hostFunctionTypeInvokeContract(): {
-            const invocation = func.invokeContract();
+          case "hostFunctionTypeInvokeContract": {
+            const invocation = func.invokeContract;
             const contractId = Address.fromScAddress(
-              invocation.contractAddress(),
+              invocation.contractAddress,
             ).toString();
-            const functionName = invocation.functionName().toString();
-            const args = invocation.args();
+            const functionName = invocation.functionName.toString();
+            const { args } = invocation;
 
             return (
               <KeyValueInvokeHostFnArgs
@@ -1283,8 +1283,10 @@ const RenderOperationArgsByType = ({
             );
           }
 
-          case xdr.HostFunctionType.hostFunctionTypeUploadContractWasm(): {
-            const wasm = func.wasm().toString();
+          case "hostFunctionTypeUploadContractWasm": {
+            // v17: `wasm` is a Uint8Array, whose `toString()` would render
+            // comma-joined decimals — encode it explicitly.
+            const wasm = xdr.encodeBytes(func.wasm, "hex");
 
             return (
               <KeyValueListItem

--- a/src/components/screens/SignTransactionDetails/components/SignTransactionAuthorizations.tsx
+++ b/src/components/screens/SignTransactionDetails/components/SignTransactionAuthorizations.tsx
@@ -1,17 +1,21 @@
 /* eslint-disable react/no-array-index-key */
 import CollapsibleSection from "components/CollapsibleSection";
 import {
+  ExternalExecutableNote,
   KeyValueListItem,
   KeyValueInvokeHostFnArgs,
 } from "components/screens/SignTransactionDetails/components/KeyVal";
 import { AuthEntryDisplay } from "components/screens/SignTransactionDetails/types";
+import { Banner } from "components/sds/Banner";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import {
   getInvocationDetails,
   InvocationArgs,
+  INVOCATION_TYPE_EXTERNAL_REF,
   INVOCATION_TYPE_INVOKE,
   INVOCATION_TYPE_SAC,
+  INVOCATION_TYPE_UNRECOGNIZED,
   INVOCATION_TYPE_WASM,
 } from "helpers/soroban";
 import { truncateAddress } from "helpers/stellar";
@@ -35,8 +39,14 @@ const SignTransactionAuthorizations = ({
         return detail.fnName;
       }
       case INVOCATION_TYPE_SAC:
-      case INVOCATION_TYPE_WASM: {
+      case INVOCATION_TYPE_WASM:
+      case INVOCATION_TYPE_EXTERNAL_REF: {
         return t("signTransactionDetails.authorizations.contractCreation");
+      }
+      case INVOCATION_TYPE_UNRECOGNIZED: {
+        return t(
+          "signTransactionDetails.authorizations.unrecognizedInvocation",
+        );
       }
       default: {
         return null;
@@ -53,6 +63,10 @@ const SignTransactionAuthorizations = ({
         return `${detail.type}-${detail.asset}`;
       case INVOCATION_TYPE_WASM:
         return `${detail.type}-${detail.hash}`;
+      case INVOCATION_TYPE_EXTERNAL_REF:
+        return `${detail.type}-${detail.owner}-${detail.tag}`;
+      case INVOCATION_TYPE_UNRECOGNIZED:
+        return detail.type;
       default:
         return `unknown-${JSON.stringify(detail)}`;
     }
@@ -164,6 +178,84 @@ const SignTransactionAuthorizations = ({
           </View>
         );
       }
+      // CAP-85 (Protocol 28): contract created from an external executable
+      // reference (owner contract + tag) instead of a Wasm hash.
+      case INVOCATION_TYPE_EXTERNAL_REF: {
+        return (
+          <View className="gap-[12px]">
+            <View className="bg-background-secondary rounded-[16px] p-[16px] gap-[12px]">
+              <View className="gap-[8px]">
+                <View className="flex-row items-center gap-[4px]">
+                  <Icon.CodeSnippet01 size={14} themeColor="gray" />
+                  <Text secondary>
+                    {t(
+                      "signTransactionDetails.authorizations.contractCreation",
+                    )}
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <ExternalExecutableNote />
+            {detail.address && (
+              <KeyValueListItem
+                operationKey={t(
+                  "signTransactionDetails.authorizations.contractAddress",
+                )}
+                operationValue={
+                  <View className="flex-row items-center gap-[4px]">
+                    <Text>{truncateAddress(detail.address)}</Text>
+                    <Icon.Copy01
+                      size={14}
+                      themeColor="gray"
+                      onPress={() => copyToClipboard(detail.address ?? "")}
+                    />
+                  </View>
+                }
+              />
+            )}
+            <KeyValueListItem
+              operationKey={t(
+                "signTransactionDetails.authorizations.executableOwner",
+              )}
+              operationValue={
+                <View className="flex-row items-center gap-[4px]">
+                  <Text>{truncateAddress(detail.owner)}</Text>
+                  <Icon.Copy01
+                    size={14}
+                    themeColor="gray"
+                    onPress={() => copyToClipboard(detail.owner)}
+                  />
+                </View>
+              }
+            />
+            <KeyValueListItem
+              operationKey={t(
+                "signTransactionDetails.authorizations.executableTag",
+              )}
+              operationValue={detail.tag}
+            />
+            {detail.salt && (
+              <KeyValueListItem
+                operationKey={t("common.salt")}
+                operationValue={truncateAddress(detail.salt)}
+              />
+            )}
+            {detail.args && <KeyValueInvokeHostFnArgs args={detail.args} />}
+          </View>
+        );
+      }
+      case INVOCATION_TYPE_UNRECOGNIZED: {
+        return (
+          <Banner
+            variant="error"
+            showChevron={false}
+            testID="UnrecognizedInvocationWarning"
+            text={t(
+              "signTransactionDetails.authorizations.unrecognizedInvocationWarning",
+            )}
+          />
+        );
+      }
       default: {
         return null;
       }
@@ -221,9 +313,7 @@ const SignTransactionAuthorizations = ({
         </Text>
       </View>
       {authEntries.map((entry, index) => (
-        <View
-          key={`auth-entry-${index}-${entry.invocation.toXDR("raw").toString()}`}
-        >
+        <View key={`auth-entry-${index}-${entry.invocation.toXdr("base64")}`}>
           {renderAuthEntry(entry)}
         </View>
       ))}

--- a/src/components/screens/SignTransactionDetails/components/SignTransactionAuthorizations.tsx
+++ b/src/components/screens/SignTransactionDetails/components/SignTransactionAuthorizations.tsx
@@ -196,23 +196,21 @@ const SignTransactionAuthorizations = ({
               </View>
             </View>
             <ExternalExecutableNote />
-            {detail.address && (
-              <KeyValueListItem
-                operationKey={t(
-                  "signTransactionDetails.authorizations.contractAddress",
-                )}
-                operationValue={
-                  <View className="flex-row items-center gap-[4px]">
-                    <Text>{truncateAddress(detail.address)}</Text>
-                    <Icon.Copy01
-                      size={14}
-                      themeColor="gray"
-                      onPress={() => copyToClipboard(detail.address ?? "")}
-                    />
-                  </View>
-                }
-              />
-            )}
+            <KeyValueListItem
+              operationKey={t(
+                "signTransactionDetails.authorizations.contractAddress",
+              )}
+              operationValue={
+                <View className="flex-row items-center gap-[4px]">
+                  <Text>{truncateAddress(detail.address)}</Text>
+                  <Icon.Copy01
+                    size={14}
+                    themeColor="gray"
+                    onPress={() => copyToClipboard(detail.address)}
+                  />
+                </View>
+              }
+            />
             <KeyValueListItem
               operationKey={t(
                 "signTransactionDetails.authorizations.executableOwner",
@@ -234,12 +232,10 @@ const SignTransactionAuthorizations = ({
               )}
               operationValue={detail.tag}
             />
-            {detail.salt && (
-              <KeyValueListItem
-                operationKey={t("common.salt")}
-                operationValue={truncateAddress(detail.salt)}
-              />
-            )}
+            <KeyValueListItem
+              operationKey={t("common.salt")}
+              operationValue={truncateAddress(detail.salt)}
+            />
             {detail.args && <KeyValueInvokeHostFnArgs args={detail.args} />}
           </View>
         );

--- a/src/components/screens/SignTransactionDetails/hooks/useSignTransactionDetails.ts
+++ b/src/components/screens/SignTransactionDetails/hooks/useSignTransactionDetails.ts
@@ -64,7 +64,7 @@ const buildAuthEntries = (transaction: Transaction | FeeBumpTransaction) => {
   if (!allAuthEntries.length) return [];
 
   return allAuthEntries.map((authEntry) => ({
-    invocation: authEntry.rootInvocation(),
+    invocation: authEntry.rootInvocation,
     boundAddress: getAuthEntryBoundAddress(authEntry),
   }));
 };
@@ -78,7 +78,7 @@ export const useSignTransactionDetails = ({
   if (!xdr) return null;
 
   try {
-    const transaction = TransactionBuilder.fromXDR(
+    const transaction = TransactionBuilder.fromXdr(
       xdr,
       networkDetails.networkPassphrase,
     );

--- a/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx
+++ b/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx
@@ -1,5 +1,9 @@
 import { xdr } from "@stellar/stellar-sdk";
-import { KeyValueInvokeHostFnArgs } from "components/screens/SignTransactionDetails/components/KeyVal";
+import {
+  ExternalExecutableNote,
+  KeyValueInvokeHostFnArgs,
+} from "components/screens/SignTransactionDetails/components/KeyVal";
+import { Banner } from "components/sds/Banner";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { logger } from "config/logger";
@@ -7,7 +11,9 @@ import {
   addressToString,
   getInvocationDetails,
   InvocationArgs,
+  INVOCATION_TYPE_EXTERNAL_REF,
   INVOCATION_TYPE_INVOKE,
+  INVOCATION_TYPE_UNRECOGNIZED,
   INVOCATION_TYPE_WASM,
 } from "helpers/soroban";
 import { truncateAddress } from "helpers/stellar";
@@ -49,7 +55,7 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
   const normalized = useMemo<NormalizedAuthPreimage | null>(() => {
     try {
       return normalizeAuthPreimage(
-        xdr.HashIdPreimage.fromXDR(entryXdr, "base64"),
+        xdr.HashIdPreimage.fromXdr(entryXdr, "base64"),
       );
     } catch (e) {
       logger.warn("DappAuthEntryDisplay", "Failed to parse auth entry XDR", {
@@ -94,11 +100,16 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
     if (detail.type === INVOCATION_TYPE_INVOKE)
       return `invoke-${detail.contractId}-${detail.fnName}`;
     if (detail.type === INVOCATION_TYPE_WASM) return `wasm-${detail.hash}`;
+    if (detail.type === INVOCATION_TYPE_EXTERNAL_REF)
+      return `externalRef-${detail.owner}-${detail.tag}`;
+    if (detail.type === INVOCATION_TYPE_UNRECOGNIZED) return detail.type;
     return `sac-${detail.asset}`;
   };
 
   const renderDetailTitle = (detail: InvocationArgs): string => {
     if (detail.type === INVOCATION_TYPE_INVOKE) return detail.fnName;
+    if (detail.type === INVOCATION_TYPE_UNRECOGNIZED)
+      return t("signTransactionDetails.authorizations.unrecognizedInvocation");
     return t("signTransactionDetails.authorizations.contractCreation");
   };
 
@@ -182,6 +193,83 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
               {truncateAddress(detail.salt)}
             </Text>
           </View>
+          {detail.args && detail.args.length > 0 && (
+            <KeyValueInvokeHostFnArgs args={detail.args} variant="tertiary" />
+          )}
+        </View>
+      );
+    }
+
+    // CAP-85 (Protocol 28): contract created from an external executable
+    // reference (owner contract + tag) instead of a Wasm hash.
+    if (detail.type === INVOCATION_TYPE_UNRECOGNIZED) {
+      return (
+        <Banner
+          variant="error"
+          showChevron={false}
+          testID="UnrecognizedInvocationWarning"
+          text={t(
+            "signTransactionDetails.authorizations.unrecognizedInvocationWarning",
+          )}
+        />
+      );
+    }
+
+    if (detail.type === INVOCATION_TYPE_EXTERNAL_REF) {
+      const { address } = detail;
+      return (
+        <View className="gap-[12px]">
+          <ExternalExecutableNote />
+          {address && (
+            <View className="gap-[4px]">
+              <Text sm secondary>
+                {t("signTransactionDetails.authorizations.contractAddress")}
+              </Text>
+              <View className="flex-row items-center gap-[8px]">
+                <Text sm primary style={{ flex: 1 }}>
+                  {truncateAddress(address)}
+                </Text>
+                <Icon.Copy01
+                  size={14}
+                  themeColor="gray"
+                  onPress={() => copyToClipboard(address)}
+                />
+              </View>
+            </View>
+          )}
+          <View className="gap-[4px]">
+            <Text sm secondary>
+              {t("signTransactionDetails.authorizations.executableOwner")}
+            </Text>
+            <View className="flex-row items-center gap-[8px]">
+              <Text sm primary style={{ flex: 1 }}>
+                {truncateAddress(detail.owner)}
+              </Text>
+              <Icon.Copy01
+                size={14}
+                themeColor="gray"
+                onPress={() => copyToClipboard(detail.owner)}
+              />
+            </View>
+          </View>
+          <View className="gap-[4px]">
+            <Text sm secondary>
+              {t("signTransactionDetails.authorizations.executableTag")}
+            </Text>
+            <Text sm primary>
+              {detail.tag}
+            </Text>
+          </View>
+          {detail.salt && (
+            <View className="gap-[4px]">
+              <Text sm secondary>
+                {t("signTransactionDetails.operations.salt")}
+              </Text>
+              <Text sm primary>
+                {truncateAddress(detail.salt)}
+              </Text>
+            </View>
+          )}
           {detail.args && detail.args.length > 0 && (
             <KeyValueInvokeHostFnArgs args={detail.args} variant="tertiary" />
           )}

--- a/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx
+++ b/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx
@@ -216,27 +216,24 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
     }
 
     if (detail.type === INVOCATION_TYPE_EXTERNAL_REF) {
-      const { address } = detail;
       return (
         <View className="gap-[12px]">
           <ExternalExecutableNote />
-          {address && (
-            <View className="gap-[4px]">
-              <Text sm secondary>
-                {t("signTransactionDetails.authorizations.contractAddress")}
+          <View className="gap-[4px]">
+            <Text sm secondary>
+              {t("signTransactionDetails.authorizations.contractAddress")}
+            </Text>
+            <View className="flex-row items-center gap-[8px]">
+              <Text sm primary style={{ flex: 1 }}>
+                {truncateAddress(detail.address)}
               </Text>
-              <View className="flex-row items-center gap-[8px]">
-                <Text sm primary style={{ flex: 1 }}>
-                  {truncateAddress(address)}
-                </Text>
-                <Icon.Copy01
-                  size={14}
-                  themeColor="gray"
-                  onPress={() => copyToClipboard(address)}
-                />
-              </View>
+              <Icon.Copy01
+                size={14}
+                themeColor="gray"
+                onPress={() => copyToClipboard(detail.address)}
+              />
             </View>
-          )}
+          </View>
           <View className="gap-[4px]">
             <Text sm secondary>
               {t("signTransactionDetails.authorizations.executableOwner")}
@@ -260,16 +257,14 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
               {detail.tag}
             </Text>
           </View>
-          {detail.salt && (
-            <View className="gap-[4px]">
-              <Text sm secondary>
-                {t("signTransactionDetails.operations.salt")}
-              </Text>
-              <Text sm primary>
-                {truncateAddress(detail.salt)}
-              </Text>
-            </View>
-          )}
+          <View className="gap-[4px]">
+            <Text sm secondary>
+              {t("signTransactionDetails.operations.salt")}
+            </Text>
+            <Text sm primary>
+              {truncateAddress(detail.salt)}
+            </Text>
+          </View>
           {detail.args && detail.args.length > 0 && (
             <KeyValueInvokeHostFnArgs args={detail.args} variant="tertiary" />
           )}

--- a/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx
+++ b/src/components/screens/WalletKit/DappAuthEntryDisplay.tsx
@@ -200,8 +200,6 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
       );
     }
 
-    // CAP-85 (Protocol 28): contract created from an external executable
-    // reference (owner contract + tag) instead of a Wasm hash.
     if (detail.type === INVOCATION_TYPE_UNRECOGNIZED) {
       return (
         <Banner
@@ -215,6 +213,8 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
       );
     }
 
+    // CAP-85 (Protocol 28): contract created from an external executable
+    // reference (owner contract + tag) instead of a Wasm hash.
     if (detail.type === INVOCATION_TYPE_EXTERNAL_REF) {
       return (
         <View className="gap-[12px]">
@@ -326,7 +326,8 @@ export const DappAuthEntryDisplay: React.FC<DappAuthEntryDisplayProps> = ({
           const isExpanded = expandedIndices.has(index);
           return (
             <View
-              key={getDetailKey(detail)}
+              // eslint-disable-next-line react/no-array-index-key --- the list is static per entry and getDetailKey can repeat (e.g. every unrecognized invocation), so the index disambiguates
+              key={`${getDetailKey(detail)}-${index}`}
               className="rounded-[16px] overflow-hidden"
               style={{ backgroundColor: themeColors.background.secondary }}
               testID={`auth-entry-item-${index}`}

--- a/src/ducks/transactionBuilder.ts
+++ b/src/ducks/transactionBuilder.ts
@@ -405,7 +405,7 @@ export const useTransactionBuilderStore = create<TransactionBuilderState>(
         // The transaction XDR already contains the muxed address (if applicable) from buildSendCollectibleTransaction
         // which checks contract muxed support and creates muxed addresses according to the behavior matrix
         const simulateResult = await simulateCollectibleTransfer({
-          transactionXdr: builtTxResult.tx.toXDR(),
+          transactionXdr: builtTxResult.tx.toXdr(),
           networkDetails,
         });
 

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -436,6 +436,23 @@ const isInvocationArg = (
   invocation: InvocationArgs | undefined,
 ): invocation is InvocationArgs => !!invocation;
 
+/**
+ * Decodes a single authorized invocation into the shape the signing screens
+ * render.
+ *
+ * Returns `undefined` for function types we do not render. For contract
+ * creations, decodes the wasm, Stellar-asset, and CAP-85 (Protocol 28)
+ * external-reference executables; the `externalRef` arm reports the owner and
+ * tag but deliberately no wasm hash, since the owner can change the code the
+ * reference resolves to after signing.
+ *
+ * Throws when the creation is not something we can safely describe: an
+ * executable paired with the wrong contract-id preimage (wasm or external ref
+ * without an address preimage, Stellar asset without an asset preimage), or an
+ * executable type this build does not know. Callers that must not fail the
+ * whole view should catch and substitute `FnArgsUnrecognized` (see
+ * `getInvocationDetails`).
+ */
 export const getInvocationArgs = (
   invocation: xdr.SorobanAuthorizedInvocation,
 ): InvocationArgs | undefined => {
@@ -570,6 +587,13 @@ export const getInvocationDetails = (
     } catch (error) {
       // An invocation we cannot decode must not take down the whole signing
       // view -- surface it so the user sees that something was unreadable.
+      //
+      // `error` rather than `warn` (unlike the XDR-parse failures upstream):
+      // the XDR itself parsed, so reaching here means either our decoder is
+      // missing an executable/preimage arm the network now accepts, or a dApp
+      // is asking the user to sign a creation the SDK considers invalid. Both
+      // warrant an engineer's attention, and volume is bounded by user-initiated
+      // sign requests.
       logger.error("soroban", "Failed to decode authorized invocation", error);
       invocations.push({ type: INVOCATION_TYPE_UNRECOGNIZED });
     }

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -126,11 +126,23 @@ export const getNativeContractDetails = (network: NETWORKS) => {
 };
 
 export const addressToString = (address: xdr.ScAddress) => {
-  if (address.switch().name === "scAddressTypeAccount") {
-    return StrKey.encodeEd25519PublicKey(address.accountId().ed25519());
+  if (address.type === "scAddressTypeAccount") {
+    return StrKey.encodeEd25519PublicKey(address.accountId.ed25519.toBytes());
   }
   return Address.fromScAddress(address).toString();
 };
+
+/**
+ * Narrows an ScVal to its SCV_ADDRESS arm.
+ *
+ * Pre-v17 the generated arm accessor (`scVal.address()`) threw when the union
+ * carried a different arm; `expectUnionVariant` preserves that contract now
+ * that arms are plain properties on variant classes.
+ *
+ * @throws TypeError if the value is not an SCV_ADDRESS
+ */
+export const scValToAddress = (scVal: xdr.ScVal): xdr.ScAddress =>
+  xdr.expectUnionVariant(scVal, "scvAddress").address;
 
 /**
  * Extracts the address credentials from a SorobanCredentials union, handling
@@ -140,14 +152,13 @@ export const addressToString = (address: xdr.ScAddress) => {
 export const getAddressCredentials = (
   credentials: xdr.SorobanCredentials,
 ): xdr.SorobanAddressCredentials | null => {
-  switch (credentials.switch().value) {
-    case xdr.SorobanCredentialsType.sorobanCredentialsAddress().value:
-      return credentials.address();
-    case xdr.SorobanCredentialsType.sorobanCredentialsAddressV2().value:
-      return credentials.addressV2();
-    case xdr.SorobanCredentialsType.sorobanCredentialsAddressWithDelegates()
-      .value:
-      return credentials.addressWithDelegates().addressCredentials();
+  switch (credentials.type) {
+    case "sorobanCredentialsAddress":
+      return credentials.address;
+    case "sorobanCredentialsAddressV2":
+      return credentials.addressV2;
+    case "sorobanCredentialsAddressWithDelegates":
+      return credentials.addressWithDelegates.addressCredentials;
     default:
       return null;
   }
@@ -161,9 +172,9 @@ export const getAddressCredentials = (
 export const getAuthEntryBoundAddress = (
   entry: xdr.SorobanAuthorizationEntry,
 ): string | undefined => {
-  const addressCredentials = getAddressCredentials(entry.credentials());
+  const addressCredentials = getAddressCredentials(entry.credentials);
   return addressCredentials
-    ? addressToString(addressCredentials.address())
+    ? addressToString(addressCredentials.address)
     : undefined;
 };
 
@@ -176,7 +187,7 @@ export const getArgsForTokenInvocation = (
   let from = "";
   let to = "";
 
-  const thirdArgType = args[2].switch();
+  const thirdArgType = args[2].type;
   switch (fnName) {
     case SorobanTokenInterface.transfer:
       // both SEP-41 & SEP-50 tokens use the transfer method
@@ -185,18 +196,18 @@ export const getArgsForTokenInvocation = (
       // by the type of the 3rd argument.
       // Token transfer - (from: Address, to: Address, amount: i128)
       // Collectible transfer - (from: Address, to: Address, tokenId: u32)
-      if (thirdArgType === xdr.ScValType.scvI128()) {
+      if (thirdArgType === "scvI128") {
         amount = scValToNative(args[2]);
       }
-      if (thirdArgType === xdr.ScValType.scvU32()) {
+      if (thirdArgType === "scvU32") {
         tokenId = scValToNative(args[2]);
       }
 
-      from = addressToString(args[0].address());
-      to = addressToString(args[1].address());
+      from = addressToString(scValToAddress(args[0]));
+      to = addressToString(scValToAddress(args[1]));
       break;
     case SorobanTokenInterface.mint:
-      to = addressToString(args[0].address());
+      to = addressToString(scValToAddress(args[0]));
       amount = scValToNative(args[1]);
       break;
     default:
@@ -209,23 +220,18 @@ export const getArgsForTokenInvocation = (
 export const getTokenInvocationArgs = (
   hostFn: Operation.InvokeHostFunction,
 ): TokenInvocationArgs | null => {
-  if (!hostFn?.func?.invokeContract) {
+  const func = hostFn?.func;
+  if (!func || func.type !== "hostFunctionTypeInvokeContract") {
     return null;
   }
 
-  let invokedContract: xdr.InvokeContractArgs;
-
-  try {
-    invokedContract = hostFn.func.invokeContract();
-  } catch (e) {
-    return null;
-  }
+  const invokedContract: xdr.InvokeContractArgs = func.invokeContract;
 
   const contractId = Address.fromScAddress(
-    invokedContract.contractAddress(),
+    invokedContract.contractAddress,
   ).toString();
-  const fnName = invokedContract.functionName().toString();
-  const args = invokedContract.args();
+  const fnName = invokedContract.functionName.toString();
+  const { args } = invokedContract;
 
   if (
     fnName !== SorobanTokenInterface.transfer &&
@@ -254,7 +260,7 @@ export const isSorobanOp = (
 ) => SOROBAN_OPERATION_TYPES.includes(operation.type);
 
 export const hasSorobanOperations = (
-  transaction: ReturnType<typeof TransactionBuilder.fromXDR>,
+  transaction: ReturnType<typeof TransactionBuilder.fromXdr>,
 ) => transaction.operations.some((operation) => isSorobanOp(operation));
 
 export const getAttrsFromSorobanHorizonOp = (
@@ -275,7 +281,7 @@ export const getAttrsFromSorobanHorizonOp = (
     };
   }
 
-  const transaction = TransactionBuilder.fromXDR(
+  const transaction = TransactionBuilder.fromXdr(
     op.transaction_attr.envelope_xdr as string,
     networkDetails.networkPassphrase,
   ) as Transaction;
@@ -370,6 +376,10 @@ export const formatTokenForDisplay = (amount: BigNumber, decimals: number) => {
 export const INVOCATION_TYPE_INVOKE = "invoke" as const;
 export const INVOCATION_TYPE_WASM = "wasm" as const;
 export const INVOCATION_TYPE_SAC = "sac" as const;
+/** CAP-85 (Protocol 28): contract created from an external executable reference. */
+export const INVOCATION_TYPE_EXTERNAL_REF = "externalRef" as const;
+/** An invocation whose contents could not be decoded. */
+export const INVOCATION_TYPE_UNRECOGNIZED = "unrecognized" as const;
 
 export interface FnArgsInvoke {
   type: typeof INVOCATION_TYPE_INVOKE;
@@ -392,7 +402,34 @@ export interface FnArgsCreateSac {
   args?: xdr.ScVal[];
 }
 
-export type InvocationArgs = FnArgsInvoke | FnArgsCreateWasm | FnArgsCreateSac;
+/**
+ * A CAP-85 (Protocol 28) contract creation whose executable is a reference
+ * into another contract's storage rather than a wasm hash. `owner` and `tag`
+ * identify the reference; the code behind it is chosen by the owner at
+ * invocation time and can change after this entry is signed, so there is
+ * deliberately no wasm hash here. `address`/`salt` are only present when the
+ * contract id preimage is the address arm.
+ */
+export interface FnArgsCreateExternalRef {
+  type: typeof INVOCATION_TYPE_EXTERNAL_REF;
+  owner: string;
+  tag: string;
+  address?: string;
+  salt?: string;
+  args?: xdr.ScVal[];
+}
+
+/** An invocation whose contents we could not decode. */
+export interface FnArgsUnrecognized {
+  type: typeof INVOCATION_TYPE_UNRECOGNIZED;
+}
+
+export type InvocationArgs =
+  | FnArgsInvoke
+  | FnArgsCreateWasm
+  | FnArgsCreateSac
+  | FnArgsCreateExternalRef
+  | FnArgsUnrecognized;
 
 const isInvocationArg = (
   invocation: InvocationArgs | undefined,
@@ -401,68 +438,110 @@ const isInvocationArg = (
 export const getInvocationArgs = (
   invocation: xdr.SorobanAuthorizedInvocation,
 ): InvocationArgs | undefined => {
-  const fn = invocation.function();
+  const fn = invocation.function;
 
-  switch (fn.switch().value) {
-    // sorobanAuthorizedFunctionTypeContractFn
-    case 0: {
-      const invocationItem = fn.contractFn();
+  switch (fn.type) {
+    case "sorobanAuthorizedFunctionTypeContractFn": {
+      const invocationItem = fn.contractFn;
       const contractId = Address.fromScAddress(
-        invocationItem.contractAddress(),
+        invocationItem.contractAddress,
       ).toString();
-      const fnName = invocationItem.functionName().toString();
-      const args = invocationItem.args();
+      const fnName = invocationItem.functionName.toString();
+      const { args } = invocationItem;
       return { fnName, contractId, args, type: INVOCATION_TYPE_INVOKE };
     }
 
-    // sorobanAuthorizedFunctionTypeCreateContractV2HostFn
-    // sorobanAuthorizedFunctionTypeCreateContractHostFn
-    case 2:
-    case 1: {
-      const invocationItem =
-        fn.switch().value === 2
-          ? fn.createContractV2HostFn()
-          : fn.createContractHostFn();
-      const [exec, preimage] = [
-        invocationItem.executable(),
-        invocationItem.contractIdPreimage(),
-      ];
+    case "sorobanAuthorizedFunctionTypeCreateContractV2HostFn":
+    case "sorobanAuthorizedFunctionTypeCreateContractHostFn": {
+      const isCreateV2 =
+        fn.type === "sorobanAuthorizedFunctionTypeCreateContractV2HostFn";
+      const invocationItem: xdr.CreateContractArgs | xdr.CreateContractArgsV2 =
+        fn.type === "sorobanAuthorizedFunctionTypeCreateContractV2HostFn"
+          ? fn.createContractV2HostFn
+          : fn.createContractHostFn;
+      const exec = invocationItem.executable;
+      const preimage = invocationItem.contractIdPreimage;
 
-      switch (exec.switch().value) {
-        // contractExecutableWasm
-        case 0: {
-          const details = preimage.fromAddress();
+      switch (exec.type) {
+        case "contractExecutableWasm": {
+          // A wasm executable must be paired with an address preimage: the
+          // contract id is derived from deployer + salt. The two arms are
+          // independent in XDR, so the invalid pairings are representable.
+          if (preimage.type !== "contractIdPreimageFromAddress") {
+            throw new Error(
+              `creation function appears invalid: a wasm executable is paired with ${preimage.type} (should be wasm+address or token+asset)`,
+            );
+          }
+          const details = preimage.fromAddress;
 
           const contractDetails = {
             type: INVOCATION_TYPE_WASM,
-            salt: details.salt().toString("hex"),
-            hash: exec.wasmHash().toString("hex"),
-            address: Address.fromScAddress(details.address()).toString(),
+            salt: xdr.encodeBytes(details.salt.toBytes(), "hex"),
+            hash: xdr.encodeBytes(exec.wasmHash.toBytes(), "hex"),
+            address: Address.fromScAddress(details.address).toString(),
           } as FnArgsCreateWasm;
 
-          if (fn.switch().value === 2) {
+          if (isCreateV2) {
             contractDetails.args = (
               invocationItem as xdr.CreateContractArgsV2
-            ).constructorArgs();
+            ).constructorArgs;
           }
 
           return contractDetails;
         }
 
-        // contractExecutableStellarAsset
-        case 1: {
+        case "contractExecutableStellarAsset": {
+          // A SAC is only ever derived from the asset it wraps.
+          if (preimage.type !== "contractIdPreimageFromAsset") {
+            throw new Error(
+              `creation function appears invalid: a Stellar asset executable is paired with ${preimage.type} (should be wasm+address or token+asset)`,
+            );
+          }
           const sacDetails = {
             type: INVOCATION_TYPE_SAC,
-            asset: SdkToken.fromOperation(preimage.fromAsset()).toString(),
+            asset: SdkToken.fromOperation(preimage.fromAsset).toString(),
           } as FnArgsCreateSac;
 
-          if (fn.switch().value === 2) {
+          if (isCreateV2) {
             sacDetails.args = (
               invocationItem as xdr.CreateContractArgsV2
-            ).constructorArgs();
+            ).constructorArgs;
           }
 
           return sacDetails;
+        }
+
+        // CAP-85 (Protocol 28): the executable is a reference to a Wasm hash
+        // held by another contract, resolved on-chain at creation time.
+        case "contractExecutableExternalRef": {
+          const { executableOwner, tag } = exec.externalRef;
+          const externalRefDetails = {
+            type: INVOCATION_TYPE_EXTERNAL_REF,
+            owner: Address.fromScAddress(executableOwner).toString(),
+            tag: tag.toString(),
+          } as FnArgsCreateExternalRef;
+
+          // CAP-85 refs are expected to deploy from an address, but the
+          // preimage arm is independent of the executable arm -- only read it
+          // when it is a shape we can describe.
+          if (preimage.type === "contractIdPreimageFromAddress") {
+            const details = preimage.fromAddress;
+            externalRefDetails.address = Address.fromScAddress(
+              details.address,
+            ).toString();
+            externalRefDetails.salt = xdr.encodeBytes(
+              details.salt.toBytes(),
+              "hex",
+            );
+          }
+
+          if (isCreateV2) {
+            externalRefDetails.args = (
+              invocationItem as xdr.CreateContractArgsV2
+            ).constructorArgs;
+          }
+
+          return externalRefDetails;
         }
 
         default:
@@ -482,9 +561,16 @@ export const getInvocationDetails = (
   const invocations = [] as InvocationArgs[];
 
   walkInvocationTree(invocation, (inv) => {
-    const args = getInvocationArgs(inv);
-    if (args) {
-      invocations.push(args);
+    try {
+      const args = getInvocationArgs(inv);
+      if (args) {
+        invocations.push(args);
+      }
+    } catch (error) {
+      // An invocation we cannot decode must not take down the whole signing
+      // view -- surface it so the user sees that something was unreadable.
+      logger.error("soroban", "Failed to decode authorized invocation", error);
+      invocations.push({ type: INVOCATION_TYPE_UNRECOGNIZED });
     }
 
     return null;
@@ -494,62 +580,60 @@ export const getInvocationDetails = (
 };
 
 export const scValByType = (scVal: xdr.ScVal): any => {
-  switch (scVal.switch()) {
-    case xdr.ScValType.scvAddress(): {
-      const address = scVal.address();
-      const addressType = address.switch();
-      if (addressType.name === "scAddressTypeAccount") {
-        return StrKey.encodeEd25519PublicKey(address.accountId().ed25519());
+  switch (scVal.type) {
+    case "scvAddress": {
+      const { address } = scVal;
+      if (address.type === "scAddressTypeAccount") {
+        return StrKey.encodeEd25519PublicKey(
+          address.accountId.ed25519.toBytes(),
+        );
       }
       return Address.fromScAddress(address).toString();
     }
 
-    case xdr.ScValType.scvBool(): {
-      return scVal.b();
+    case "scvBool": {
+      return scVal.b;
     }
 
-    case xdr.ScValType.scvBytes(): {
-      return scVal
-        .bytes()
-        .toJSON()
-        .data.map((d) => d.toString(16).padStart(2, "0"))
-        .join("");
+    case "scvBytes": {
+      return xdr.encodeBytes(scVal.bytes.toBytes(), "hex");
     }
 
-    case xdr.ScValType.scvContractInstance(): {
-      const instance = scVal.instance();
-      return instance.executable().wasmHash()?.toString();
+    case "scvContractInstance": {
+      const { executable } = scVal.instance;
+      return executable.type === "contractExecutableWasm"
+        ? xdr.encodeBytes(executable.wasmHash.toBytes(), "hex")
+        : undefined;
     }
 
-    case xdr.ScValType.scvError(): {
-      const error = scVal.error();
-      return error.value();
+    case "scvError": {
+      return scVal.error.value;
     }
 
-    case xdr.ScValType.scvTimepoint():
-    case xdr.ScValType.scvDuration():
-    case xdr.ScValType.scvI128():
-    case xdr.ScValType.scvI256():
-    case xdr.ScValType.scvI32():
-    case xdr.ScValType.scvI64():
-    case xdr.ScValType.scvU128():
-    case xdr.ScValType.scvU256():
-    case xdr.ScValType.scvU32():
-    case xdr.ScValType.scvU64(): {
+    case "scvTimepoint":
+    case "scvDuration":
+    case "scvI128":
+    case "scvI256":
+    case "scvI32":
+    case "scvI64":
+    case "scvU128":
+    case "scvU256":
+    case "scvU32":
+    case "scvU64": {
       return scValToNative(scVal).toString();
     }
 
-    case xdr.ScValType.scvLedgerKeyNonce():
-    case xdr.ScValType.scvLedgerKeyContractInstance(): {
-      if (scVal.switch().name === "scvLedgerKeyNonce") {
-        const val = scVal.nonceKey().nonce();
-        return val.toString();
-      }
-      return scVal.value();
+    case "scvLedgerKeyNonce": {
+      return scVal.nonceKey.nonce.toString();
     }
 
-    case xdr.ScValType.scvVec():
-    case xdr.ScValType.scvMap(): {
+    case "scvLedgerKeyContractInstance": {
+      // void arm — carries no payload
+      return null;
+    }
+
+    case "scvVec":
+    case "scvMap": {
       return JSON.stringify(
         scValToNative(scVal),
         (_, val) => (typeof val === "bigint" ? val.toString() : val),
@@ -557,16 +641,23 @@ export const scValByType = (scVal: xdr.ScVal): any => {
       );
     }
 
-    case xdr.ScValType.scvString():
-    case xdr.ScValType.scvSymbol(): {
+    // CAP-85 (Protocol 28): an executable tag is an SCString.
+    case "scvExecutableTag": {
+      return scVal.executableTag.toString();
+    }
+
+    case "scvString":
+    case "scvSymbol": {
       const native = scValToNative(scVal);
-      if (native.constructor === "Uint8Array") {
-        return native.toString();
+      // v17: scValToNative returns Uint8Array (not a lossy string) when the
+      // XDR string/symbol payload is not valid UTF-8.
+      if (native instanceof Uint8Array) {
+        return xdr.encodeBytes(native, "hex");
       }
       return native;
     }
 
-    case xdr.ScValType.scvVoid(): {
+    case "scvVoid": {
       return null;
     }
 
@@ -576,23 +667,25 @@ export const scValByType = (scVal: xdr.ScVal): any => {
 };
 
 export const getCreateContractArgs = (hostFunction: xdr.HostFunction) => {
-  if (
-    hostFunction.switch() !==
-    xdr.HostFunctionType.hostFunctionTypeCreateContractV2()
-  ) {
-    const args = hostFunction.createContract();
+  if (hostFunction.type !== "hostFunctionTypeCreateContractV2") {
+    // Pre-v17 the generated `createContract()` arm accessor threw for any
+    // other host function type; keep that contract.
+    const args = xdr.expectUnionVariant(
+      hostFunction,
+      "hostFunctionTypeCreateContract",
+    ).createContract;
 
     return {
-      contractIdPreimage: args.contractIdPreimage(),
-      executable: args.executable(),
+      contractIdPreimage: args.contractIdPreimage,
+      executable: args.executable,
     };
   }
 
-  const argsV2 = hostFunction.createContractV2();
+  const argsV2 = hostFunction.createContractV2;
 
   return {
-    contractIdPreimage: argsV2.contractIdPreimage(),
-    executable: argsV2.executable(),
-    constructorArgs: argsV2.constructorArgs(),
+    contractIdPreimage: argsV2.contractIdPreimage,
+    executable: argsV2.executable,
+    constructorArgs: argsV2.constructorArgs,
   };
 };

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -407,15 +407,16 @@ export interface FnArgsCreateSac {
  * into another contract's storage rather than a wasm hash. `owner` and `tag`
  * identify the reference; the code behind it is chosen by the owner at
  * invocation time and can change after this entry is signed, so there is
- * deliberately no wasm hash here. `address`/`salt` are only present when the
- * contract id preimage is the address arm.
+ * deliberately no wasm hash here. `tag` is the SEP-51 JSON form of the
+ * SCString so a non-UTF-8 tag stays distinguishable (e.g. `\xff\xfe`) instead
+ * of collapsing to replacement characters.
  */
 export interface FnArgsCreateExternalRef {
   type: typeof INVOCATION_TYPE_EXTERNAL_REF;
   owner: string;
   tag: string;
-  address?: string;
-  salt?: string;
+  address: string;
+  salt: string;
   args?: xdr.ScVal[];
 }
 
@@ -514,26 +515,26 @@ export const getInvocationArgs = (
         // CAP-85 (Protocol 28): the executable is a reference to a Wasm hash
         // held by another contract, resolved on-chain at creation time.
         case "contractExecutableExternalRef": {
+          // Like wasm, an external reference deploys from an address; the SDK's
+          // own invocation decoder rejects every other pairing, so do the same
+          // rather than rendering an invalid authorization as a normal
+          // contract creation.
+          if (preimage.type !== "contractIdPreimageFromAddress") {
+            throw new Error(
+              `creation function appears invalid: an external executable reference is paired with ${preimage.type} (should be wasm+address, external ref+address, or token+asset)`,
+            );
+          }
+          const details = preimage.fromAddress;
           const { executableOwner, tag } = exec.externalRef;
+
           const externalRefDetails = {
             type: INVOCATION_TYPE_EXTERNAL_REF,
             owner: Address.fromScAddress(executableOwner).toString(),
-            tag: tag.toString(),
+            // SEP-51 form: reversible for non-UTF-8 bytes, plain text otherwise.
+            tag: tag.toJson(),
+            address: Address.fromScAddress(details.address).toString(),
+            salt: xdr.encodeBytes(details.salt.toBytes(), "hex"),
           } as FnArgsCreateExternalRef;
-
-          // CAP-85 refs are expected to deploy from an address, but the
-          // preimage arm is independent of the executable arm -- only read it
-          // when it is a shape we can describe.
-          if (preimage.type === "contractIdPreimageFromAddress") {
-            const details = preimage.fromAddress;
-            externalRefDetails.address = Address.fromScAddress(
-              details.address,
-            ).toString();
-            externalRefDetails.salt = xdr.encodeBytes(
-              details.salt.toBytes(),
-              "hex",
-            );
-          }
 
           if (isCreateV2) {
             externalRefDetails.args = (
@@ -641,9 +642,11 @@ export const scValByType = (scVal: xdr.ScVal): any => {
       );
     }
 
-    // CAP-85 (Protocol 28): an executable tag is an SCString.
+    // CAP-85 (Protocol 28): an executable tag is an SCString. Use the SEP-51
+    // JSON form so a non-UTF-8 tag stays distinguishable instead of decoding
+    // to replacement characters.
     case "scvExecutableTag": {
-      return scVal.executableTag.toString();
+      return scVal.executableTag.toJson();
     }
 
     case "scvString":

--- a/src/helpers/stellar.ts
+++ b/src/helpers/stellar.ts
@@ -249,8 +249,22 @@ export const truncateAddress = (
   return `${prefix}...${suffix}`;
 };
 
-export const formattedBuffer = (data: Buffer) =>
-  truncateAddress(Buffer.from(data).toString("hex").toUpperCase());
+/**
+ * Renders a hash for display as truncated uppercase hex.
+ *
+ * Accepts a string as well as bytes because the SDK is inconsistent: the
+ * `revokeSponsorship` signer arm returns `sha256Hash` / `preAuthTx` as
+ * already-hex strings (`convertXdrSignerKeyToObject`), while `setOptions`
+ * returns real `Uint8Array`s. A string is passed through rather than re-encoded
+ * -- encoding it again would hex the ASCII of the hex.
+ */
+export const formattedBuffer = (data: Uint8Array | string) =>
+  truncateAddress(
+    (typeof data === "string"
+      ? data
+      : xdr.encodeBytes(data, "hex")
+    ).toUpperCase(),
+  );
 
 /**
  * Determines if two Stellar addresses refer to the same account
@@ -340,14 +354,14 @@ export const SIGN_MESSAGE_PREFIX = "Stellar Signed Message:\n";
  *
  * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md
  * @param message - UTF-8 string message to encode
- * @returns Buffer containing the 32-byte SHA-256 hash ready for signing
+ * @returns Uint8Array containing the 32-byte SHA-256 hash ready for signing
  *
  * @example
  * const message = "Hello, Stellar!";
  * const encodedMessage = encodeSep53Message(message);
- * // Returns Buffer containing SHA-256 hash of "Stellar Signed Message:\nHello, Stellar!"
+ * // Returns Uint8Array containing SHA-256 hash of "Stellar Signed Message:\nHello, Stellar!"
  */
-export const encodeSep53Message = (message: string): Buffer => {
+export const encodeSep53Message = (message: string): Uint8Array => {
   const messageBytes = Buffer.from(message, "utf8");
   const prefixBytes = Buffer.from(SIGN_MESSAGE_PREFIX, "utf8");
   const encodedMessage = Buffer.concat([prefixBytes, messageBytes]);
@@ -380,8 +394,10 @@ export const signMessage = (message: string, privateKey: string): string => {
 
   const keyPair = Keypair.fromSecret(privateKey);
   const encodedMessage = encodeSep53Message(message);
+  // v17: Keypair.sign returns a Uint8Array, whose `toString("base64")` would
+  // silently yield comma-joined decimals — encode explicitly.
   const signature = keyPair.sign(encodedMessage);
-  return signature.toString("base64");
+  return xdr.encodeBytes(signature, "base64");
 };
 
 /**
@@ -410,7 +426,7 @@ export const signAuthEntry = (
 ): { signedAuthEntry: string; signerAddress: string } => {
   // Validate that the XDR is a Soroban authorization HashIdPreimage (either
   // arm) before signing — rejects arbitrary blobs that do not conform to SEP-43.
-  const preimage = xdr.HashIdPreimage.fromXDR(preimageXdr, "base64");
+  const preimage = xdr.HashIdPreimage.fromXdr(preimageXdr, "base64");
   if (!normalizeAuthPreimage(preimage)) {
     throw new Error("Unsupported auth entry preimage type");
   }
@@ -428,7 +444,7 @@ export const signAuthEntry = (
   const signingPayload = hash(Buffer.from(preimageXdr, "base64"));
   const signature = keyPair.sign(signingPayload);
   return {
-    signedAuthEntry: signature.toString("base64"),
+    signedAuthEntry: xdr.encodeBytes(signature, "base64"),
     signerAddress: keyPair.publicKey(),
   };
 };

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -518,7 +518,7 @@ export const approveSessionRequest = async ({
   let signedTransaction: string | null;
   let dappDomain: string | undefined;
   try {
-    transaction = TransactionBuilder.fromXDR(xdr as string, networkPassphrase);
+    transaction = TransactionBuilder.fromXdr(xdr as string, networkPassphrase);
 
     // Always sign the transaction for both supported RPC methods
     signedTransaction = signTransaction(transaction);

--- a/src/helpers/walletKitValidation.ts
+++ b/src/helpers/walletKitValidation.ts
@@ -91,7 +91,7 @@ export function parseAuthEntryPreimage(
   entryXdr: string,
 ): ValidationResult<xdr.HashIdPreimage> {
   try {
-    const preimage = xdr.HashIdPreimage.fromXDR(entryXdr, "base64");
+    const preimage = xdr.HashIdPreimage.fromXdr(entryXdr, "base64");
     return { valid: true, value: preimage };
   } catch (e) {
     return { valid: false, errorKey: ValidationErrorKeys.INVALID_AUTH_ENTRY };
@@ -105,7 +105,8 @@ export function parseAuthEntryPreimage(
  * signer address in addition to the legacy fields.
  */
 export interface NormalizedAuthPreimage {
-  networkId: Buffer;
+  /** v17: an `xdr.Hash` wrapper (not raw bytes) — compare via `.equals()`. */
+  networkId: xdr.Hash;
   invocation: xdr.SorobanAuthorizedInvocation;
   /** Present only for envelopeTypeSorobanAuthorizationWithAddress (CAP-71 ADDRESS_V2). */
   address?: xdr.ScAddress;
@@ -119,17 +120,17 @@ export function normalizeAuthPreimage(
   preimage: xdr.HashIdPreimage,
 ): NormalizedAuthPreimage | null {
   try {
-    switch (preimage.switch()) {
-      case xdr.EnvelopeType.envelopeTypeSorobanAuthorization(): {
-        const auth = preimage.sorobanAuthorization();
-        return { networkId: auth.networkId(), invocation: auth.invocation() };
+    switch (preimage.type) {
+      case "envelopeTypeSorobanAuthorization": {
+        const auth = preimage.sorobanAuthorization;
+        return { networkId: auth.networkId, invocation: auth.invocation };
       }
-      case xdr.EnvelopeType.envelopeTypeSorobanAuthorizationWithAddress(): {
-        const auth = preimage.sorobanAuthorizationWithAddress();
+      case "envelopeTypeSorobanAuthorizationWithAddress": {
+        const auth = preimage.sorobanAuthorizationWithAddress;
         return {
-          networkId: auth.networkId(),
-          invocation: auth.invocation(),
-          address: auth.address(),
+          networkId: auth.networkId,
+          invocation: auth.invocation,
+          address: auth.address,
         };
       }
       default:
@@ -158,7 +159,10 @@ export function validateAuthEntryNetwork(
     return { valid: false, errorKey: ValidationErrorKeys.INVALID_AUTH_ENTRY };
   }
 
-  const expectedNetworkId = hash(Buffer.from(networkPassphrase));
+  // v17: `networkId` is an `xdr.Hash` wrapper, so compare via its structural
+  // `equals` against an equally-wrapped expected hash (a wrapper's `equals`
+  // returns false for raw bytes rather than comparing them).
+  const expectedNetworkId = new xdr.Hash(hash(Buffer.from(networkPassphrase)));
   if (!normalized.networkId.equals(expectedNetworkId)) {
     return {
       valid: false,

--- a/src/hooks/useGetActiveAccount.ts
+++ b/src/hooks/useGetActiveAccount.ts
@@ -62,7 +62,7 @@ const useGetActiveAccount = () => {
 
       transaction.sign(keyPair);
 
-      return transaction.toXDR();
+      return transaction.toXdr();
     },
     [account],
   );

--- a/src/hooks/useValidateTransactionMemo.ts
+++ b/src/hooks/useValidateTransactionMemo.ts
@@ -19,11 +19,11 @@ import { stellarSdkServer } from "services/stellar";
 /**
  * Checks if a memo is required by querying cached memo-required accounts
  *
- * @param {ReturnType<typeof TransactionBuilder.fromXDR>} transaction - The transaction to check
+ * @param {ReturnType<typeof TransactionBuilder.fromXdr>} transaction - The transaction to check
  * @returns {Promise<boolean>} True if a memo is required, false otherwise
  */
 export const checkMemoRequiredFromCache = async (
-  transaction: ReturnType<typeof TransactionBuilder.fromXDR>,
+  transaction: ReturnType<typeof TransactionBuilder.fromXdr>,
 ): Promise<boolean> => {
   const response = await cachedFetch<MemoRequiredAccountsApiResponse>({
     urlOrFn: getApiStellarExpertIsMemoRequiredListUrl(),
@@ -50,12 +50,12 @@ export const checkMemoRequiredFromCache = async (
  * Checks if a memo is required using Stellar SDK's built-in validation
  * This is a fallback method when cache validation fails
  *
- * @param {ReturnType<typeof TransactionBuilder.fromXDR>} transaction - The transaction to check
+ * @param {ReturnType<typeof TransactionBuilder.fromXdr>} transaction - The transaction to check
  * @param {string} networkUrl - The network URL for the Stellar server
  * @returns {Promise<boolean>} True if a memo is required, false otherwise
  */
 export const checkMemoRequiredFromStellarSDK = async (
-  transaction: ReturnType<typeof TransactionBuilder.fromXDR>,
+  transaction: ReturnType<typeof TransactionBuilder.fromXdr>,
   networkUrl: string,
 ): Promise<boolean> => {
   const server = stellarSdkServer(networkUrl);
@@ -93,7 +93,7 @@ export const useValidateTransactionMemo = (incomingXdr?: string | null) => {
   const [localMemo, setLocalMemo] = useState<string>(transactionMemo ?? "");
   const [isValidatingMemo, setIsValidatingMemo] = useState(false);
   const [localTransaction, setLocalTransaction] = useState<ReturnType<
-    typeof TransactionBuilder.fromXDR
+    typeof TransactionBuilder.fromXdr
   > | null>(null);
   const networkDetails = useMemo(
     () => mapNetworkToNetworkDetails(network),
@@ -136,9 +136,9 @@ export const useValidateTransactionMemo = (incomingXdr?: string | null) => {
       return;
     }
 
-    let transaction: ReturnType<typeof TransactionBuilder.fromXDR>;
+    let transaction: ReturnType<typeof TransactionBuilder.fromXdr>;
     try {
-      transaction = TransactionBuilder.fromXDR(xdr, network);
+      transaction = TransactionBuilder.fromXdr(xdr, network);
     } catch (e) {
       // Malformed XDR — cannot validate memo, reset state to avoid stale UI
       logger.warn(

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -1173,6 +1173,11 @@
       "functionName": "Function name",
       "parameters": "Parameters",
       "contractAddress": "Contract address",
+      "executableOwner": "Executable owner",
+      "executableTag": "Executable tag",
+      "executableNote": "This contract's code is managed by the executable owner and can change after you sign.",
+      "unrecognizedInvocation": "Unrecognized invocation",
+      "unrecognizedInvocationWarning": "Freighter could not read this authorization. Do not sign unless you trust this site.",
       "address": "Signer address"
     },
     "operations": {

--- a/src/i18n/locales/pt/translations.json
+++ b/src/i18n/locales/pt/translations.json
@@ -1173,6 +1173,11 @@
       "functionName": "Nome da função",
       "parameters": "Parâmetros",
       "contractAddress": "Endereço do contrato",
+      "executableOwner": "Proprietário do executável",
+      "executableTag": "Tag do executável",
+      "executableNote": "O código deste contrato é gerenciado pelo proprietário do executável e pode mudar depois que você assinar.",
+      "unrecognizedInvocation": "Invocação não reconhecida",
+      "unrecognizedInvocationWarning": "O Freighter não conseguiu ler esta autorização. Não assine a menos que você confie neste site.",
       "address": "Endereço do signatário"
     },
     "operations": {

--- a/src/services/analytics/core.ts
+++ b/src/services/analytics/core.ts
@@ -1,6 +1,6 @@
 import * as amplitude from "@amplitude/analytics-react-native";
 import { Experiment } from "@amplitude/experiment-react-native-client";
-import { hash } from "@stellar/stellar-sdk";
+import { hash, xdr } from "@stellar/stellar-sdk";
 import { AnalyticsEvent, isScreenViewEvent } from "config/analyticsConfig";
 import { logger } from "config/logger";
 import { syncSentryEnablement } from "config/sentryConfig";
@@ -274,7 +274,7 @@ export const getAccountIdHash = (publicKey: string): string => {
   const cached = accountIdHashCache.get(publicKey);
   if (cached) return cached;
   try {
-    const digest = hash(Buffer.from(publicKey, "utf8")).toString("hex");
+    const digest = xdr.encodeBytes(hash(Buffer.from(publicKey, "utf8")), "hex");
     accountIdHashCache.set(publicKey, digest);
     return digest;
   } catch {

--- a/src/services/auth/buildAuthJwt.ts
+++ b/src/services/auth/buildAuthJwt.ts
@@ -1,4 +1,4 @@
-import { Keypair } from "@stellar/stellar-sdk";
+import { Keypair, xdr } from "@stellar/stellar-sdk";
 import { createHash } from "crypto";
 
 export const ISS = "freighter-mobile";
@@ -12,9 +12,11 @@ export interface BuildAuthJwtParams {
   now?: number; // ms epoch; injectable for tests
 }
 
-const b64url = (b: Buffer): string =>
-  b
-    .toString("base64")
+// v17: Keypair.sign / rawPublicKey return Uint8Array (not Buffer), whose
+// `toString("base64")` would silently yield comma-joined decimals.
+const b64url = (b: Uint8Array): string =>
+  xdr
+    .encodeBytes(b, "base64")
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/, "");
@@ -38,7 +40,7 @@ export const buildAuthJwt = ({
     .update(body ?? "")
     .digest("hex");
   const payload = {
-    sub: keypair.rawPublicKey().toString("hex"),
+    sub: xdr.encodeBytes(keypair.rawPublicKey(), "hex"),
     iss: ISS,
     iat,
     exp: iat + JWT_LIFETIME_SECONDS,

--- a/src/services/auth/deriveAuthKeypair.ts
+++ b/src/services/auth/deriveAuthKeypair.ts
@@ -9,7 +9,7 @@
 // derives from `bip39` directly (stellar/freighter#2876), and (2) we need its
 // async `mnemonicToSeed` + `validateMnemonic` here. It is pinned to the same
 // exact version stellar-hd-wallet resolves transitively.
-import { Keypair } from "@stellar/stellar-sdk";
+import { Keypair, xdr } from "@stellar/stellar-sdk";
 import { mnemonicToSeed, validateMnemonic } from "bip39";
 import { createHmac } from "crypto";
 
@@ -36,5 +36,7 @@ export const deriveAuthKeypair = async (
   mnemonic: string,
 ): Promise<{ userId: string; keypair: Keypair }> => {
   const keypair = Keypair.fromRawEd25519Seed(await deriveAuthSeed(mnemonic));
-  return { userId: keypair.rawPublicKey().toString("hex"), keypair };
+  // v17: rawPublicKey returns a Uint8Array (not Buffer), whose
+  // `toString("hex")` would silently yield comma-joined decimals.
+  return { userId: xdr.encodeBytes(keypair.rawPublicKey(), "hex"), keypair };
 };

--- a/src/services/auth/getAuthUserId.ts
+++ b/src/services/auth/getAuthUserId.ts
@@ -1,3 +1,4 @@
+import { xdr } from "@stellar/stellar-sdk";
 import { getAuthKeypair } from "services/auth/getAuthKeypair";
 
 /**
@@ -7,5 +8,5 @@ import { getAuthKeypair } from "services/auth/getAuthKeypair";
  */
 export const getAuthUserId = async (): Promise<string | null> => {
   const keypair = await getAuthKeypair();
-  return keypair ? keypair.rawPublicKey().toString("hex") : null;
+  return keypair ? xdr.encodeBytes(keypair.rawPublicKey(), "hex") : null;
 };

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -908,7 +908,7 @@ export const simulateTokenTransfer = async (
 
   return {
     ...data,
-    preparedTx: TransactionBuilder.fromXDR(
+    preparedTx: TransactionBuilder.fromXdr(
       data.preparedTransaction,
       params.network_passphrase,
     ),

--- a/src/services/stellar.ts
+++ b/src/services/stellar.ts
@@ -147,7 +147,7 @@ export const submitTx = async (
 
   const transaction =
     typeof tx === "string"
-      ? TransactionBuilder.fromXDR(tx, networkPassphrase)
+      ? TransactionBuilder.fromXdr(tx, networkPassphrase)
       : tx;
 
   let submittedTx;
@@ -283,14 +283,14 @@ export const buildChangeTrustTx = async (input: BuildChangeTrustTxParams) => {
     .addOperation(buildChangeTrustOperation({ tokenCode, issuer, isRemove }))
     .setTimeout(DEFAULT_TRANSACTION_TIMEOUT);
 
-  return txBuilder.build().toXDR();
+  return txBuilder.build().toXdr();
 };
 
 export const signTransaction = (input: SignTxParams): string => {
   const { tx, secretKey, network } = input;
   const { networkPassphrase } = mapNetworkToNetworkDetails(network);
-  const transactionXDR = typeof tx === "string" ? tx : tx.toXDR();
-  const transaction = TransactionBuilder.fromXDR(
+  const transactionXDR = typeof tx === "string" ? tx : tx.toXdr();
+  const transaction = TransactionBuilder.fromXdr(
     transactionXDR,
     networkPassphrase,
   );
@@ -298,7 +298,7 @@ export const signTransaction = (input: SignTxParams): string => {
   const keypair = Keypair.fromSecret(secretKey);
   transaction.sign(keypair);
 
-  return transaction.toXDR();
+  return transaction.toXdr();
 };
 
 export const getAccount = async (

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -518,7 +518,7 @@ export const buildPaymentTransaction = async (
       });
 
       const transaction = transactionBuilder.build();
-      const transactionXDR = transaction.toXDR();
+      const transactionXDR = transaction.toXdr();
 
       return {
         tx: transaction,
@@ -557,7 +557,7 @@ export const buildPaymentTransaction = async (
 
             return {
               tx: transaction,
-              xdr: transaction.toXDR(),
+              xdr: transaction.toXdr(),
               finalDestination: recipientAddress,
             };
           }
@@ -580,7 +580,7 @@ export const buildPaymentTransaction = async (
 
     return {
       tx: transaction,
-      xdr: transaction.toXDR(),
+      xdr: transaction.toXdr(),
       finalDestination: recipientAddress,
     };
   } catch (error) {
@@ -678,7 +678,7 @@ export const buildSwapTransaction = async (
     );
 
     const transaction = txBuilder.build();
-    return { tx: transaction, xdr: transaction.toXDR() };
+    return { tx: transaction, xdr: transaction.toXdr() };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -758,7 +758,7 @@ export const buildSendCollectibleTransaction = async (
 
     return {
       tx: transaction,
-      xdr: transaction.toXDR(),
+      xdr: transaction.toXdr(),
       finalDestination,
     };
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,6 +2181,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/bytes@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "@exodus/bytes@npm:1.15.1"
+  peerDependencies:
+    "@noble/hashes": ^1.8.0 || ^2.0.0
+  peerDependenciesMeta:
+    "@noble/hashes":
+      optional: true
+  checksum: 10c0/333056a6953bbf875d9f3b86c32314de29458d842e5f56f6ef8034b18c2d9660184550093d1bae5de0064043d5e23f54cc03148798d9d29cf5167ac03f2e9f8c
+  languageName: node
+  linkType: hard
+
 "@exodus/patch-broken-hermes-typed-arrays@npm:1.0.0-alpha.1":
   version: 1.0.0-alpha.1
   resolution: "@exodus/patch-broken-hermes-typed-arrays@npm:1.0.0-alpha.1"
@@ -4677,17 +4689,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stellar/js-xdr@npm:4.0.0, @stellar/js-xdr@npm:^4.0.0":
+"@stellar/js-xdr@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@stellar/js-xdr@npm:3.1.2"
+  checksum: 10c0/eaa1fc9341b1d1bcaf5c616b9bc0a6dc9a6c7ef7a477f6f6b4cb4206a947cdd3c7e06395ba7be30f6137179eec5f206d75b3ed66fdfe5e2ac54553b7a353130c
+  languageName: node
+  linkType: hard
+
+"@stellar/js-xdr@npm:^4.0.0":
   version: 4.0.0
   resolution: "@stellar/js-xdr@npm:4.0.0"
   checksum: 10c0/617bb3d7fa9fbdb607e5cb42cc032a15ad1c111440c6d7ede40fcecde204e88ed351aebc80ce1e4eedac6c1d949c3da5722696611e2b00569e7edbd5a0634c37
   languageName: node
   linkType: hard
 
-"@stellar/js-xdr@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "@stellar/js-xdr@npm:3.1.2"
-  checksum: 10c0/eaa1fc9341b1d1bcaf5c616b9bc0a6dc9a6c7ef7a477f6f6b4cb4206a947cdd3c7e06395ba7be30f6137179eec5f206d75b3ed66fdfe5e2ac54553b7a353130c
+"@stellar/js-xdr@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@stellar/js-xdr@npm:5.0.0"
+  checksum: 10c0/c61b1e0ed2d74ec523d306437318f63d639889cc853fe7db7e7b2bb923da0c4d1ea568060ca6ed542546a3ef4943f150a385318fcc5723dc820b2efd511130be
   languageName: node
   linkType: hard
 
@@ -4742,17 +4761,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stellar/stellar-sdk@npm:16.0.0":
-  version: 16.0.0
-  resolution: "@stellar/stellar-sdk@npm:16.0.0"
+"@stellar/stellar-sdk@npm:17.0.1":
+  version: 17.0.1
+  resolution: "@stellar/stellar-sdk@npm:17.0.1"
   dependencies:
+    "@exodus/bytes": "npm:^1.15.1"
     "@noble/ed25519": "npm:^3.1.0"
     "@noble/hashes": "npm:^2.2.0"
-    "@stellar/js-xdr": "npm:4.0.0"
-    axios: "npm:1.16.1"
-    base32.js: "npm:^0.1.0"
-    bignumber.js: "npm:^11.1.1"
-    buffer: "npm:^6.0.3"
+    "@stellar/js-xdr": "npm:^5.0.0"
+    "@types/json-schema": "npm:^7.0.15"
+    axios: "npm:1.18.0"
+    bignumber.js: "npm:^11.1.4"
     commander: "npm:^14.0.3"
     eventsource: "npm:^4.1.0"
     feaxios: "npm:^0.0.23"
@@ -4760,7 +4779,7 @@ __metadata:
     uint8array-extras: "npm:^1.5.0"
   bin:
     stellar-js: bin/stellar-js
-  checksum: 10c0/d3aa09d009787e147c9a3da4b4bf39d15001112cbd968d658aaea0d32a4c5ed3b8f3bd92b1c76b925a253f4e2c0c718a9737e49367be74e6f5683d9b365bf8a1
+  checksum: 10c0/027d1a5c1187998cc9fc3142c74039ef272e20ed4200a9f34f058c130000b680066c0edd0978543f18a005558cf2bd6ceb0e05ccdb757a7f9136935d9376600e
   languageName: node
   linkType: hard
 
@@ -5181,7 +5200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -6678,15 +6697,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.1":
-  version: 1.16.1
-  resolution: "axios@npm:1.16.1"
+"axios@npm:1.18.0":
+  version: 1.18.0
+  resolution: "axios@npm:1.18.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2f77e37e6552bbff8a772d058fb09500198e9188c6b20dc799d82dbe12a8cb506f6eed4e4e62a9ba612a35cbab496faa26d68f9bff14a53af6d15c3e136391a7
+  checksum: 10c0/f88aae13fd9dd395dea3053c7299178fee62f436f20424a1d6d79ec11ffb7656ba664b4630defbadab2c387b6ea07e29afb9f28b26d8e0e49d45be766983290d
   languageName: node
   linkType: hard
 
@@ -7093,10 +7112,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^11.1.1":
-  version: 11.1.3
-  resolution: "bignumber.js@npm:11.1.3"
-  checksum: 10c0/5ab91a37ee92d334d7df92b79a0340b559e75d78ed0175f497243b8b043e00368e26b4f5fbed15ab129d922337c22cfe20d8b861cd9ef25e0d4e1dbae6b25c3b
+"bignumber.js@npm:^11.1.4":
+  version: 11.1.5
+  resolution: "bignumber.js@npm:11.1.5"
+  checksum: 10c0/8e829402c6c190d92becb2495d62581c66f170deae99f43ae859e54cdc586d4375c752131d07f60fcc709b84c9ca4c362623c97f3703629e69792c7bb1def00c
   languageName: node
   linkType: hard
 
@@ -9955,7 +9974,7 @@ __metadata:
     "@shopify/react-native-skia": "npm:2.2.21"
     "@stablelib/base64": "npm:2.0.1"
     "@stablelib/utf8": "npm:2.0.1"
-    "@stellar/stellar-sdk": "npm:16.0.0"
+    "@stellar/stellar-sdk": "npm:17.0.1"
     "@stellar/typescript-wallet-sdk-km": "npm:3.0.0"
     "@testing-library/jest-native": "npm:5.4.3"
     "@testing-library/react-hooks": "npm:8.0.1"


### PR DESCRIPTION
### What

Bumps `@stellar/stellar-sdk` from 16.0.0 to 17.0.1 (Protocol 28 XDR via `@stellar/js-xdr` 5) and migrates every call site through both v17 breaking-change guides: the class-based `xdr` namespace (unions switch on `.type` with property arms, enums are singletons, `int64` is `bigint`, named byte aliases are wrappers read via `.toBytes()`) and the `Buffer` -> `Uint8Array` return type change. This is the mobile port of stellar/freighter#2977, including its CAP-85 follow-up commits.

Beyond the mechanical rename/accessor updates, the diff covers: explicit `xdr.encodeBytes` at every site that previously relied on `Buffer.toString("hex"|"base64")` on an SDK result (SEP-53 `signMessage`, SEP-43 `signAuthEntry`, auth-JWT `sub`/`userId`/signature, analytics account-id hash, wasm hash/salt/bytes rendering), since `Uint8Array.toString` silently yields comma-joined decimals; auth-entry network-id comparison via `xdr.Hash.equals` (a wrapper's `equals` returns `false` for raw bytes); signer hashes rendered as the same uppercase hex whether the SDK hands back a hex string (`revokeSponsorship`) or bytes (`setOptions`); `@exodus/bytes` added to the Jest transform allowlist because v17's CJS build `require()`s it and Jest cannot load ESM through its CJS registry.

Protocol 28 / CAP-85: `getInvocationArgs` and the create-contract KeyVal handle `CONTRACT_EXECUTABLE_EXTERNAL_REF` (executable owner + tag, a note that the owner can change the code after signing, deliberately no wasm hash, `address`/`salt` only read from the address preimage arm); `scValByType` decodes `SCV_EXECUTABLE_TAG`; `getInvocationDetails` logs and renders an "unrecognized invocation" warning instead of letting one undecodable invocation throw from a render body and take down the signing view; invalid executable/preimage pairings throw an error naming the pairing.

### Why

v17 is the SDK release that carries the Protocol 28 XDR schema (CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` becomes the default, CAP-83, CAP-85) and Freighter must decode and review those entries on day one. The XDR rebuild also changed behaviors that do not surface as compile errors: `.toString("hex")` on byte results stops matching silently, `scValToNative` returns `Uint8Array` for non-UTF-8 strings, and previously undecodable CAP-85 arms now decode successfully and reach our own `switch` statements, so every one of those paths needed an explicit update and a test rather than relying on the deprecated aliases 17.0.1 restores.

17.0.1 is used over the extension's 17.0.0 because it adds the deprecated `toXDR`-style aliases as a runtime safety net for any third-party code path we do not control and contains no protocol-affecting changes. The lockfile pins the resolution, so the 7-day `npmMinimalAgeGate` in `.yarnrc.yml` does not affect `yarn install --immutable`.

### Known limitations

`yarn lint:check` reports the same pre-existing `import/order` conflict between ESLint and the Prettier sort-imports plugin for files importing Node builtins alongside `@stellar/stellar-sdk` (`parseTransaction.ts` on `main`, and the two `services/auth` files here); Prettier's order is what the pre-commit hook enforces, and `lint:check` is not part of CI. The sign-transaction and auth-entry review screens were verified via unit tests (including new CAP-85 fixtures) rather than a live dApp round-trip on device. `xdr.ScAddress.scAddressTypeContract(rawBytes)` in 17.0.1 produces an address whose `contractId` fails to encode (wrapping in `new xdr.ContractId(...)` works); only a test fixture was affected, but it is worth an upstream report.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [ ] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.

#### Verification

- [x] `yarn tsc --noEmit` clean
- [x] `yarn jest --ci`: 223/223 suites, 2984 tests green
- [x] `yarn install --immutable` passes from the updated lockfile without touching `.yarnrc.yml`
- [x] Metro production bundle builds (`react-native bundle --platform ios --dev false`), confirming v17's ESM deps (`@exodus/bytes`, `uint8array-extras`, `smol-toml`) resolve under Metro
- [x] Dev build boots on Hermes (iPhone 17 simulator) with live Horizon balances and no JS errors
- [ ] CI green