### PR TITLE
refactor(walletkit): route dApp requests through a transport-agnostic DappRequest

### DIFF
--- a/__tests__/helpers/dappExecutor.test.ts
+++ b/__tests__/helpers/dappExecutor.test.ts
@@ -1,0 +1,203 @@
+import {
+  Account,
+  BASE_FEE,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { DappErrorCode, DappRequest, DappTransport } from "config/dappRequest";
+import { StellarRpcChains, StellarRpcMethods } from "ducks/walletKit";
+import { executeDappRequest } from "helpers/walletKitUtil";
+import { TFunction } from "i18next";
+import { submitTx } from "services/stellar";
+
+jest.mock("services/analytics", () => ({
+  analytics: {
+    trackSignedMessage: jest.fn(),
+    trackSignedTransaction: jest.fn(),
+    trackSignedAuthEntry: jest.fn(),
+    trackSubmittedTransaction: jest.fn(),
+  },
+}));
+
+jest.mock("services/stellar", () => ({ submitTx: jest.fn() }));
+
+describe("shared dApp executor", () => {
+  const setup = (method: string, params: Record<string, unknown> = {}) => {
+    const respond = jest.fn().mockResolvedValue(undefined);
+    const sessionRequest: DappRequest = {
+      id: "request-1",
+      params: {
+        chainId: StellarRpcChains.TESTNET,
+        request: { method, params },
+      },
+      origin: "https://example.org",
+      metadata: {
+        name: "Example",
+        description: "",
+        url: "https://example.org",
+        icons: [],
+      },
+      transport: DappTransport.WALLET_CONNECT,
+      isValid: jest.fn(() => true),
+      respond,
+    };
+    return {
+      sessionRequest,
+      signTransaction: jest.fn(() => "signed-xdr"),
+      signMessage: jest.fn(() => "signature"),
+      signAuthEntry: jest.fn(() => ({
+        signedAuthEntry: "signed",
+        signerAddress: "GACCOUNT",
+      })),
+      networkPassphrase: "Test SDF Network ; September 2015",
+      publicKey: "GACCOUNT",
+      activeChain: StellarRpcChains.TESTNET,
+      showToast: jest.fn(),
+      t: ((key: string) => key) as TFunction<"translations", undefined>,
+    };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("rejects an unknown method without parsing XDR or signing", async () => {
+    const args = setup("unknown", { xdr: "bad-xdr" });
+    await executeDappRequest(args);
+    expect(args.signTransaction).not.toHaveBeenCalled();
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: "UNSUPPORTED_METHOD" }),
+      }),
+    );
+  });
+
+  it("refuses a stale document before signing", async () => {
+    const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: "hello" });
+    args.sessionRequest.isValid = () => false;
+    await executeDappRequest(args);
+    expect(args.signMessage).not.toHaveBeenCalled();
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: DappErrorCode.CONTEXT_CHANGED }),
+      }),
+    );
+  });
+
+  it("returns message signatures through the transport", async () => {
+    const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: "hello" });
+    await executeDappRequest(args);
+    expect(args.signMessage).toHaveBeenCalledWith("hello");
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith({
+      id: "request-1",
+      jsonrpc: "2.0",
+      result: { signature: "signature" },
+    });
+    expect(args.showToast).toHaveBeenCalledWith({
+      title: "walletKit.signMessageSuccessfull",
+      message: "walletKit.returnToBrowser",
+      variant: "success",
+    });
+  });
+
+  it("rejects wrong network and malformed messages before signing", async () => {
+    const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: 42 });
+    await executeDappRequest(args);
+    expect(args.signMessage).not.toHaveBeenCalled();
+    args.sessionRequest.params.chainId = StellarRpcChains.PUBLIC;
+    await executeDappRequest(args);
+    expect(args.signMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([StellarRpcMethods.SIGN_XDR, StellarRpcMethods.SIGN_AND_SUBMIT_XDR])(
+    "routes %s results through the same transport",
+    async (method) => {
+      const args = setup(method, { xdr: "xdr" });
+      jest
+        .spyOn(TransactionBuilder, "fromXdr")
+        .mockReturnValue({} as Transaction);
+      await executeDappRequest(args);
+      expect(args.signTransaction).toHaveBeenCalledTimes(1);
+      expect(args.sessionRequest.respond).toHaveBeenCalledWith({
+        id: "request-1",
+        jsonrpc: "2.0",
+        result:
+          method === StellarRpcMethods.SIGN_XDR
+            ? { signedXDR: "signed-xdr" }
+            : { status: "success" },
+      });
+      expect(submitTx).toHaveBeenCalledTimes(
+        method === StellarRpcMethods.SIGN_XDR ? 0 : 1,
+      );
+    },
+  );
+
+  it("rejects malformed authorization entries before signing", async () => {
+    const args = setup(StellarRpcMethods.SIGN_AUTH_ENTRY, { entryXdr: "bad" });
+    await executeDappRequest(args);
+    expect(args.signAuthEntry).not.toHaveBeenCalled();
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: "INVALID_PARAMS" }),
+      }),
+    );
+  });
+
+  it("checks context again before submission", async () => {
+    const args = setup(StellarRpcMethods.SIGN_AND_SUBMIT_XDR, { xdr: "xdr" });
+    jest
+      .spyOn(TransactionBuilder, "fromXdr")
+      .mockReturnValue({} as Transaction);
+    args.signTransaction.mockImplementation(() => {
+      args.sessionRequest.isValid = () => false;
+      return "signed-xdr";
+    });
+    await executeDappRequest(args);
+    expect(args.signTransaction).toHaveBeenCalled();
+    expect(submitTx).not.toHaveBeenCalled();
+  });
+
+  it("returns an XDR signature verifiable for the approved account and network", async () => {
+    const signer = Keypair.random();
+    const unsigned = new TransactionBuilder(
+      new Account(signer.publicKey(), "100"),
+      {
+        fee: BASE_FEE,
+        networkPassphrase: Networks.TESTNET,
+      },
+    )
+      .addOperation(
+        Operation.manageData({ name: "bridge-test", value: "approved" }),
+      )
+      .setTimeout(0)
+      .build();
+    const args = setup(StellarRpcMethods.SIGN_XDR, { xdr: unsigned.toXdr() });
+    const respond = jest.fn().mockResolvedValue(undefined);
+    await executeDappRequest({
+      ...args,
+      publicKey: signer.publicKey(),
+      sessionRequest: { ...args.sessionRequest, respond },
+      signTransaction: (transaction: Transaction | FeeBumpTransaction) => {
+        transaction.sign(signer);
+        return transaction.toXdr();
+      },
+    });
+    expect(respond).toHaveBeenCalledTimes(1);
+    const { signedXDR } = respond.mock.calls[0][0].result as {
+      signedXDR: string;
+    };
+    const signed = TransactionBuilder.fromXdr(signedXDR, Networks.TESTNET);
+    expect(signed.hash()).toEqual(unsigned.hash());
+    expect(signed.signatures).toHaveLength(1);
+    const signature = signed.signatures[0].signature.toBytes();
+    expect(signer.verify(signed.hash(), signature)).toBe(true);
+    const wrongNetwork = TransactionBuilder.fromXdr(signedXDR, Networks.PUBLIC);
+    expect(signer.verify(wrongNetwork.hash(), signature)).toBe(false);
+    expect(Keypair.random().verify(signed.hash(), signature)).toBe(false);
+  });
+});

--- a/__tests__/helpers/walletKitUtil.test.ts
+++ b/__tests__/helpers/walletKitUtil.test.ts
@@ -44,7 +44,7 @@ describe("resolveDappRejectionEvent (dApp-request teardown → signing.*_rejecte
     ).toBeNull();
   });
 
-  // approveSessionRequest threw: the WC fallback rejection still fires, but this
+  // executeDappRequest threw: the WC fallback rejection still fires, but this
   // is an approval attempt, not a user reject — so no analytics rejection.
   it("returns null when an approval attempt was in flight (even if it threw)", () => {
     expect(

--- a/src/components/screens/WalletKit/DappRequestBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappRequestBottomSheetContent.tsx
@@ -4,17 +4,13 @@ import { DappSignAuthEntryBottomSheetContent } from "components/screens/WalletKi
 import { DappSignMessageBottomSheetContent } from "components/screens/WalletKit/DappSignMessageBottomSheetContent";
 import { DappSignTransactionBottomSheetContent } from "components/screens/WalletKit/DappSignTransactionBottomSheetContent";
 import { NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import {
-  StellarRpcMethods,
-  StellarSignAuthEntryParams,
-  StellarSignMessageParams,
-  WalletKitSessionRequest,
-} from "ducks/walletKit";
+import { StellarRpcMethods } from "ducks/walletKit";
 import React from "react";
 
 interface DappRequestBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   onCancelRequest: () => void;
@@ -40,16 +36,16 @@ const DappRequestBottomSheetContent: React.FC<
   const requestParams = requestEvent?.params?.request?.params;
 
   if (requestMethod === StellarRpcMethods.SIGN_MESSAGE) {
-    const message = (requestParams as StellarSignMessageParams)?.message;
-    if (message) {
+    const message = requestParams?.message;
+    if (typeof message === "string" && message) {
       return <DappSignMessageBottomSheetContent {...props} message={message} />;
     }
     return null;
   }
 
   if (requestMethod === StellarRpcMethods.SIGN_AUTH_ENTRY) {
-    const entryXdr = (requestParams as StellarSignAuthEntryParams)?.entryXdr;
-    if (entryXdr) {
+    const entryXdr = requestParams?.entryXdr;
+    if (typeof entryXdr === "string" && entryXdr) {
       return (
         <DappSignAuthEntryBottomSheetContent {...props} entryXdr={entryXdr} />
       );

--- a/src/components/screens/WalletKit/DappSignAuthEntryBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignAuthEntryBottomSheetContent.tsx
@@ -9,8 +9,8 @@ import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useClipboard } from "hooks/useClipboard";
 import useColors from "hooks/useColors";
@@ -18,7 +18,7 @@ import React, { useMemo } from "react";
 import { Dimensions, ScrollView, View } from "react-native";
 
 interface DappSignAuthEntryBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   entryXdr: string;

--- a/src/components/screens/WalletKit/DappSignMessageBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignMessageBottomSheetContent.tsx
@@ -8,8 +8,8 @@ import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useMemo } from "react";
@@ -25,7 +25,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 const SHEET_CHROME_HEIGHT = 80;
 
 interface DappSignMessageBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   message: string;

--- a/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx
@@ -12,8 +12,8 @@ import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { AnalyticsEvent } from "config/analyticsConfig";
 import { NATIVE_TOKEN_CODE, NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import { formatTokenForDisplay } from "helpers/formatAmount";
 import { useTransactionBalanceListItems } from "hooks/blockaid/useTransactionBalanceListItems";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -22,7 +22,7 @@ import React, { useMemo } from "react";
 import { View } from "react-native";
 
 interface DappSignTransactionBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   onCancelRequest: () => void;

--- a/src/components/screens/WalletKit/useDappHeader.ts
+++ b/src/components/screens/WalletKit/useDappHeader.ts
@@ -1,8 +1,7 @@
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
 import { useProtocolsStore } from "ducks/protocols";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import { findMatchedProtocol, getDisplayHost } from "helpers/protocols";
-import { useDappMetadata } from "hooks/useDappMetadata";
 import { useMemo } from "react";
 
 /**
@@ -10,12 +9,12 @@ import { useMemo } from "react";
  * Returns null if required data is not yet available — callers should render null in that case.
  */
 export const useDappHeader = (
-  requestEvent: WalletKitSessionRequest | null,
+  requestEvent: DappRequest | null,
   account: ActiveAccount | null,
 ) => {
   const { protocols } = useProtocolsStore();
-  const dappMetadata = useDappMetadata(requestEvent);
-  const requestOrigin = requestEvent?.verifyContext?.verified?.origin;
+  const dappMetadata = requestEvent?.metadata;
+  const requestOrigin = requestEvent?.origin;
 
   const matchedProtocol = useMemo(
     () =>

--- a/src/config/dappRequest.ts
+++ b/src/config/dappRequest.ts
@@ -1,0 +1,37 @@
+/** Where a dApp request arrived from; decides how the response travels back. */
+export enum DappTransport {
+  WALLET_CONNECT = "walletconnect",
+}
+
+/**
+ * Error codes attached to dApp rejections. WalletConnect keeps its numeric
+ * JSON-RPC code on the wire; these name the reason for callers and tests.
+ */
+export enum DappErrorCode {
+  INVALID_PARAMS = "INVALID_PARAMS",
+  UNSUPPORTED_METHOD = "UNSUPPORTED_METHOD",
+  WRONG_NETWORK = "WRONG_NETWORK",
+  USER_REJECTED = "USER_REJECTED",
+  CONTEXT_CHANGED = "CONTEXT_CHANGED",
+}
+
+/** A native-verified dApp request, independent of its response transport. */
+export interface DappRequest {
+  id: number | string;
+  params: {
+    chainId: string;
+    request: { method: string; params?: Record<string, unknown> };
+  };
+  /** Origin the wallet verified natively; never taken from the request payload. */
+  origin: string;
+  metadata: { name: string; description: string; url: string; icons: string[] };
+  transport: DappTransport;
+  /** False once navigation, tab, lock or account/network changes made the request stale. */
+  isValid: () => boolean;
+  respond: (response: {
+    id: number | string;
+    jsonrpc: string;
+    result?: unknown;
+    error?: { code: DappErrorCode | number; message: string };
+  }) => Promise<void>;
+}

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -11,8 +11,15 @@ import {
   getSdkError,
   SdkErrorKey,
 } from "@walletconnect/utils";
-import { NETWORK_NAMES, NETWORKS } from "config/constants";
+import {
+  NETWORK_NAMES,
+  NETWORKS,
+  mapNetworkToNetworkDetails,
+} from "config/constants";
+import { DappErrorCode, DappRequest, DappTransport } from "config/dappRequest";
 import { logger } from "config/logger";
+import { AUTH_STATUS } from "config/types";
+import { useAuthenticationStore } from "ducks/auth";
 import {
   ActiveSessions,
   StellarRpcChains,
@@ -53,10 +60,10 @@ const stellarNamespaceEvents = [StellarRpcEvents.ACCOUNTS_CHANGED];
  *
  * A rejection is emitted ONLY for a genuine user dismissal of a still-pending
  * request:
- * - `hasResponded` (approveSessionRequest already sent a WC response) => the
+ * - `hasResponded` (executeDappRequest already sent a response) => the
  *   request was approved/completed, never a rejection.
  * - `approvalInFlight` (the user hit Approve — success OR an unexpected throw in
- *   approveSessionRequest) => an approval attempt, not a dismissal; the throw
+ *   executeDappRequest) => an approval attempt, not a dismissal; the throw
  *   still triggers a WC-level fallback rejection but must not be counted as a
  *   user reject in analytics.
  * - no active `requestEvent` => nothing to reject.
@@ -256,9 +263,45 @@ export const rejectSessionRequest = async ({
 };
 
 /**
- * Approves and processes a session request from a dApp
+ * Rejects a dApp request on whichever transport it arrived on. Fire-and-forget:
+ * a delivery failure is logged, never thrown, so rejection paths cannot
+ * themselves fail.
  * @param {Object} params - The parameters object
- * @param {WalletKitSessionRequest} params.sessionRequest - The session request to approve
+ * @param {DappRequest} params.sessionRequest - The request to reject
+ * @param {string} params.message - Human-readable reason sent to the dApp
+ * @param {DappErrorCode} [params.code] - Error code; defaults to USER_REJECTED
+ */
+export const rejectDappRequest = ({
+  sessionRequest,
+  message,
+  code = DappErrorCode.USER_REJECTED,
+}: {
+  sessionRequest: DappRequest;
+  message: string;
+  code?: DappErrorCode;
+}): void => {
+  sessionRequest
+    .respond({
+      id: sessionRequest.id,
+      jsonrpc: "2.0",
+      error: { code, message },
+    })
+    .catch((error) => {
+      logger.warn(
+        "walletKitUtil.rejectDappRequest",
+        "Rejection could not be delivered",
+        error,
+      );
+    });
+};
+
+/**
+ * Validates, signs and (for sign-and-submit) submits a dApp request, then
+ * responds on the request's own transport. Shared by WalletConnect and the
+ * in-app WebView bridge; re-checks `sessionRequest.isValid()` right before
+ * signing so a stale request never reaches the signer.
+ * @param {Object} params - The parameters object
+ * @param {DappRequest} params.sessionRequest - The native-verified request to execute
  * @param {Function} params.signTransaction - Function to sign the transaction
  * @param {string} params.networkPassphrase - The network passphrase
  * @param {string} params.activeChain - The active chain identifier
@@ -266,7 +309,7 @@ export const rejectSessionRequest = async ({
  * @param {TFunction} params.t - Translation function
  * @returns {Promise<void>} A promise that resolves when the approval is complete
  */
-export const approveSessionRequest = async ({
+export const executeDappRequest = async ({
   sessionRequest,
   signTransaction,
   signMessage,
@@ -277,7 +320,7 @@ export const approveSessionRequest = async ({
   showToast,
   t,
 }: {
-  sessionRequest: WalletKitSessionRequest;
+  sessionRequest: DappRequest;
   signTransaction: (
     transaction: Transaction | FeeBumpTransaction,
   ) => string | null;
@@ -291,12 +334,31 @@ export const approveSessionRequest = async ({
   showToast: (options: ToastOptions) => void;
   t: TFunction<"translations", undefined>;
 }) => {
-  const { id, params, topic } = sessionRequest;
+  const { id, params } = sessionRequest;
   const { request, chainId } = params || {};
   const { params: requestParams, method: requestMethod } = request || {};
   const { xdr } = requestParams || {};
 
   const rpcMethod = requestMethod as StellarRpcMethods;
+
+  const ensureValid = () => {
+    if (sessionRequest.isValid()) return true;
+    rejectDappRequest({
+      sessionRequest,
+      message: "Wallet context changed",
+      code: DappErrorCode.CONTEXT_CHANGED,
+    });
+    return false;
+  };
+  if (!ensureValid()) return;
+  if (!stellarNamespaceMethods.includes(rpcMethod)) {
+    rejectDappRequest({
+      sessionRequest,
+      message: t("walletKit.errorUnsupportedMethod", { method: requestMethod }),
+      code: DappErrorCode.UNSUPPORTED_METHOD,
+    });
+    return;
+  }
 
   const supportedChains = [StellarRpcChains.PUBLIC, StellarRpcChains.TESTNET];
 
@@ -310,7 +372,11 @@ export const approveSessionRequest = async ({
       message,
       variant: "error",
     });
-    rejectSessionRequest({ sessionRequest, message });
+    rejectDappRequest({
+      sessionRequest,
+      message,
+      code: DappErrorCode.WRONG_NETWORK,
+    });
     return;
   }
 
@@ -329,7 +395,11 @@ export const approveSessionRequest = async ({
       message,
       variant: "error",
     });
-    rejectSessionRequest({ sessionRequest, message });
+    rejectDappRequest({
+      sessionRequest,
+      message,
+      code: DappErrorCode.WRONG_NETWORK,
+    });
     return;
   }
 
@@ -345,7 +415,11 @@ export const approveSessionRequest = async ({
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({
+        sessionRequest,
+        message: errorMessage,
+        code: DappErrorCode.INVALID_PARAMS,
+      });
       return;
     }
 
@@ -357,35 +431,33 @@ export const approveSessionRequest = async ({
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({
+        sessionRequest,
+        message: errorMessage,
+        code: DappErrorCode.INVALID_PARAMS,
+      });
       return;
     }
 
+    if (!sessionRequest.isValid()) {
+      ensureValid();
+      return;
+    }
     const signedMessage = signMessage(contentResult.value);
 
     if (!signedMessage) {
       const errorMessage = "Failed to sign message";
-      logger.error(
-        "approveSessionRequest",
-        errorMessage,
-        new Error(errorMessage),
-      );
+      logger.error("executeDappRequest", errorMessage, new Error(errorMessage));
       showToast({
         title: t("walletKit.errorSigningMessage"),
         message: t("walletKit.pleaseTryAgainLater"),
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({ sessionRequest, message: errorMessage });
       return;
     }
 
-    // Get dapp metadata for analytics
-    const { activeSessions } = useWalletKitStore.getState();
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
-    );
-    const dappDomain = dappMetadata?.url;
+    const dappDomain = sessionRequest.origin;
 
     analytics.trackSignedMessage({
       messageLength: contentResult.value.length,
@@ -399,7 +471,7 @@ export const approveSessionRequest = async ({
     };
 
     try {
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signMessageSuccessfull"),
@@ -418,7 +490,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message: errorMsg });
+      rejectDappRequest({ sessionRequest, message: errorMsg });
     }
 
     return;
@@ -443,36 +515,34 @@ export const approveSessionRequest = async ({
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({
+        sessionRequest,
+        message: errorMessage,
+        code: DappErrorCode.INVALID_PARAMS,
+      });
       return;
     }
 
     // signAuthEntry catches internally — null return signals failure
+    if (!sessionRequest.isValid()) {
+      ensureValid();
+      return;
+    }
     const result = signAuthEntry(entryXdr as string);
 
     if (!result) {
       const errorMessage = t("walletKit.failedToProcessAuthEntry");
-      logger.error(
-        "approveSessionRequest",
-        errorMessage,
-        new Error(errorMessage),
-      );
+      logger.error("executeDappRequest", errorMessage, new Error(errorMessage));
       showToast({
         title: t("walletKit.errorSigningAuthEntry"),
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({ sessionRequest, message: errorMessage });
       return;
     }
 
-    // Get dapp metadata for analytics
-    const { activeSessions } = useWalletKitStore.getState();
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
-    );
-    const dappDomain = dappMetadata?.url;
+    const dappDomain = sessionRequest.origin;
 
     analytics.trackSignedAuthEntry({
       ...(dappDomain ? { dappDomain } : {}),
@@ -485,7 +555,7 @@ export const approveSessionRequest = async ({
     };
 
     try {
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signAuthEntrySuccessfull"),
@@ -504,7 +574,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t("walletKit.failedToProcessAuthEntry"),
       });
@@ -521,34 +591,28 @@ export const approveSessionRequest = async ({
     transaction = TransactionBuilder.fromXdr(xdr as string, networkPassphrase);
 
     // Always sign the transaction for both supported RPC methods
+    if (!sessionRequest.isValid()) {
+      ensureValid();
+      return;
+    }
     signedTransaction = signTransaction(transaction);
 
     if (!signedTransaction) {
       const errorMessage = "Failed to sign transaction";
-      logger.error(
-        "approveSessionRequest",
-        errorMessage,
-        new Error(errorMessage),
-      );
+      logger.error("executeDappRequest", errorMessage, new Error(errorMessage));
       showToast({
         title: t("walletKit.errorSigning"),
         message: t("walletKit.pleaseTryAgainLater"),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t("common.error", { errorMessage }),
       });
       return;
     }
 
-    // Get dapp metadata for analytics
-    const { activeSessions } = useWalletKitStore.getState();
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
-    );
-    dappDomain = dappMetadata?.url;
+    dappDomain = sessionRequest.origin;
 
     analytics.trackSignedTransaction({
       ...(dappDomain ? { dappDomain } : {}),
@@ -563,7 +627,7 @@ export const approveSessionRequest = async ({
       message,
       variant: "error",
     });
-    rejectSessionRequest({ sessionRequest, message });
+    rejectDappRequest({ sessionRequest, message });
     return;
   }
 
@@ -571,6 +635,10 @@ export const approveSessionRequest = async ({
   if (rpcMethod === StellarRpcMethods.SIGN_AND_SUBMIT_XDR) {
     // For stellar_signAndSubmitXDR: sign AND submit, then return success status
     try {
+      if (!sessionRequest.isValid()) {
+        ensureValid();
+        return;
+      }
       await submitTx({
         network: targetNetwork,
         tx: signedTransaction,
@@ -591,7 +659,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message });
+      rejectDappRequest({ sessionRequest, message });
 
       return;
     }
@@ -603,7 +671,7 @@ export const approveSessionRequest = async ({
         jsonrpc: "2.0",
       };
 
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signAndSubmitSuccessfull"),
@@ -622,7 +690,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message });
+      rejectDappRequest({ sessionRequest, message });
     }
   } else if (rpcMethod === StellarRpcMethods.SIGN_XDR) {
     // For stellar_signXDR: sign only, then return the signed transaction
@@ -633,7 +701,7 @@ export const approveSessionRequest = async ({
     };
 
     try {
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signSuccessfull"),
@@ -652,21 +720,55 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message });
+      rejectDappRequest({ sessionRequest, message });
     }
-  } else {
-    // Unknown RPC method
-    const message = t("walletKit.errorUnsupportedMethod", {
-      method: rpcMethod || "unknown",
-    });
-    logger.error("approveSessionRequest", message, new Error(message));
-    showToast({
-      title: t("walletKit.errorUnsupportedMethodTitle"),
-      message,
-      variant: "error",
-    });
-    rejectSessionRequest({ sessionRequest, message });
   }
+};
+
+/** WalletConnect keeps its session transport and numeric rejection code. */
+export const toDappRequest = (
+  sessionRequest: WalletKitSessionRequest,
+  publicKey: string,
+  networkPassphrase: string,
+): DappRequest => {
+  const metadata = getDappMetadataFromEvent(
+    sessionRequest,
+    useWalletKitStore.getState().activeSessions,
+  ) || { name: "", description: "", url: "", icons: [] };
+  return {
+    id: sessionRequest.id,
+    params: sessionRequest.params,
+    origin: sessionRequest.verifyContext?.verified?.origin || metadata.url,
+    metadata,
+    transport: DappTransport.WALLET_CONNECT,
+    isValid: () => {
+      const state = useAuthenticationStore.getState();
+      return (
+        state.authStatus === AUTH_STATUS.AUTHENTICATED &&
+        !state.isSoftLocked &&
+        state.account?.publicKey === publicKey &&
+        (mapNetworkToNetworkDetails(state.network)
+          .networkPassphrase as string) === networkPassphrase
+      );
+    },
+    respond: async (response) => {
+      if (response.error) {
+        await rejectSessionRequest({
+          sessionRequest,
+          message: response.error.message,
+        });
+      } else {
+        await walletKit.respondSessionRequest({
+          topic: sessionRequest.topic,
+          response: {
+            id: sessionRequest.id,
+            jsonrpc: "2.0",
+            result: response.result,
+          },
+        });
+      }
+    },
+  };
 };
 
 /**

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1,6 +1,6 @@
 import Blockaid from "@blockaid/client";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
-import { xdr as stellarXdr } from "@stellar/stellar-sdk";
+import { TransactionBuilder, xdr as stellarXdr } from "@stellar/stellar-sdk";
 import AddMemoExplanationBottomSheet from "components/AddMemoExplanationBottomSheet";
 import BottomSheet from "components/BottomSheet";
 import InformationBottomSheet from "components/InformationBottomSheet";
@@ -11,6 +11,7 @@ import DappRequestBottomSheetContent from "components/screens/WalletKit/DappRequ
 import Icon from "components/sds/Icon";
 import { AnalyticsEvent } from "config/analyticsConfig";
 import { mapNetworkToNetworkDetails, NETWORKS } from "config/constants";
+import { DappErrorCode, type DappRequest } from "config/dappRequest";
 import { logger } from "config/logger";
 import { AUTH_STATUS } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
@@ -23,13 +24,14 @@ import {
   WalletKitSessionRequest,
   StellarRpcChains,
   StellarRpcMethods,
-  StellarSignXDRParams,
 } from "ducks/walletKit";
 import { isE2ETest } from "helpers/isEnv";
 import { getHostname } from "helpers/protocols";
 import {
   approveSessionProposal,
-  approveSessionRequest,
+  executeDappRequest,
+  rejectDappRequest,
+  toDappRequest,
   rejectSessionRequest,
   rejectSessionProposal,
   resolveDappRejectionEvent,
@@ -125,8 +127,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const [isSigning, setIsSigning] = useState(false);
   const [proposalEvent, setProposalEvent] =
     useState<WalletKitSessionProposal | null>(null);
-  const [requestEvent, setRequestEvent] =
-    useState<WalletKitSessionRequest | null>(null);
+  const [requestEvent, setRequestEvent] = useState<DappRequest | null>(null);
   const [siteScanResult, setSiteScanResult] = useState<
     Blockaid.SiteScanResponse | undefined
   >(undefined);
@@ -136,13 +137,22 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
   // Request queue to prevent concurrent request handling race conditions
   const isProcessingRequestRef = useRef(false);
+  const activeProposalRef = useRef<number | null>(null);
+  const activeRequestRef = useRef<DappRequest | null>(null);
+  const isClearingRequestRef = useRef(false);
+  const securityWarningDecisionRef = useRef(false);
+  /** Releases the active request slot after a rejection so the next queued request can proceed. */
+  const resetActiveRequest = () => {
+    activeRequestRef.current = null;
+    isProcessingRequestRef.current = false;
+  };
   const pendingRequestsQueueRef = useRef<WalletKitSessionRequest[]>([]);
-  // Guard against double-reject: set to true once approveSessionRequest has sent
+  // Guard against double-reject: set to true once executeDappRequest has sent
   // its own response (success or handled error) so handleClearDappRequest doesn't
   // send a duplicate rejection when it fires via .finally().
   const hasRespondedRef = useRef(false);
   // True once the user has committed to approving (handleDappRequest called
-  // approveSessionRequest). Distinguishes an approval attempt — whether it
+  // executeDappRequest). Distinguishes an approval attempt — whether it
   // succeeds or throws — from a genuine user dismissal, so the exceptional
   // approve-threw path isn't miscounted as a signing.*_rejected. Reset with
   // hasRespondedRef in the teardown.
@@ -150,7 +160,9 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
   const xdr = useMemo(
     () =>
-      (requestEvent?.params.request.params as StellarSignXDRParams)?.xdr ?? "",
+      typeof requestEvent?.params.request.params?.xdr === "string"
+        ? requestEvent.params.request.params.xdr
+        : "",
     [requestEvent],
   );
 
@@ -189,6 +201,31 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const dappConnectionBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const dappRequestBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const siteSecurityWarningBottomSheetModalRef = useRef<BottomSheetModal>(null);
+  // The site and transaction warnings share one BottomSheetModal. Presenting it
+  // while its previous dismissal is still animating lets that dismissal's
+  // onDismiss fire against the new presentation and cancel it (the signing
+  // sheet then never appears and the dApp waits forever). Track presentation
+  // and in-flight dismissal so a present during a dismiss is deferred to
+  // onDismiss instead.
+  const securityWarningPresentedRef = useRef(false);
+  const securityWarningDismissingRef = useRef(false);
+  const securityWarningPendingPresentRef = useRef(false);
+  /** Presents the shared security warning sheet, deferring until an in-flight dismiss has settled. */
+  const presentSecurityWarning = () => {
+    if (securityWarningDismissingRef.current) {
+      securityWarningPendingPresentRef.current = true;
+      return;
+    }
+    securityWarningPresentedRef.current = true;
+    securityWarningDecisionRef.current = false;
+    siteSecurityWarningBottomSheetModalRef.current?.present();
+  };
+  /** Dismisses the shared security warning sheet if presented; onDismiss replays a deferred present. */
+  const dismissSecurityWarning = () => {
+    if (!securityWarningPresentedRef.current) return;
+    securityWarningDismissingRef.current = true;
+    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+  };
   const verifyDomainBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const [securityWarningContext, setSecurityWarningContext] =
     useState<SecurityContext>(SecurityContext.SITE);
@@ -419,8 +456,10 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleClearDappConnection = () => {
+    activeProposalRef.current = null;
     dappConnectionBottomSheetModalRef.current?.dismiss();
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
     verifyDomainBottomSheetModalRef.current?.dismiss();
     // Also ensure other sheets are closed to avoid any leftovers
     dappRequestBottomSheetModalRef.current?.dismiss();
@@ -430,6 +469,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     setSiteScanResult(undefined);
     setSecurityWarningContext(SecurityContext.SITE);
     clearEvent();
+    if (pendingRequestsQueueRef.current.length)
+      setEvent(pendingRequestsQueueRef.current.shift()!);
   };
 
   /**
@@ -439,16 +480,23 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleClearDappRequest = () => {
+    if (
+      isClearingRequestRef.current ||
+      activeRequestRef.current !== requestEvent
+    )
+      return;
+    isClearingRequestRef.current = true;
     dappRequestBottomSheetModalRef.current?.dismiss();
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
 
     // We need to explicitly reject the request here otherwise
     // the app will show the request again on next app launch.
-    // Skip if approveSessionRequest already sent a response. This WC-level
-    // fallback fires on BOTH a user dismissal AND the exceptional case where
-    // approveSessionRequest threw (so the dApp isn't left hanging).
+    // Skip if executeDappRequest already sent a response. This fallback
+    // fires on BOTH a user dismissal AND the exceptional case where
+    // executeDappRequest threw (so the dApp isn't left hanging).
     if (requestEvent && !hasRespondedRef.current) {
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest: requestEvent,
         message: t("walletKit.userRejected"),
       });
@@ -465,8 +513,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       approvalInFlight: approvalInFlightRef.current,
     });
     if (rejectionEvent && requestEvent) {
-      const dappDomain =
-        getDappMetadataFromEvent(requestEvent, activeSessions)?.url || "";
+      const dappDomain = requestEvent.metadata.url || "";
       const payload = dappDomain ? { dappDomain } : {};
       if (rejectionEvent === "message") {
         analytics.trackSignedMessageRejected(payload);
@@ -478,6 +525,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     }
 
     setTimeout(() => {
+      if (activeRequestRef.current !== requestEvent) return;
+      activeRequestRef.current = null;
       setIsSigning(false);
       setRequestEvent(null);
       setTransactionScanResult(undefined);
@@ -491,6 +540,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
       // Mark processing as complete and process pending request if any
       isProcessingRequestRef.current = false;
+      isClearingRequestRef.current = false;
       if (pendingRequestsQueueRef.current.length > 0) {
         logger.debug(
           "WalletKitProvider",
@@ -563,7 +613,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleDappRequest = () => {
-    if (!requestEvent) {
+    if (
+      !requestEvent ||
+      approvalInFlightRef.current ||
+      isClearingRequestRef.current ||
+      !requestEvent.isValid()
+    ) {
       return;
     }
 
@@ -572,7 +627,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     // exceptional approve-threw .catch path) is not miscounted as a user reject.
     approvalInFlightRef.current = true;
 
-    approveSessionRequest({
+    executeDappRequest({
       sessionRequest: requestEvent,
       signTransaction,
       signMessage,
@@ -584,7 +639,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       t,
     })
       .then(() => {
-        // approveSessionRequest handled the WC response internally (success or
+        if (activeRequestRef.current !== requestEvent) return;
+        // executeDappRequest handled the WC response internally (success or
         // its own rejection). Mark responded so handleClearDappRequest won't
         // send a duplicate rejection.
         hasRespondedRef.current = true;
@@ -599,6 +655,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         );
       })
       .finally(() => {
+        if (activeRequestRef.current !== requestEvent) return;
         handleClearDappRequest();
       });
   };
@@ -623,7 +680,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         dappConnectionBottomSheetModalRef.current?.dismiss();
       }
 
-      siteSecurityWarningBottomSheetModalRef.current?.present();
+      presentSecurityWarning();
     },
     [],
   );
@@ -632,7 +689,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Handles proceeding anyway from security warning (context-aware)
    */
   const handleProceedAnyway = (): void => {
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
 
     const isUnableToScan =
       securityWarningContext === SecurityContext.TRANSACTION
@@ -664,7 +722,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleCancelSecurityWarning = () => {
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
 
     if (
       securityWarningBlocksSheet &&
@@ -698,9 +757,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Validates the message param for sign_message requests.
    * @returns true if valid, false if invalid (rejection already handled)
    */
-  const prevalidateSignMessage = (
-    sessionRequest: WalletKitSessionRequest,
-  ): boolean => {
+  const prevalidateSignMessage = (sessionRequest: DappRequest): boolean => {
     const msgParam = (
       sessionRequest.params as
         | { request?: { params?: { message?: unknown } } }
@@ -715,12 +772,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(contentResult.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(contentResult.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -732,12 +789,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(lengthResult.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(lengthResult.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -749,7 +806,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns the entryXdr string if valid, or null if invalid (rejection handled)
    */
   const prevalidateSignAuthEntryContent = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
   ): string | null => {
     const entryParam = (
       sessionRequest.params as
@@ -764,12 +821,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return null;
     }
 
@@ -781,7 +838,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns the parsed preimage if valid, or null if invalid (rejection handled)
    */
   const prevalidateSignAuthEntryXdrFormat = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
     entryXdr: string,
   ): stellarXdr.HashIdPreimage | null => {
     const result = parseAuthEntryPreimage(entryXdr);
@@ -791,12 +848,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return null;
     }
 
@@ -809,7 +866,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns true if valid, false if invalid (rejection handled)
    */
   const prevalidateSignAuthEntryNetworkId = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
     preimage: stellarXdr.HashIdPreimage,
   ): boolean => {
     const result = validateAuthEntryNetwork(
@@ -822,12 +879,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -839,7 +896,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * wallet account. Rejects the request on mismatch.
    */
   const prevalidateSignAuthEntryAddress = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
     preimage: stellarXdr.HashIdPreimage,
   ): boolean => {
     const result = validateAuthEntryAddress(preimage, publicKey);
@@ -849,12 +906,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -865,9 +922,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Orchestrates all sign_auth_entry pre-validations.
    * @returns true if all validations pass, false if any fail (rejection handled)
    */
-  const prevalidateSignAuthEntry = (
-    sessionRequest: WalletKitSessionRequest,
-  ): boolean => {
+  const prevalidateSignAuthEntry = (sessionRequest: DappRequest): boolean => {
     // Step 1: Validate content (presence, type, non-empty)
     const entryXdr = prevalidateSignAuthEntryContent(sessionRequest);
     if (!entryXdr) {
@@ -900,6 +955,19 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Handles SESSION_PROPOSAL events — validates auth, scans site, shows connection sheet.
    */
   const handleSessionProposal = (sessionProposal: WalletKitSessionProposal) => {
+    if (activeProposalRef.current === sessionProposal.id) return;
+    if (
+      isProcessingRequestRef.current ||
+      isClearingRequestRef.current ||
+      activeProposalRef.current !== null
+    ) {
+      rejectSessionProposal({
+        sessionProposal,
+        message: t("walletKit.userRejected"),
+      });
+      clearEvent();
+      return;
+    }
     // Check if user is not authenticated
     if (authStatus === AUTH_STATUS.NOT_AUTHENTICATED) {
       showToast({
@@ -937,6 +1005,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       return;
     }
 
+    activeProposalRef.current = sessionProposal.id;
     setProposalEvent(sessionProposal);
 
     const dappMetadata = getDappMetadataFromEvent(
@@ -947,6 +1016,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
     scanSite(dappDomain)
       .then((scanResult) => {
+        if (activeProposalRef.current !== sessionProposal.id) return;
         setSiteScanResult(scanResult);
         const securityAssessment = assessSiteSecurity(
           scanResult,
@@ -954,12 +1024,13 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         );
         if (securityAssessment.isUnableToScan) {
           setSecurityWarningContext(SecurityContext.SITE);
-          siteSecurityWarningBottomSheetModalRef.current?.present();
+          presentSecurityWarning();
         } else {
           dappConnectionBottomSheetModalRef.current?.present();
         }
       })
       .catch(() => {
+        if (activeProposalRef.current !== sessionProposal.id) return;
         setSiteScanResult(undefined);
         const securityAssessment = assessSiteSecurity(
           undefined,
@@ -967,11 +1038,137 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         );
         if (securityAssessment.isUnableToScan) {
           setSecurityWarningContext(SecurityContext.SITE);
-          siteSecurityWarningBottomSheetModalRef.current?.present();
+          presentSecurityWarning();
         } else {
           dappConnectionBottomSheetModalRef.current?.present();
         }
       });
+  };
+
+  /**
+   * Entry point shared by both transports once a request is native-verified:
+   * pins it as the active request, validates method and params, runs the
+   * Blockaid transaction scan for XDR requests, and presents the signing
+   * sheet. Everything downstream (approve/reject) reads `activeRequestRef`.
+   */
+  const handleNormalizedRequest = (incoming: DappRequest) => {
+    const sessionRequest: DappRequest = {
+      ...incoming,
+      isValid: () =>
+        activeRequestRef.current === sessionRequest &&
+        !isClearingRequestRef.current &&
+        incoming.isValid(),
+    };
+    activeRequestRef.current = sessionRequest;
+    if (!sessionRequest.isValid()) {
+      rejectDappRequest({
+        sessionRequest,
+        message: t("walletKit.userNotAuthenticated"),
+        code: DappErrorCode.CONTEXT_CHANGED,
+      });
+      resetActiveRequest();
+      return;
+    }
+    const { method } = sessionRequest.params.request;
+    const { params } = sessionRequest.params.request;
+    const supported = Object.values(StellarRpcMethods).includes(
+      method as StellarRpcMethods,
+    );
+    const transactionMethod =
+      method === (StellarRpcMethods.SIGN_XDR as string) ||
+      method === (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
+    if (
+      !supported ||
+      (transactionMethod &&
+        (typeof params?.xdr !== "string" || !params.xdr.trim()))
+    ) {
+      rejectDappRequest({
+        sessionRequest,
+        message: t("walletKit.invalidRequestTitle"),
+        code: !supported
+          ? DappErrorCode.UNSUPPORTED_METHOD
+          : DappErrorCode.INVALID_PARAMS,
+      });
+      resetActiveRequest();
+      return;
+    }
+    // Get dApp metadata
+    const dappDomain = sessionRequest.origin;
+
+    const requestParams = sessionRequest.params as
+      | { request?: { method?: string; params?: { xdr?: string } } }
+      | undefined;
+    const currentRequestMethod = requestParams?.request?.method;
+    const requestXdr = requestParams?.request?.params?.xdr;
+
+    const isXdrRequest =
+      currentRequestMethod === (StellarRpcMethods.SIGN_XDR as string) ||
+      currentRequestMethod ===
+        (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
+
+    if (isXdrRequest && requestXdr) {
+      try {
+        TransactionBuilder.fromXdr(
+          requestXdr,
+          networkDetails.networkPassphrase,
+        );
+      } catch {
+        rejectDappRequest({
+          sessionRequest,
+          message: t("walletKit.invalidRequestTitle"),
+          code: DappErrorCode.INVALID_PARAMS,
+        });
+        resetActiveRequest();
+        return;
+      }
+      setRequestEvent(sessionRequest);
+      // XDR-based requests: scan transaction first
+      scanTransaction(requestXdr, dappDomain)
+        .then((scanResult) => {
+          if (!sessionRequest.isValid()) return;
+          setTransactionScanResult(scanResult);
+          const securityAssessment = assessTransactionSecurity(
+            scanResult,
+            overriddenBlockaidResponse,
+          );
+          if (securityAssessment.isUnableToScan) {
+            setSecurityWarningContext(SecurityContext.TRANSACTION);
+            setSecurityWarningBlocksSheet(true);
+            presentSecurityWarning();
+          } else {
+            dappRequestBottomSheetModalRef.current?.present();
+          }
+        })
+        .catch(() => {
+          if (!sessionRequest.isValid()) return;
+          setTransactionScanResult(undefined);
+          const securityAssessment = assessTransactionSecurity(
+            undefined,
+            overriddenBlockaidResponse,
+          );
+          if (securityAssessment.isUnableToScan) {
+            setSecurityWarningContext(SecurityContext.TRANSACTION);
+            setSecurityWarningBlocksSheet(true);
+            presentSecurityWarning();
+          } else {
+            dappRequestBottomSheetModalRef.current?.present();
+          }
+        });
+    } else {
+      // Non-XDR requests (sign_message, sign_auth_entry): validate params first
+      if (currentRequestMethod === (StellarRpcMethods.SIGN_MESSAGE as string)) {
+        if (!prevalidateSignMessage(sessionRequest)) return;
+      }
+
+      if (
+        currentRequestMethod === (StellarRpcMethods.SIGN_AUTH_ENTRY as string)
+      ) {
+        if (!prevalidateSignAuthEntry(sessionRequest)) return;
+      }
+
+      setRequestEvent(sessionRequest);
+      dappRequestBottomSheetModalRef.current?.present();
+    }
   };
 
   /**
@@ -980,7 +1177,11 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    */
   const handleSessionRequest = (sessionRequest: WalletKitSessionRequest) => {
     // Simple queue: if already processing a request, store this one as pending
-    if (isProcessingRequestRef.current) {
+    if (
+      isProcessingRequestRef.current ||
+      activeProposalRef.current !== null ||
+      isClearingRequestRef.current
+    ) {
       // Normal queue flow, not an error condition.
       logger.info(
         "WalletKitProvider",
@@ -1112,74 +1313,13 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       return;
     }
 
-    setRequestEvent(sessionRequest);
-
-    // Get dApp metadata
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
+    handleNormalizedRequest(
+      toDappRequest(
+        sessionRequest,
+        publicKey,
+        networkDetails.networkPassphrase,
+      ),
     );
-    const dappDomain =
-      (dappMetadata?.url as string) ||
-      sessionRequest.verifyContext?.verified?.origin ||
-      "";
-
-    const requestParams = sessionRequest.params as
-      | { request?: { method?: string; params?: { xdr?: string } } }
-      | undefined;
-    const currentRequestMethod = requestParams?.request?.method;
-    const requestXdr = requestParams?.request?.params?.xdr;
-
-    const isXdrRequest =
-      currentRequestMethod === (StellarRpcMethods.SIGN_XDR as string) ||
-      currentRequestMethod ===
-        (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
-
-    if (isXdrRequest && requestXdr) {
-      // XDR-based requests: scan transaction first
-      scanTransaction(requestXdr, dappDomain)
-        .then((scanResult) => {
-          setTransactionScanResult(scanResult);
-          const securityAssessment = assessTransactionSecurity(
-            scanResult,
-            overriddenBlockaidResponse,
-          );
-          if (securityAssessment.isUnableToScan) {
-            setSecurityWarningContext(SecurityContext.TRANSACTION);
-            setSecurityWarningBlocksSheet(true);
-            siteSecurityWarningBottomSheetModalRef.current?.present();
-          } else {
-            dappRequestBottomSheetModalRef.current?.present();
-          }
-        })
-        .catch(() => {
-          setTransactionScanResult(undefined);
-          const securityAssessment = assessTransactionSecurity(
-            undefined,
-            overriddenBlockaidResponse,
-          );
-          if (securityAssessment.isUnableToScan) {
-            setSecurityWarningContext(SecurityContext.TRANSACTION);
-            setSecurityWarningBlocksSheet(true);
-            siteSecurityWarningBottomSheetModalRef.current?.present();
-          } else {
-            dappRequestBottomSheetModalRef.current?.present();
-          }
-        });
-    } else {
-      // Non-XDR requests (sign_message, sign_auth_entry): validate params first
-      if (currentRequestMethod === (StellarRpcMethods.SIGN_MESSAGE as string)) {
-        if (!prevalidateSignMessage(sessionRequest)) return;
-      }
-
-      if (
-        currentRequestMethod === (StellarRpcMethods.SIGN_AUTH_ENTRY as string)
-      ) {
-        if (!prevalidateSignAuthEntry(sessionRequest)) return;
-      }
-
-      dappRequestBottomSheetModalRef.current?.present();
-    }
   };
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -1302,6 +1442,20 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       <BottomSheet
         modalRef={siteSecurityWarningBottomSheetModalRef}
         handleCloseModal={handleCancelSecurityWarning}
+        bottomSheetModalProps={{
+          onDismiss: () => {
+            securityWarningPresentedRef.current = false;
+            securityWarningDismissingRef.current = false;
+            const decided = securityWarningDecisionRef.current;
+            securityWarningDecisionRef.current = false;
+            if (securityWarningPendingPresentRef.current) {
+              securityWarningPendingPresentRef.current = false;
+              presentSecurityWarning();
+              return;
+            }
+            if (!decided) handleCancelSecurityWarning();
+          },
+        }}
         customContent={
           <SecurityDetailBottomSheet
             warnings={getWarnings()}


### PR DESCRIPTION
### What

WalletConnect requests now go through a small transport-agnostic shape, `DappRequest`, before they reach validation, Blockaid scanning and signing. `executeDappRequest` and `rejectDappRequest` replace `approveSessionRequest` / `rejectSessionRequest`, and they respond through the request itself instead of calling WalletKit directly. The signing sheet components and `useDappHeader` take a `DappRequest`.

Two small fixes in `WalletKitProvider` ride along because they are part of the same lifecycle:

- The provider pins the active request (`activeRequestRef` / `isClearingRequestRef`) and re-checks `isValid()` right before signing, so a request that went stale during approval is rejected instead of signed.
- The site and transaction warnings share one bottom sheet. Presenting it while the previous dismiss is still animating let that dismiss cancel the new sheet. `presentSecurityWarning` now defers until the dismiss settles.

### Why

This is the first of three PRs that add an in-app WebView wallet provider to Discovery. That feature needs a second way for dApp requests to arrive and be answered, so the shared code (validation, Blockaid, signing, sheets) has to stop assuming WalletConnect. Landing this part on its own keeps the WalletConnect-only diff small and easy to revert, and it can be verified on its own: no user-facing behaviour changes here.

Stacked on top: WebView provider (next PR), then silent SEP-10 sign-in.

### Known limitations

- WalletConnect still sends its numeric `5000` rejection code on the wire. The new `DappErrorCode` strings are only used in-app and in tests.
- Tested on iOS as part of the full stack, not on Android yet.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes. (No UI change.)
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes. (No UI change.)
