### PR TITLE
fix(ci): authenticate and retry the SSH host-key fetch (iOS + Android)

### DIFF
--- a/.github/workflows/prPreviewAndroid.yml
+++ b/.github/workflows/prPreviewAndroid.yml
@@ -129,9 +129,10 @@ jobs:
           set -uo pipefail
           KEY_FILE="$(mktemp)"
           KNOWN_HOSTS="$(mktemp)"
+          META_JSON="$(mktemp)"
           CLONE_DIR="$(mktemp -d)"
           CONFIG_OUT="${RUNNER_TEMP}/freighter-config.json"
-          cleanup() { rm -f "$KEY_FILE" "$KNOWN_HOSTS"; rm -rf "$CLONE_DIR"; }
+          cleanup() { rm -f "$KEY_FILE" "$KNOWN_HOSTS" "$META_JSON"; rm -rf "$CLONE_DIR"; }
           trap cleanup EXIT
 
           if [ -z "${FREIGHTER_CONFIG_DEPLOY_KEY}" ]; then
@@ -143,23 +144,49 @@ jobs:
           printf '%s\n' "${FREIGHTER_CONFIG_DEPLOY_KEY}" > "$KEY_FILE"
           chmod 600 "$KEY_FILE"
 
-          # Pin GitHub's SSH host keys (fetched over TLS-authenticated HTTPS —
-          # always current, no hardcoded key to rot) + StrictHostKeyChecking=yes
-          # so a network impersonator can't MITM the clone and serve an
-          # attacker-controlled config.json. If keys can't be fetched, degrade.
-          # Authenticated and retried, because a failure here silently costs
-          # the preview its sandbox targeting. Unauthenticated api.github.com
-          # allows 60 requests/hour PER IP and runners share egress addresses,
-          # so a busy pool exhausts it and this 403s — which is why iOS
-          # degraded far more often than Android, on a smaller runner pool.
-          # The job token raises the limit to 5000/hour and returns an
-          # identical response (verified: same ssh_keys either way). Retries
-          # cover transient blips on top of that.
-          if ! curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-connrefused \
-               -H "Authorization: Bearer ${GH_META_TOKEN}" \
-               https://api.github.com/meta \
-               | jq -r '.ssh_keys[] | "github.com \(.)"' > "$KNOWN_HOSTS" \
-             || [ ! -s "$KNOWN_HOSTS" ]; then
+          # Fetch to a FILE, not a pipe. curl can only discard the partial body
+          # of a failed transfer when the target is a file — with a pipe it
+          # re-sends the whole body on retry, jq receives partial+full, and the
+          # parse fails anyway. Piped retries buy nothing here.
+          #
+          # --retry-all-errors because curl's default "transient" set is
+          # timeouts plus 408/429/5xx. GitHub answers a rate limit with 403,
+          # which is precisely the failure this is meant to survive, and plain
+          # --retry makes exactly one attempt against it.
+          #
+          # --retry-max-time bounds the total wait: curl honours Retry-After
+          # over --retry-delay, and GitHub's secondary limits send values in the
+          # tens of seconds, so an unbounded retry could stall this optional
+          # step for minutes. --max-time is per-attempt and resets on retry, so
+          # it cannot bound this on its own.
+          #
+          # Authenticated first, then anonymous. /meta needs no auth, so the
+          # token is upside for rate limits — GITHUB_TOKEN gets 1,000 req/hour
+          # per REPOSITORY (shared with every other workflow here and with the
+          # gh calls later in this one) instead of 60/hour per runner IP shared
+          # across the whole pool. But authenticating introduces failures the
+          # anonymous request cannot have: an empty or rejected token, or org IP
+          # allow-lists that apply to authenticated calls only. The two draw on
+          # different buckets, so trying both is strictly better than either.
+          fetch_meta() {
+            if [ -n "${1:-}" ]; then
+              curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-max-time 40 \
+                --retry-all-errors -H "Authorization: Bearer $1" \
+                -o "$META_JSON" https://api.github.com/meta
+            else
+              curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-max-time 40 \
+                --retry-all-errors -o "$META_JSON" https://api.github.com/meta
+            fi
+          }
+
+          if fetch_meta "${GH_META_TOKEN:-}"; then
+            :
+          elif fetch_meta ""; then
+            echo "::warning::Authenticated api.github.com/meta fetch failed; anonymous fetch succeeded"
+          fi
+          jq -r '.ssh_keys[] | "github.com \(.)"' "$META_JSON" > "$KNOWN_HOSTS" 2>/dev/null || true
+
+          if [ ! -s "$KNOWN_HOSTS" ]; then
             echo "config_available=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Could not fetch GitHub SSH host keys; falling back to staging"
             exit 0

--- a/.github/workflows/prPreviewAndroid.yml
+++ b/.github/workflows/prPreviewAndroid.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           FREIGHTER_CONFIG_DEPLOY_KEY:
             ${{ secrets.FREIGHTER_CONFIG_DEPLOY_KEY }}
+          GH_META_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           KEY_FILE="$(mktemp)"
@@ -146,7 +147,17 @@ jobs:
           # always current, no hardcoded key to rot) + StrictHostKeyChecking=yes
           # so a network impersonator can't MITM the clone and serve an
           # attacker-controlled config.json. If keys can't be fetched, degrade.
-          if ! curl -fsS --max-time 15 https://api.github.com/meta \
+          # Authenticated and retried, because a failure here silently costs
+          # the preview its sandbox targeting. Unauthenticated api.github.com
+          # allows 60 requests/hour PER IP and runners share egress addresses,
+          # so a busy pool exhausts it and this 403s — which is why iOS
+          # degraded far more often than Android, on a smaller runner pool.
+          # The job token raises the limit to 5000/hour and returns an
+          # identical response (verified: same ssh_keys either way). Retries
+          # cover transient blips on top of that.
+          if ! curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-connrefused \
+               -H "Authorization: Bearer ${GH_META_TOKEN}" \
+               https://api.github.com/meta \
                | jq -r '.ssh_keys[] | "github.com \(.)"' > "$KNOWN_HOSTS" \
              || [ ! -s "$KNOWN_HOSTS" ]; then
             echo "config_available=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -146,6 +146,7 @@ jobs:
         env:
           FREIGHTER_CONFIG_DEPLOY_KEY:
             ${{ secrets.FREIGHTER_CONFIG_DEPLOY_KEY }}
+          GH_META_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           KEY_FILE="$(mktemp)"
@@ -174,7 +175,17 @@ jobs:
           # cert), write them to a temp known_hosts, and require
           # StrictHostKeyChecking=yes. If we can't obtain the keys, degrade to
           # staging rather than fall back to unverified host trust.
-          if ! curl -fsS --max-time 15 https://api.github.com/meta \
+          # Authenticated and retried, because a failure here silently costs
+          # the preview its sandbox targeting. Unauthenticated api.github.com
+          # allows 60 requests/hour PER IP and runners share egress addresses,
+          # so a busy pool exhausts it and this 403s — which is why iOS
+          # degraded far more often than Android, on a smaller runner pool.
+          # The job token raises the limit to 5000/hour and returns an
+          # identical response (verified: same ssh_keys either way). Retries
+          # cover transient blips on top of that.
+          if ! curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-connrefused \
+               -H "Authorization: Bearer ${GH_META_TOKEN}" \
+               https://api.github.com/meta \
                | jq -r '.ssh_keys[] | "github.com \(.)"' > "$KNOWN_HOSTS" \
              || [ ! -s "$KNOWN_HOSTS" ]; then
             echo "config_available=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prPreviewIos.yml
+++ b/.github/workflows/prPreviewIos.yml
@@ -151,9 +151,10 @@ jobs:
           set -uo pipefail
           KEY_FILE="$(mktemp)"
           KNOWN_HOSTS="$(mktemp)"
+          META_JSON="$(mktemp)"
           CLONE_DIR="$(mktemp -d)"
           CONFIG_OUT="${RUNNER_TEMP}/freighter-config.json"
-          cleanup() { rm -f "$KEY_FILE" "$KNOWN_HOSTS"; rm -rf "$CLONE_DIR"; }
+          cleanup() { rm -f "$KEY_FILE" "$KNOWN_HOSTS" "$META_JSON"; rm -rf "$CLONE_DIR"; }
           trap cleanup EXIT
 
           if [ -z "${FREIGHTER_CONFIG_DEPLOY_KEY}" ]; then
@@ -165,29 +166,49 @@ jobs:
           printf '%s\n' "${FREIGHTER_CONFIG_DEPLOY_KEY}" > "$KEY_FILE"
           chmod 600 "$KEY_FILE"
 
-          # Pin GitHub's SSH host keys instead of trusting-on-first-use. On an
-          # ephemeral runner every connection is "first contact", so
-          # StrictHostKeyChecking=accept-new offers no MITM protection — a
-          # network impersonator could serve an attacker-controlled config.json
-          # whose URLs would be baked into the preview. Fetch GitHub's published
-          # host keys from the meta API over TLS-authenticated HTTPS (always
-          # current — no hardcoded key to rot; a MITM can't forge api.github.com's
-          # cert), write them to a temp known_hosts, and require
-          # StrictHostKeyChecking=yes. If we can't obtain the keys, degrade to
-          # staging rather than fall back to unverified host trust.
-          # Authenticated and retried, because a failure here silently costs
-          # the preview its sandbox targeting. Unauthenticated api.github.com
-          # allows 60 requests/hour PER IP and runners share egress addresses,
-          # so a busy pool exhausts it and this 403s — which is why iOS
-          # degraded far more often than Android, on a smaller runner pool.
-          # The job token raises the limit to 5000/hour and returns an
-          # identical response (verified: same ssh_keys either way). Retries
-          # cover transient blips on top of that.
-          if ! curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-connrefused \
-               -H "Authorization: Bearer ${GH_META_TOKEN}" \
-               https://api.github.com/meta \
-               | jq -r '.ssh_keys[] | "github.com \(.)"' > "$KNOWN_HOSTS" \
-             || [ ! -s "$KNOWN_HOSTS" ]; then
+          # Fetch to a FILE, not a pipe. curl can only discard the partial body
+          # of a failed transfer when the target is a file — with a pipe it
+          # re-sends the whole body on retry, jq receives partial+full, and the
+          # parse fails anyway. Piped retries buy nothing here.
+          #
+          # --retry-all-errors because curl's default "transient" set is
+          # timeouts plus 408/429/5xx. GitHub answers a rate limit with 403,
+          # which is precisely the failure this is meant to survive, and plain
+          # --retry makes exactly one attempt against it.
+          #
+          # --retry-max-time bounds the total wait: curl honours Retry-After
+          # over --retry-delay, and GitHub's secondary limits send values in the
+          # tens of seconds, so an unbounded retry could stall this optional
+          # step for minutes. --max-time is per-attempt and resets on retry, so
+          # it cannot bound this on its own.
+          #
+          # Authenticated first, then anonymous. /meta needs no auth, so the
+          # token is upside for rate limits — GITHUB_TOKEN gets 1,000 req/hour
+          # per REPOSITORY (shared with every other workflow here and with the
+          # gh calls later in this one) instead of 60/hour per runner IP shared
+          # across the whole pool. But authenticating introduces failures the
+          # anonymous request cannot have: an empty or rejected token, or org IP
+          # allow-lists that apply to authenticated calls only. The two draw on
+          # different buckets, so trying both is strictly better than either.
+          fetch_meta() {
+            if [ -n "${1:-}" ]; then
+              curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-max-time 40 \
+                --retry-all-errors -H "Authorization: Bearer $1" \
+                -o "$META_JSON" https://api.github.com/meta
+            else
+              curl -fsS --max-time 15 --retry 3 --retry-delay 2 --retry-max-time 40 \
+                --retry-all-errors -o "$META_JSON" https://api.github.com/meta
+            fi
+          }
+
+          if fetch_meta "${GH_META_TOKEN:-}"; then
+            :
+          elif fetch_meta ""; then
+            echo "::warning::Authenticated api.github.com/meta fetch failed; anonymous fetch succeeded"
+          fi
+          jq -r '.ssh_keys[] | "github.com \(.)"' "$META_JSON" > "$KNOWN_HOSTS" 2>/dev/null || true
+
+          if [ ! -s "$KNOWN_HOSTS" ]; then
             echo "config_available=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Could not fetch GitHub SSH host keys; falling back to staging"
             exit 0


### PR DESCRIPTION
## TL;DR

Preview builds were intermittently losing their sandbox targeting and silently falling back to staging — **4 of the last 12 iOS preview runs** hit it.

The cause is a rate limit: the workflow fetched GitHub's published SSH host keys from `api.github.com/meta` **unauthenticated**, which allows 60 requests/hour *per IP*. Runners share egress addresses, so a busy pool exhausts it and the call 403s. This authenticates the call, and makes the retry actually cover that failure.

<details>
<summary>Implementation details (for agents/reviewers)</summary>

**Why it matters more than a flaky step.** The fetch exists so the `freighter-config` clone can use `StrictHostKeyChecking=yes` rather than trusting-on-first-use — on an ephemeral runner every connection is first contact. When it fails we deliberately degrade to staging rather than fall back to unverified host trust. **That design is unchanged.** The problem was that it fired often enough to become noise, and a preview pointed at the wrong backend looks like a working app.

**Evidence it's rate limiting, not flakiness:** stellar/freighter-mobile#988's iOS run at 18:45 degraded, while *its own run at 18:26 — same commit, same config —* resolved to `sandbox (aristidesstaffieri)`. Android on that same commit resolved correctly at the same moment; Android runs on `ubuntu-latest`, iOS on the smaller `macos-26-xlarge` pool. That asymmetry is what a per-IP budget looks like.

**The change:**

| | Why |
| :-- | :-- |
| `-H "Authorization: Bearer ${GH_META_TOKEN}"` (`github.token`) | swaps a 60/hour **per-IP** budget shared across the runner pool for **1,000/hour per repository** — shared with other workflows here and with this workflow's own `gh` calls, but far more headroom |
| falls back to an **anonymous** fetch if the authenticated one fails | `/meta` needs no auth, so authenticating adds failures anonymous can't have (empty/rejected token, org IP allow-lists). Different rate-limit buckets, so trying both beats either |
| `-o "$META_JSON"` instead of piping to `jq` | curl only discards a failed transfer's partial body when the target is a **file**; with a pipe it re-sends the whole body and `jq` gets partial+full |
| `--retry-all-errors` | curl's default "transient" set is timeouts + 408/429/5xx. GitHub answers a rate limit with **403**, so plain `--retry` made exactly **one** attempt against the very failure this targets |
| `--retry-max-time 40` | curl honours `Retry-After` over `--retry-delay`, so an unbounded retry could stall this optional step for minutes. `--max-time` is per-attempt and resets on retry, so it can't bound this alone |

`--retry-all-errors` does retry permanent 4xx as well. That's intended here: the request is idempotent, the endpoint is public, the total is bounded by `--retry-max-time`, and every remaining failure path still lands on the same safe degrade.

**Verified rather than asserted:**

| Check | Result |
| :-- | :-- |
| `--retry 3` against a stub 403 | **1 request** |
| `--retry 3 --retry-all-errors` against same | **4 requests** |
| `--retry-max-time 3` vs unbounded, dead port | **4.0s vs 6.0s** |
| Authenticated vs anonymous `/meta` payload | identical — same three `ssh_keys` |
| Step run with a valid token | 3 keys, no degrade |
| Step run with an **invalid** token | anonymous fallback → 3 keys (**previously degraded**) |
| Step run with an empty token | 3 keys |
| Step run against an unreachable host | degrades with the warning, `exit 0` |

`actionlint` unchanged from the base branch in all files.

**No new permissions.** `github.token` is always present and `/meta` is public; the token only identifies the caller for rate-limiting.
