### PR TITLE
discovery: support hyperlinks in protocol descriptions

### DIFF
--- a/__tests__/components/LinkedText.test.tsx
+++ b/__tests__/components/LinkedText.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, act } from "@testing-library/react-native";
+import { LinkedText } from "components/LinkedText";
+import { renderWithProviders } from "helpers/testUtils";
+import React from "react";
+import { Linking } from "react-native";
+
+describe("LinkedText", () => {
+  it("renders plain text with no links untouched", () => {
+    const { getByText } = renderWithProviders(
+      <LinkedText md>just plain text</LinkedText>,
+    );
+    expect(getByText("just plain text")).toBeTruthy();
+  });
+
+  it("opens the target URL when a markdown-style link is pressed", async () => {
+    const { getByText } = renderWithProviders(
+      <LinkedText md>
+        {"See the [docs](https://example.com/docs) now."}
+      </LinkedText>,
+    );
+
+    const link = getByText("docs");
+    expect(link.props.accessibilityRole).toBe("link");
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      fireEvent.press(link);
+    });
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/docs");
+  });
+
+  it("opens the URL when a bare https:// link is pressed", async () => {
+    const { getByText } = renderWithProviders(
+      <LinkedText md>{"Visit https://example.com/x today"}</LinkedText>,
+    );
+
+    const link = getByText("https://example.com/x");
+    expect(link.props.accessibilityRole).toBe("link");
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      fireEvent.press(link);
+    });
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/x");
+  });
+});

--- a/__tests__/helpers/linkedText.test.ts
+++ b/__tests__/helpers/linkedText.test.ts
@@ -119,4 +119,31 @@ describe("parseLinkedText", () => {
       { text: '" now.' },
     ]);
   });
+
+  it("does not linkify a malformed bare URL with no host", () => {
+    expect(parseLinkedText("See https:// for syntax")).toEqual([
+      { text: "See https:// for syntax" },
+    ]);
+    expect(parseLinkedText("See https://?query for syntax")).toEqual([
+      { text: "See https://?query for syntax" },
+    ]);
+  });
+
+  it("does not linkify a malformed markdown URL with no host", () => {
+    expect(parseLinkedText("[bad](https://)")).toEqual([
+      { text: "[bad](https://)" },
+    ]);
+  });
+
+  it("keeps square brackets inside a markdown destination", () => {
+    expect(
+      parseLinkedText(
+        "Search [tags](https://example.com/search?tag[]=security) here.",
+      ),
+    ).toEqual([
+      { text: "Search " },
+      { text: "tags", url: "https://example.com/search?tag[]=security" },
+      { text: " here." },
+    ]);
+  });
 });

--- a/__tests__/helpers/linkedText.test.ts
+++ b/__tests__/helpers/linkedText.test.ts
@@ -1,0 +1,63 @@
+import { parseLinkedText } from "helpers/linkedText";
+
+describe("parseLinkedText", () => {
+  it("returns a single plain-text segment when there are no links", () => {
+    expect(parseLinkedText("just plain text")).toEqual([
+      { text: "just plain text" },
+    ]);
+  });
+
+  it("parses a markdown-style link", () => {
+    expect(
+      parseLinkedText(
+        "See the [incident update](https://example.com/x) now.",
+      ),
+    ).toEqual([
+      { text: "See the " },
+      { text: "incident update", url: "https://example.com/x" },
+      { text: " now." },
+    ]);
+  });
+
+  it("linkifies a bare URL", () => {
+    expect(parseLinkedText("Visit https://example.com/x today")).toEqual([
+      { text: "Visit " },
+      { text: "https://example.com/x", url: "https://example.com/x" },
+      { text: " today" },
+    ]);
+  });
+
+  it("strips trailing punctuation from a bare URL", () => {
+    expect(parseLinkedText("See https://example.com/x.")).toEqual([
+      { text: "See " },
+      { text: "https://example.com/x", url: "https://example.com/x" },
+      { text: "." },
+    ]);
+  });
+
+  it("handles multiple links in the same string", () => {
+    expect(
+      parseLinkedText(
+        "First https://a.com then [second](https://b.com) link.",
+      ),
+    ).toEqual([
+      { text: "First " },
+      { text: "https://a.com", url: "https://a.com" },
+      { text: " then " },
+      { text: "second", url: "https://b.com" },
+      { text: " link." },
+    ]);
+  });
+
+  it("does not linkify non-https schemes", () => {
+    expect(parseLinkedText("Run javascript:alert(1) please")).toEqual([
+      { text: "Run javascript:alert(1) please" },
+    ]);
+  });
+
+  it("does not linkify a bare http (non-https) URL", () => {
+    expect(parseLinkedText("Visit http://example.com/x today")).toEqual([
+      { text: "Visit http://example.com/x today" },
+    ]);
+  });
+});

--- a/__tests__/helpers/linkedText.test.ts
+++ b/__tests__/helpers/linkedText.test.ts
@@ -60,4 +60,34 @@ describe("parseLinkedText", () => {
       { text: "Visit http://example.com/x today" },
     ]);
   });
+
+  it("keeps balanced parentheses inside a bare URL", () => {
+    expect(
+      parseLinkedText(
+        "See https://en.wikipedia.org/wiki/Function_(mathematics) for details.",
+      ),
+    ).toEqual([
+      { text: "See " },
+      {
+        text: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+        url: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+      },
+      { text: " for details." },
+    ]);
+  });
+
+  it("keeps balanced parentheses inside a markdown-style URL", () => {
+    expect(
+      parseLinkedText(
+        "See [Function](https://en.wikipedia.org/wiki/Function_(mathematics)) for details.",
+      ),
+    ).toEqual([
+      { text: "See " },
+      {
+        text: "Function",
+        url: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+      },
+      { text: " for details." },
+    ]);
+  });
 });

--- a/__tests__/helpers/linkedText.test.ts
+++ b/__tests__/helpers/linkedText.test.ts
@@ -1,4 +1,7 @@
-import { parseLinkedText } from "helpers/linkedText";
+// "helpers/*" is remapped by jest.config.js's moduleNameMapper to
+// __mocks__/helpers/*, which has no entry for linkedText - import the real
+// module directly to get the actual implementation under test.
+import { parseLinkedText } from "../../src/helpers/linkedText";
 
 describe("parseLinkedText", () => {
   it("returns a single plain-text segment when there are no links", () => {
@@ -88,6 +91,32 @@ describe("parseLinkedText", () => {
         url: "https://en.wikipedia.org/wiki/Function_(mathematics)",
       },
       { text: " for details." },
+    ]);
+  });
+
+  it("does not let a stray unmatched bracket swallow the real link", () => {
+    expect(
+      parseLinkedText("Rates [APY vary. See the [docs](https://b.com)."),
+    ).toEqual([
+      { text: "Rates [APY vary. See the " },
+      { text: "docs", url: "https://b.com" },
+      { text: "." },
+    ]);
+  });
+
+  it("does not double-linkify a markdown label that is itself a URL", () => {
+    expect(
+      parseLinkedText("[https://label.example](https://target.example)"),
+    ).toEqual([
+      { text: "https://label.example", url: "https://target.example" },
+    ]);
+  });
+
+  it("does not absorb a quote that closes a quoted bare URL", () => {
+    expect(parseLinkedText('See "https://example.com/x" now.')).toEqual([
+      { text: 'See "' },
+      { text: "https://example.com/x", url: "https://example.com/x" },
+      { text: '" now.' },
     ]);
   });
 });

--- a/src/components/LinkedText.tsx
+++ b/src/components/LinkedText.tsx
@@ -24,6 +24,7 @@ export const LinkedText: React.FC<LinkedTextProps> = ({
   <Text {...textProps}>
     {parseLinkedText(children).map((segment, index) =>
       segment.url ? (
+        // eslint-disable-next-line react/no-array-index-key
         <Text
           key={`${index}-${segment.url}`}
           {...textProps}

--- a/src/components/LinkedText.tsx
+++ b/src/components/LinkedText.tsx
@@ -29,6 +29,7 @@ export const LinkedText: React.FC<LinkedTextProps> = ({
           {...textProps}
           color={THEME.colors.primary}
           url={segment.url}
+          accessibilityRole="link"
         >
           {segment.text}
         </Text>

--- a/src/components/LinkedText.tsx
+++ b/src/components/LinkedText.tsx
@@ -1,0 +1,41 @@
+import { Text, TextProps } from "components/sds/Typography";
+import { THEME } from "config/theme";
+import { parseLinkedText } from "helpers/linkedText";
+import React from "react";
+
+interface LinkedTextProps extends Omit<TextProps, "children" | "url"> {
+  children: string;
+}
+
+/**
+ * Renders text while turning markdown-style `[text](https://...)` links and
+ * bare `https://` URLs into tappable links, opened via the existing `Text`
+ * `url` prop (in-app browser). Everything else renders as plain text - no
+ * other markdown/HTML is parsed, so this is safe to use directly on
+ * untrusted/external strings (e.g. API responses).
+ *
+ * Drop-in replacement for `<Text>` wherever the text content may contain a
+ * link, e.g. `<LinkedText md>{protocol.description}</LinkedText>`.
+ */
+export const LinkedText: React.FC<LinkedTextProps> = ({
+  children,
+  ...textProps
+}) => (
+  <Text {...textProps}>
+    {parseLinkedText(children).map((segment, index) =>
+      segment.url ? (
+        <Text
+          key={`${index}-${segment.url}`}
+          {...textProps}
+          color={THEME.colors.primary}
+          url={segment.url}
+        >
+          {segment.text}
+        </Text>
+      ) : (
+        // eslint-disable-next-line react/no-array-index-key
+        <React.Fragment key={`${index}-text`}>{segment.text}</React.Fragment>
+      ),
+    )}
+  </Text>
+);

--- a/src/components/screens/DiscoveryScreen/components/ProtocolDetailsBottomSheet.tsx
+++ b/src/components/screens/DiscoveryScreen/components/ProtocolDetailsBottomSheet.tsx
@@ -1,5 +1,6 @@
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import BottomSheet from "components/BottomSheet";
+import { LinkedText } from "components/LinkedText";
 import { App } from "components/sds/App";
 import { Badge } from "components/sds/Badge";
 import { Button } from "components/sds/Button";
@@ -15,6 +16,11 @@ interface ProtocolDetails {
   name: string;
   iconUrl: string;
   websiteUrl: string;
+  /**
+   * Rendered via LinkedText: supports markdown-style `[text](https://...)`
+   * links and bare `https://` URLs, which render as tappable links. No
+   * other markdown/HTML is parsed.
+   */
   description: string;
   tags: string[];
 }
@@ -96,7 +102,7 @@ const ProtocolDetailsBottomSheet: React.FC<ProtocolDetailsBottomSheetProps> =
               <Text sm secondary>
                 {t("discovery.description")}
               </Text>
-              <Text md>{protocol.description}</Text>
+              <LinkedText md>{protocol.description}</LinkedText>
             </View>
           )}
         </View>

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -429,6 +429,11 @@ export type CollectibleMetadata = {
  * Represents a discover protocol from the backend API
  */
 export type DiscoverProtocol = {
+  /**
+   * Rendered via LinkedText (components/LinkedText): supports markdown-style
+   * `[text](https://...)` links and bare `https://` URLs, which render as
+   * tappable links. No other markdown/HTML is parsed.
+   */
   description: string;
   iconUrl: string;
   name: string;

--- a/src/helpers/linkedText.ts
+++ b/src/helpers/linkedText.ts
@@ -15,9 +15,12 @@ export interface LinkedTextSegment {
 // used elsewhere for protocol URLs (see helpers/protocols.ts).
 const HTTPS_PREFIX = "https://";
 
-// A markdown link opener (`[label](`) ending exactly where a `https://`
-// occurrence begins, e.g. matched against the text preceding the URL.
-const MARKDOWN_OPENER_PATTERN = /\[([^\]]+)]\($/;
+// Characters that always end a URL, whether or not it's inside a markdown
+// link: whitespace, angle brackets, square brackets (markdown syntax), and
+// quotes (prose delimiters - a quoted URL shouldn't swallow the closing
+// quote). Parentheses are handled separately in findUrlEnd, since a URL may
+// legitimately contain balanced ones (e.g. a Wikipedia article title).
+const URL_BOUNDARY_CHAR = /[\s<>[\]"']/;
 
 const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
 
@@ -46,7 +49,7 @@ const findUrlEnd = (text: string, start: number): number => {
 
   while (index < text.length) {
     const char = text[index];
-    if (/[\s<>[\]]/.test(char)) {
+    if (URL_BOUNDARY_CHAR.test(char)) {
       break;
     }
     if (char === "(") {
@@ -63,15 +66,50 @@ const findUrlEnd = (text: string, start: number): number => {
   return index;
 };
 
-const matchMarkdownOpener = (
+interface MarkdownLink {
+  label: string;
+  url: string;
+  end: number;
+}
+
+// Tries to parse a complete markdown link `[label](https://...)` starting
+// at the `[` found at `openIndex`. Returns null if it isn't one - e.g. no
+// matching `]`, the label itself contains an unescaped `[` (meaning
+// `openIndex` isn't the real opening bracket - see the "nested brackets"
+// test case), or there's no `(https://...)` immediately after the `]`.
+// Parsing forward like this (rather than scanning backward from a `https://`
+// occurrence) means a label that itself contains a URL - e.g.
+// `[https://a.example](https://b.example)` - is handled as a single link
+// instead of the label's URL being matched as a stray bare link first.
+const tryParseMarkdownLink = (
   text: string,
-  httpsIndex: number,
-): { labelStart: number; label: string } | null => {
-  const match = text.slice(0, httpsIndex).match(MARKDOWN_OPENER_PATTERN);
-  if (!match) {
+  openIndex: number,
+): MarkdownLink | null => {
+  const closeBracket = text.indexOf("]", openIndex + 1);
+  if (closeBracket === -1) {
     return null;
   }
-  return { labelStart: httpsIndex - match[0].length, label: match[1] };
+
+  const label = text.slice(openIndex + 1, closeBracket);
+  if (label.includes("[")) {
+    return null;
+  }
+
+  if (text[closeBracket + 1] !== "(") {
+    return null;
+  }
+
+  const urlStart = closeBracket + 2;
+  if (!text.startsWith(HTTPS_PREFIX, urlStart)) {
+    return null;
+  }
+
+  const urlEnd = findUrlEnd(text, urlStart);
+  if (text[urlEnd] !== ")") {
+    return null;
+  }
+
+  return { label, url: text.slice(urlStart, urlEnd), end: urlEnd + 1 };
 };
 
 /**
@@ -86,29 +124,38 @@ const matchMarkdownOpener = (
  */
 export const parseLinkedText = (text: string): LinkedTextSegment[] => {
   const segments: LinkedTextSegment[] = [];
-  let cursor = 0;
+  let emitted = 0;
+  let searchFrom = 0;
 
-  while (cursor < text.length) {
-    const httpsIndex = text.indexOf(HTTPS_PREFIX, cursor);
-    if (httpsIndex === -1) {
-      segments.push({ text: text.slice(cursor) });
-      break;
-    }
+  while (searchFrom < text.length) {
+    const bracketIndex = text.indexOf("[", searchFrom);
+    const httpsIndex = text.indexOf(HTTPS_PREFIX, searchFrom);
 
-    const opener = matchMarkdownOpener(text, httpsIndex);
-    if (opener) {
-      const urlEnd = findUrlEnd(text, httpsIndex);
-      if (text[urlEnd] === ")") {
-        if (opener.labelStart > cursor) {
-          segments.push({ text: text.slice(cursor, opener.labelStart) });
+    if (
+      bracketIndex !== -1 &&
+      (httpsIndex === -1 || bracketIndex < httpsIndex)
+    ) {
+      const link = tryParseMarkdownLink(text, bracketIndex);
+      if (link) {
+        if (bracketIndex > emitted) {
+          segments.push({ text: text.slice(emitted, bracketIndex) });
         }
-        segments.push({
-          text: opener.label,
-          url: text.slice(httpsIndex, urlEnd),
-        });
-        cursor = urlEnd + 1;
+        segments.push({ text: link.label, url: link.url });
+        emitted = link.end;
+        searchFrom = link.end;
         continue;
       }
+
+      // Not a complete markdown link - this "[" is just literal text.
+      // Keep it pending and resume searching right after it (e.g. it may
+      // be a stray bracket preceding the real link, per the nested-bracket
+      // test case).
+      searchFrom = bracketIndex + 1;
+      continue;
+    }
+
+    if (httpsIndex === -1) {
+      break;
     }
 
     const urlEnd = findUrlEnd(text, httpsIndex);
@@ -116,16 +163,22 @@ export const parseLinkedText = (text: string): LinkedTextSegment[] => {
       text.slice(httpsIndex, urlEnd),
     );
 
-    if (httpsIndex > cursor) {
-      segments.push({ text: text.slice(cursor, httpsIndex) });
+    if (httpsIndex > emitted) {
+      segments.push({ text: text.slice(emitted, httpsIndex) });
     }
     segments.push({ text: url, url });
-    cursor = httpsIndex + url.length;
+    emitted = httpsIndex + url.length;
+    searchFrom = emitted;
 
     if (trailing) {
       segments.push({ text: trailing });
-      cursor += trailing.length;
+      emitted += trailing.length;
+      searchFrom = emitted;
     }
+  }
+
+  if (emitted < text.length) {
+    segments.push({ text: text.slice(emitted) });
   }
 
   return segments;

--- a/src/helpers/linkedText.ts
+++ b/src/helpers/linkedText.ts
@@ -1,0 +1,75 @@
+/**
+ * Text-with-links parsing utilities
+ * @fileoverview Parses markdown-style `[text](https://...)` links and bare
+ * `https://` URLs out of a plain-text string, for rendering as tappable
+ * segments (see components/LinkedText).
+ */
+
+export interface LinkedTextSegment {
+  text: string;
+  url?: string;
+}
+
+// Matches markdown-style `[text](https://...)` links, or a bare `https://`
+// URL. Deliberately restricted to https - no other scheme (e.g. `http:`,
+// `javascript:`) is ever recognized as a link, matching the HTTPS-only
+// convention used elsewhere for protocol URLs (see helpers/protocols.ts).
+const LINK_PATTERN =
+  /\[([^\]]+)]\((https:\/\/[^\s)]+)\)|(https:\/\/[^\s<>()[\]]+)/g;
+
+const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
+
+const splitTrailingPunctuation = (
+  url: string,
+): { url: string; trailing: string } => {
+  const match = url.match(TRAILING_PUNCTUATION);
+  if (!match) {
+    return { url, trailing: "" };
+  }
+  return {
+    url: url.slice(0, url.length - match[0].length),
+    trailing: match[0],
+  };
+};
+
+/**
+ * Parses plain text for markdown-style links (`[text](https://...)`) and
+ * bare `https://` URLs, returning an ordered list of segments to render.
+ * A segment with a `url` should be rendered as a tappable link; a segment
+ * without one is plain text.
+ *
+ * This never parses or renders any other markdown/HTML - it's safe to use
+ * on untrusted/external strings (e.g. an API response) since the output is
+ * always plain text plus a small, whitelisted set of link segments.
+ */
+export const parseLinkedText = (text: string): LinkedTextSegment[] => {
+  const segments: LinkedTextSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(LINK_PATTERN)) {
+    const [full, markdownText, markdownUrl, bareUrl] = match;
+    const start = match.index ?? 0;
+
+    if (start > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, start) });
+    }
+
+    if (markdownText && markdownUrl) {
+      segments.push({ text: markdownText, url: markdownUrl });
+    } else if (bareUrl) {
+      const { url, trailing } = splitTrailingPunctuation(bareUrl);
+      segments.push({ text: url, url });
+      if (trailing) {
+        segments.push({ text: trailing });
+      }
+    }
+
+    lastIndex = start + full.length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex) });
+  }
+
+  return segments;
+};

--- a/src/helpers/linkedText.ts
+++ b/src/helpers/linkedText.ts
@@ -10,12 +10,14 @@ export interface LinkedTextSegment {
   url?: string;
 }
 
-// Matches markdown-style `[text](https://...)` links, or a bare `https://`
-// URL. Deliberately restricted to https - no other scheme (e.g. `http:`,
-// `javascript:`) is ever recognized as a link, matching the HTTPS-only
-// convention used elsewhere for protocol URLs (see helpers/protocols.ts).
-const LINK_PATTERN =
-  /\[([^\]]+)]\((https:\/\/[^\s)]+)\)|(https:\/\/[^\s<>()[\]]+)/g;
+// Only https:// is ever recognized as a link - no other scheme (e.g.
+// `http:`, `javascript:`) matches, matching the HTTPS-only convention
+// used elsewhere for protocol URLs (see helpers/protocols.ts).
+const HTTPS_PREFIX = "https://";
+
+// A markdown link opener (`[label](`) ending exactly where a `https://`
+// occurrence begins, e.g. matched against the text preceding the URL.
+const MARKDOWN_OPENER_PATTERN = /\[([^\]]+)]\($/;
 
 const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
 
@@ -32,6 +34,46 @@ const splitTrailingPunctuation = (
   };
 };
 
+// Extends a URL starting at `start` as far as possible, allowing balanced
+// parentheses inside it (e.g. https://en.wikipedia.org/wiki/Function_(maths))
+// so a legitimate paren in the URL path isn't mistaken for markdown/prose
+// punctuation. An unmatched closing paren ends the URL instead of being
+// consumed by it, since it's almost always the boundary of a markdown link
+// or the prose wrapping a link in parens.
+const findUrlEnd = (text: string, start: number): number => {
+  let depth = 0;
+  let index = start;
+
+  while (index < text.length) {
+    const char = text[index];
+    if (/[\s<>[\]]/.test(char)) {
+      break;
+    }
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      if (depth === 0) {
+        break;
+      }
+      depth -= 1;
+    }
+    index += 1;
+  }
+
+  return index;
+};
+
+const matchMarkdownOpener = (
+  text: string,
+  httpsIndex: number,
+): { labelStart: number; label: string } | null => {
+  const match = text.slice(0, httpsIndex).match(MARKDOWN_OPENER_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return { labelStart: httpsIndex - match[0].length, label: match[1] };
+};
+
 /**
  * Parses plain text for markdown-style links (`[text](https://...)`) and
  * bare `https://` URLs, returning an ordered list of segments to render.
@@ -44,31 +86,46 @@ const splitTrailingPunctuation = (
  */
 export const parseLinkedText = (text: string): LinkedTextSegment[] => {
   const segments: LinkedTextSegment[] = [];
-  let lastIndex = 0;
+  let cursor = 0;
 
-  for (const match of text.matchAll(LINK_PATTERN)) {
-    const [full, markdownText, markdownUrl, bareUrl] = match;
-    const start = match.index ?? 0;
-
-    if (start > lastIndex) {
-      segments.push({ text: text.slice(lastIndex, start) });
+  while (cursor < text.length) {
+    const httpsIndex = text.indexOf(HTTPS_PREFIX, cursor);
+    if (httpsIndex === -1) {
+      segments.push({ text: text.slice(cursor) });
+      break;
     }
 
-    if (markdownText && markdownUrl) {
-      segments.push({ text: markdownText, url: markdownUrl });
-    } else if (bareUrl) {
-      const { url, trailing } = splitTrailingPunctuation(bareUrl);
-      segments.push({ text: url, url });
-      if (trailing) {
-        segments.push({ text: trailing });
+    const opener = matchMarkdownOpener(text, httpsIndex);
+    if (opener) {
+      const urlEnd = findUrlEnd(text, httpsIndex);
+      if (text[urlEnd] === ")") {
+        if (opener.labelStart > cursor) {
+          segments.push({ text: text.slice(cursor, opener.labelStart) });
+        }
+        segments.push({
+          text: opener.label,
+          url: text.slice(httpsIndex, urlEnd),
+        });
+        cursor = urlEnd + 1;
+        continue;
       }
     }
 
-    lastIndex = start + full.length;
-  }
+    const urlEnd = findUrlEnd(text, httpsIndex);
+    const { url, trailing } = splitTrailingPunctuation(
+      text.slice(httpsIndex, urlEnd),
+    );
 
-  if (lastIndex < text.length) {
-    segments.push({ text: text.slice(lastIndex) });
+    if (httpsIndex > cursor) {
+      segments.push({ text: text.slice(cursor, httpsIndex) });
+    }
+    segments.push({ text: url, url });
+    cursor = httpsIndex + url.length;
+
+    if (trailing) {
+      segments.push({ text: trailing });
+      cursor += trailing.length;
+    }
   }
 
   return segments;

--- a/src/helpers/linkedText.ts
+++ b/src/helpers/linkedText.ts
@@ -15,12 +15,18 @@ export interface LinkedTextSegment {
 // used elsewhere for protocol URLs (see helpers/protocols.ts).
 const HTTPS_PREFIX = "https://";
 
-// Characters that always end a URL, whether or not it's inside a markdown
-// link: whitespace, angle brackets, square brackets (markdown syntax), and
-// quotes (prose delimiters - a quoted URL shouldn't swallow the closing
-// quote). Parentheses are handled separately in findUrlEnd, since a URL may
+// Characters that always end a URL: whitespace, angle brackets, and quotes
+// (prose delimiters - a quoted URL shouldn't swallow the closing quote).
+// Parentheses are handled separately in findUrlEnd, since a URL may
 // legitimately contain balanced ones (e.g. a Wikipedia article title).
-const URL_BOUNDARY_CHAR = /[\s<>[\]"']/;
+const BARE_URL_BOUNDARY_CHAR = /[\s<>[\]"']/;
+
+// Inside a markdown link's `(https://...)` destination, square brackets are
+// valid URL characters (e.g. the common `?tag[]=value` query syntax) - only
+// the balanced closing paren, whitespace, angle brackets, or a quote can end
+// it. Brackets are excluded from a *bare* URL's boundary set above only to
+// avoid ambiguity with an immediately following markdown link.
+const MARKDOWN_URL_BOUNDARY_CHAR = /[\s<>"']/;
 
 const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
 
@@ -37,19 +43,34 @@ const splitTrailingPunctuation = (
   };
 };
 
-// Extends a URL starting at `start` as far as possible, allowing balanced
-// parentheses inside it (e.g. https://en.wikipedia.org/wiki/Function_(maths))
-// so a legitimate paren in the URL path isn't mistaken for markdown/prose
-// punctuation. An unmatched closing paren ends the URL instead of being
-// consumed by it, since it's almost always the boundary of a markdown link
-// or the prose wrapping a link in parens.
-const findUrlEnd = (text: string, start: number): number => {
+// A candidate is only treated as a link if it's an actual parseable https
+// URL with a host - e.g. bare "https://" or "https://?query" (no host) are
+// rejected and left as plain text, matching the HTTPS-only convention used
+// elsewhere for protocol URLs. The original text is still used for
+// display/navigation (never `url.href`), since the WHATWG URL parser
+// normalizes some inputs (e.g. adding a trailing slash to a bare origin).
+const isValidHttpsUrl = (candidate: string): boolean => {
+  try {
+    return new URL(candidate).protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+// Extends a URL starting at `start` as far as possible per `boundary`,
+// allowing balanced parentheses inside it (e.g.
+// https://en.wikipedia.org/wiki/Function_(maths)) so a legitimate paren in
+// the URL path isn't mistaken for markdown/prose punctuation. An unmatched
+// closing paren ends the URL instead of being consumed by it, since it's
+// almost always the boundary of a markdown link or the prose wrapping a
+// link in parens.
+const findUrlEnd = (text: string, start: number, boundary: RegExp): number => {
   let depth = 0;
   let index = start;
 
   while (index < text.length) {
     const char = text[index];
-    if (URL_BOUNDARY_CHAR.test(char)) {
+    if (boundary.test(char)) {
       break;
     }
     if (char === "(") {
@@ -76,7 +97,8 @@ interface MarkdownLink {
 // at the `[` found at `openIndex`. Returns null if it isn't one - e.g. no
 // matching `]`, the label itself contains an unescaped `[` (meaning
 // `openIndex` isn't the real opening bracket - see the "nested brackets"
-// test case), or there's no `(https://...)` immediately after the `]`.
+// test case), there's no `(https://...)` immediately after the `]`, or the
+// URL itself isn't a valid https URL with a host.
 // Parsing forward like this (rather than scanning backward from a `https://`
 // occurrence) means a label that itself contains a URL - e.g.
 // `[https://a.example](https://b.example)` - is handled as a single link
@@ -104,12 +126,17 @@ const tryParseMarkdownLink = (
     return null;
   }
 
-  const urlEnd = findUrlEnd(text, urlStart);
+  const urlEnd = findUrlEnd(text, urlStart, MARKDOWN_URL_BOUNDARY_CHAR);
   if (text[urlEnd] !== ")") {
     return null;
   }
 
-  return { label, url: text.slice(urlStart, urlEnd), end: urlEnd + 1 };
+  const url = text.slice(urlStart, urlEnd);
+  if (!isValidHttpsUrl(url)) {
+    return null;
+  }
+
+  return { label, url, end: urlEnd + 1 };
 };
 
 /**
@@ -158,10 +185,17 @@ export const parseLinkedText = (text: string): LinkedTextSegment[] => {
       break;
     }
 
-    const urlEnd = findUrlEnd(text, httpsIndex);
+    const urlEnd = findUrlEnd(text, httpsIndex, BARE_URL_BOUNDARY_CHAR);
     const { url, trailing } = splitTrailingPunctuation(
       text.slice(httpsIndex, urlEnd),
     );
+
+    if (!isValidHttpsUrl(url)) {
+      // Not a real URL (e.g. bare "https://" with no host) - leave it as
+      // plain text and keep scanning past the prefix.
+      searchFrom = httpsIndex + HTTPS_PREFIX.length;
+      continue;
+    }
 
     if (httpsIndex > emitted) {
       segments.push({ text: text.slice(emitted, httpsIndex) });

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -1152,7 +1152,9 @@ export const submitTransaction = async (body: SubmitTransactionBody) => {
  * @interface ProtocolsResponse
  * @property {Object} data - Response data container
  * @property {Object[]} data.protocols - Array of protocol objects
- * @property {string} data.protocols[].description - Protocol description
+ * @property {string} data.protocols[].description - Protocol description. Rendered via
+ * LinkedText (components/LinkedText): supports markdown-style `[text](https://...)` links
+ * and bare `https://` URLs, which render as tappable links. No other markdown/HTML is parsed.
  * @property {string} data.protocols[].icon_url - Protocol icon URL
  * @property {string} data.protocols[].name - Protocol name
  * @property {string} data.protocols[].website_url - Protocol website URL


### PR DESCRIPTION
### What

Adds a `LinkedText` component (`src/components/LinkedText.tsx`) that renders a protocol's `description` in `ProtocolDetailsBottomSheet`, turning markdown-style `[text](https://...)` links and bare `https://` URLs into tappable links via the existing `Text` `url` prop (in-app browser). Newlines already render correctly via React Native's native `Text` behavior, so no change was needed there.

### Why

The `/protocols` description field currently renders as inert plain text. We just used this field to add a security-incident notice with a link (see the `stellar/kube` PR for the mainnet `Blend` entry) and want that link to actually be tappable.

### Known limitations

- Only `https://` URLs are ever linkified, matching the HTTPS-only convention already used for protocol URLs elsewhere (`helpers/protocols.ts`).
- No new dependency — `LinkedText` reuses the existing `Text` component's `url`/in-app-browser plumbing (the same pattern already used in `WelcomeScreen.tsx`) plus a small regex-based parser (`helpers/linkedText.ts`).
- I was unable to run this repo's Jest/lint/typecheck or a simulator build in my environment (Yarn Berry 4.10.0 install failed — `repo.yarnpkg.com` was unreachable). I verified the `parseLinkedText` regex logic against the added test cases with a standalone Node script, but the actual test suite and on-device testing have not been done — flagging this as a draft PR for that reason.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes.
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [ ] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [ ] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQfNLwL7cmVNqbSUFFQ1kw)_