### PR TITLE
feat(webview): silent SEP-10 sign-in for approved documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Domain terms you will encounter throughout this codebase:
 ## Documentation
 
 - [WalletConnect RPC Methods](./docs/walletconnect-rpc-methods.md)
+- [In-app WebView dApp Provider](./docs/webview-provider.md)
 - [Release Process](./RELEASE.md)
 - [E2E Testing Guide](./e2e/README.md)
 - [E2E CI & Triggers](./e2e/docs/ci-and-triggers.md)
@@ -160,21 +161,21 @@ yarn test                         # Unit tests must pass
 
 ## Best Practices
 
-| Concern              | File                                        | When to Read                                        |
-| -------------------- | ------------------------------------------- | --------------------------------------------------- |
-| Code Style           | docs/best-practices/code-style.md           | Writing or reviewing any code                       |
-| Architecture         | docs/best-practices/architecture.md         | Adding features, understanding the codebase         |
-| Styling              | docs/best-practices/styling.md              | Creating or modifying UI components                 |
-| Security             | docs/best-practices/security.md             | Touching keys, auth, storage, or dApp interactions  |
-| Testing              | docs/best-practices/testing.md              | Writing or fixing tests                             |
-| Performance          | docs/best-practices/performance.md          | Optimizing renders, lists, images, or startup       |
-| Error Handling       | docs/best-practices/error-handling.md       | Adding error states, retries, or user-facing errors |
-| Internationalization | docs/best-practices/i18n.md                 | Adding or modifying user-facing strings             |
-| WalletConnect        | docs/best-practices/walletconnect.md        | Working with dApp connections or RPC methods        |
-| Navigation           | docs/best-practices/navigation.md           | Adding screens, deep links, or navigation flows     |
-| Git & PR Workflow    | docs/best-practices/git-workflow.md         | Branching, committing, opening PRs, CI, releases    |
-| Dependencies         | docs/best-practices/dependencies.md         | Adding, updating, or auditing packages              |
-| Anti-Patterns        | docs/best-practices/anti-patterns.md        | Code review, avoiding common mistakes               |
+| Concern              | File                                  | When to Read                                        |
+| -------------------- | ------------------------------------- | --------------------------------------------------- |
+| Code Style           | docs/best-practices/code-style.md     | Writing or reviewing any code                       |
+| Architecture         | docs/best-practices/architecture.md   | Adding features, understanding the codebase         |
+| Styling              | docs/best-practices/styling.md        | Creating or modifying UI components                 |
+| Security             | docs/best-practices/security.md       | Touching keys, auth, storage, or dApp interactions  |
+| Testing              | docs/best-practices/testing.md        | Writing or fixing tests                             |
+| Performance          | docs/best-practices/performance.md    | Optimizing renders, lists, images, or startup       |
+| Error Handling       | docs/best-practices/error-handling.md | Adding error states, retries, or user-facing errors |
+| Internationalization | docs/best-practices/i18n.md           | Adding or modifying user-facing strings             |
+| WalletConnect        | docs/best-practices/walletconnect.md  | Working with dApp connections or RPC methods        |
+| Navigation           | docs/best-practices/navigation.md     | Adding screens, deep links, or navigation flows     |
+| Git & PR Workflow    | docs/best-practices/git-workflow.md   | Branching, committing, opening PRs, CI, releases    |
+| Dependencies         | docs/best-practices/dependencies.md   | Adding, updating, or auditing packages              |
+| Anti-Patterns        | docs/best-practices/anti-patterns.md  | Code review, avoiding common mistakes               |
 
 For build failures, setup issues, and known bugs, see
 [`docs/troubleshooting-guide.md`](./docs/troubleshooting-guide.md).

--- a/__tests__/helpers/dappExecutor.test.ts
+++ b/__tests__/helpers/dappExecutor.test.ts
@@ -41,7 +41,7 @@ describe("shared dApp executor", () => {
         url: "https://example.org",
         icons: [],
       },
-      transport: DappTransport.WALLET_CONNECT,
+      transport: DappTransport.WEBVIEW,
       isValid: jest.fn(() => true),
       respond,
     };
@@ -89,7 +89,7 @@ describe("shared dApp executor", () => {
     );
   });
 
-  it("returns message signatures through the transport", async () => {
+  it("returns message signatures through the transport without browser instructions", async () => {
     const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: "hello" });
     await executeDappRequest(args);
     expect(args.signMessage).toHaveBeenCalledWith("hello");
@@ -100,7 +100,6 @@ describe("shared dApp executor", () => {
     });
     expect(args.showToast).toHaveBeenCalledWith({
       title: "walletKit.signMessageSuccessfull",
-      message: "walletKit.returnToBrowser",
       variant: "success",
     });
   });

--- a/__tests__/helpers/dappExecutor.test.ts
+++ b/__tests__/helpers/dappExecutor.test.ts
@@ -1,0 +1,203 @@
+import {
+  Account,
+  BASE_FEE,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { DappErrorCode, DappRequest, DappTransport } from "config/dappRequest";
+import { StellarRpcChains, StellarRpcMethods } from "ducks/walletKit";
+import { executeDappRequest } from "helpers/walletKitUtil";
+import { TFunction } from "i18next";
+import { submitTx } from "services/stellar";
+
+jest.mock("services/analytics", () => ({
+  analytics: {
+    trackSignedMessage: jest.fn(),
+    trackSignedTransaction: jest.fn(),
+    trackSignedAuthEntry: jest.fn(),
+    trackSubmittedTransaction: jest.fn(),
+  },
+}));
+
+jest.mock("services/stellar", () => ({ submitTx: jest.fn() }));
+
+describe("shared dApp executor", () => {
+  const setup = (method: string, params: Record<string, unknown> = {}) => {
+    const respond = jest.fn().mockResolvedValue(undefined);
+    const sessionRequest: DappRequest = {
+      id: "request-1",
+      params: {
+        chainId: StellarRpcChains.TESTNET,
+        request: { method, params },
+      },
+      origin: "https://example.org",
+      metadata: {
+        name: "Example",
+        description: "",
+        url: "https://example.org",
+        icons: [],
+      },
+      transport: DappTransport.WALLET_CONNECT,
+      isValid: jest.fn(() => true),
+      respond,
+    };
+    return {
+      sessionRequest,
+      signTransaction: jest.fn(() => "signed-xdr"),
+      signMessage: jest.fn(() => "signature"),
+      signAuthEntry: jest.fn(() => ({
+        signedAuthEntry: "signed",
+        signerAddress: "GACCOUNT",
+      })),
+      networkPassphrase: "Test SDF Network ; September 2015",
+      publicKey: "GACCOUNT",
+      activeChain: StellarRpcChains.TESTNET,
+      showToast: jest.fn(),
+      t: ((key: string) => key) as TFunction<"translations", undefined>,
+    };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("rejects an unknown method without parsing XDR or signing", async () => {
+    const args = setup("unknown", { xdr: "bad-xdr" });
+    await executeDappRequest(args);
+    expect(args.signTransaction).not.toHaveBeenCalled();
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: "UNSUPPORTED_METHOD" }),
+      }),
+    );
+  });
+
+  it("refuses a stale document before signing", async () => {
+    const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: "hello" });
+    args.sessionRequest.isValid = () => false;
+    await executeDappRequest(args);
+    expect(args.signMessage).not.toHaveBeenCalled();
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: DappErrorCode.CONTEXT_CHANGED }),
+      }),
+    );
+  });
+
+  it("returns message signatures through the transport", async () => {
+    const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: "hello" });
+    await executeDappRequest(args);
+    expect(args.signMessage).toHaveBeenCalledWith("hello");
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith({
+      id: "request-1",
+      jsonrpc: "2.0",
+      result: { signature: "signature" },
+    });
+    expect(args.showToast).toHaveBeenCalledWith({
+      title: "walletKit.signMessageSuccessfull",
+      message: "walletKit.returnToBrowser",
+      variant: "success",
+    });
+  });
+
+  it("rejects wrong network and malformed messages before signing", async () => {
+    const args = setup(StellarRpcMethods.SIGN_MESSAGE, { message: 42 });
+    await executeDappRequest(args);
+    expect(args.signMessage).not.toHaveBeenCalled();
+    args.sessionRequest.params.chainId = StellarRpcChains.PUBLIC;
+    await executeDappRequest(args);
+    expect(args.signMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([StellarRpcMethods.SIGN_XDR, StellarRpcMethods.SIGN_AND_SUBMIT_XDR])(
+    "routes %s results through the same transport",
+    async (method) => {
+      const args = setup(method, { xdr: "xdr" });
+      jest
+        .spyOn(TransactionBuilder, "fromXdr")
+        .mockReturnValue({} as Transaction);
+      await executeDappRequest(args);
+      expect(args.signTransaction).toHaveBeenCalledTimes(1);
+      expect(args.sessionRequest.respond).toHaveBeenCalledWith({
+        id: "request-1",
+        jsonrpc: "2.0",
+        result:
+          method === StellarRpcMethods.SIGN_XDR
+            ? { signedXDR: "signed-xdr" }
+            : { status: "success" },
+      });
+      expect(submitTx).toHaveBeenCalledTimes(
+        method === StellarRpcMethods.SIGN_XDR ? 0 : 1,
+      );
+    },
+  );
+
+  it("rejects malformed authorization entries before signing", async () => {
+    const args = setup(StellarRpcMethods.SIGN_AUTH_ENTRY, { entryXdr: "bad" });
+    await executeDappRequest(args);
+    expect(args.signAuthEntry).not.toHaveBeenCalled();
+    expect(args.sessionRequest.respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: "INVALID_PARAMS" }),
+      }),
+    );
+  });
+
+  it("checks context again before submission", async () => {
+    const args = setup(StellarRpcMethods.SIGN_AND_SUBMIT_XDR, { xdr: "xdr" });
+    jest
+      .spyOn(TransactionBuilder, "fromXdr")
+      .mockReturnValue({} as Transaction);
+    args.signTransaction.mockImplementation(() => {
+      args.sessionRequest.isValid = () => false;
+      return "signed-xdr";
+    });
+    await executeDappRequest(args);
+    expect(args.signTransaction).toHaveBeenCalled();
+    expect(submitTx).not.toHaveBeenCalled();
+  });
+
+  it("returns an XDR signature verifiable for the approved account and network", async () => {
+    const signer = Keypair.random();
+    const unsigned = new TransactionBuilder(
+      new Account(signer.publicKey(), "100"),
+      {
+        fee: BASE_FEE,
+        networkPassphrase: Networks.TESTNET,
+      },
+    )
+      .addOperation(
+        Operation.manageData({ name: "bridge-test", value: "approved" }),
+      )
+      .setTimeout(0)
+      .build();
+    const args = setup(StellarRpcMethods.SIGN_XDR, { xdr: unsigned.toXdr() });
+    const respond = jest.fn().mockResolvedValue(undefined);
+    await executeDappRequest({
+      ...args,
+      publicKey: signer.publicKey(),
+      sessionRequest: { ...args.sessionRequest, respond },
+      signTransaction: (transaction: Transaction | FeeBumpTransaction) => {
+        transaction.sign(signer);
+        return transaction.toXdr();
+      },
+    });
+    expect(respond).toHaveBeenCalledTimes(1);
+    const { signedXDR } = respond.mock.calls[0][0].result as {
+      signedXDR: string;
+    };
+    const signed = TransactionBuilder.fromXdr(signedXDR, Networks.TESTNET);
+    expect(signed.hash()).toEqual(unsigned.hash());
+    expect(signed.signatures).toHaveLength(1);
+    const signature = signed.signatures[0].signature.toBytes();
+    expect(signer.verify(signed.hash(), signature)).toBe(true);
+    const wrongNetwork = TransactionBuilder.fromXdr(signedXDR, Networks.PUBLIC);
+    expect(signer.verify(wrongNetwork.hash(), signature)).toBe(false);
+    expect(Keypair.random().verify(signed.hash(), signature)).toBe(false);
+  });
+});

--- a/__tests__/helpers/walletKitUtil.test.ts
+++ b/__tests__/helpers/walletKitUtil.test.ts
@@ -44,7 +44,7 @@ describe("resolveDappRejectionEvent (dApp-request teardown → signing.*_rejecte
     ).toBeNull();
   });
 
-  // approveSessionRequest threw: the WC fallback rejection still fires, but this
+  // executeDappRequest threw: the WC fallback rejection still fires, but this
   // is an approval attempt, not a user reject — so no analytics rejection.
   it("returns null when an approval attempt was in flight (even if it threw)", () => {
     expect(

--- a/__tests__/hooks/useWebviewBridge.test.ts
+++ b/__tests__/hooks/useWebviewBridge.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react-native";
-import { NETWORKS } from "config/constants";
+import { NETWORKS, mapNetworkToNetworkDetails } from "config/constants";
+import { WebviewBridgeMethod } from "config/dappRequest";
 import { AUTH_STATUS } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
 import { useBrowserTabsStore } from "ducks/browserTabs";
@@ -7,14 +8,25 @@ import { useDappApprovalStore } from "ducks/dappApproval";
 import { useRemoteConfigStore } from "ducks/remoteConfig";
 import { useWebviewBridge } from "hooks/useWebviewBridge";
 import type { WebView } from "react-native-webview";
+import { prepareSep10Auth } from "services/webview/sep10";
 
 jest.mock("react-native-quick-crypto", () => ({
   randomBytes: (size: number) => Buffer.alloc(size, 7),
 }));
+jest.mock("services/webview/sep10", () => ({ prepareSep10Auth: jest.fn() }));
 
 const ORIGIN = "https://example.org";
 const TAB_ID = "tab-1";
 const PUBLIC_KEY = "GAZAJVMMEWVIQRP6RXQYTVAITE7SC2CBHALQTVW2N4DYBYPWZUH5VJGG";
+const AUTH = {
+  challengeXdr: "challenge",
+  signedXdr: "signed",
+  networkPassphrase: mapNetworkToNetworkDetails(NETWORKS.TESTNET)
+    .networkPassphrase,
+  homeDomain: "example.org",
+  webAuthEndpoint: `${ORIGIN}/auth`,
+};
+
 const setup = () => {
   const injectJavaScript = jest.fn();
   const refs = {
@@ -29,13 +41,43 @@ const setup = () => {
       .find(Boolean);
     return activation?.[1] ?? "";
   };
-  return { ...hook, injectJavaScript, activationToken };
+  const connect = (id: string) =>
+    hook.result.current.receive(
+      TAB_ID,
+      JSON.stringify({
+        protocol: "freighter-webview",
+        version: 1,
+        id,
+        documentToken: activationToken(),
+        method: WebviewBridgeMethod.CONNECT,
+        params: {},
+      }),
+      ORIGIN,
+    );
+  return { ...hook, injectJavaScript, activationToken, connect };
+};
+
+const approvePendingSite = async () => {
+  await act(async () => {});
+  const { job } = useDappApprovalStore.getState();
+  expect(job?.kind).toBe("site");
+  await act(async () => {
+    await job!.request.respond({
+      id: job!.request.id,
+      jsonrpc: "2.0",
+      result: true,
+    });
+  });
 };
 
 describe("useWebviewBridge", () => {
   beforeEach(() => {
+    jest.mocked(prepareSep10Auth).mockReset().mockResolvedValue(AUTH);
     useDappApprovalStore.setState({ job: null, walletConnectBusy: false });
-    useRemoteConfigStore.setState({ webview_provider_enabled: false });
+    useRemoteConfigStore.setState({
+      webview_provider_enabled: false,
+      webview_auto_signin_enabled: false,
+    });
     useAuthenticationStore.setState({
       authStatus: AUTH_STATUS.AUTHENTICATED,
       isSoftLocked: false,
@@ -77,5 +119,45 @@ describe("useWebviewBridge", () => {
     expect(h.injectJavaScript.mock.calls[0][0]).toContain(
       `location.origin === ${JSON.stringify(ORIGIN)}`,
     );
+  });
+
+  it("connects without a SEP-10 auth while webview_auto_signin_enabled is off", async () => {
+    useRemoteConfigStore.setState({ webview_provider_enabled: true });
+    const h = setup();
+    h.result.current.start(TAB_ID, `${ORIGIN}/app`);
+    h.result.current.loaded(TAB_ID, `${ORIGIN}/app`);
+    const pending = h.connect("1");
+    await approvePendingSite();
+    await pending;
+    expect(prepareSep10Auth).not.toHaveBeenCalled();
+    const delivered = h.injectJavaScript.mock.calls.at(-1)[0] as string;
+    expect(delivered).toContain(PUBLIC_KEY);
+    expect(delivered).not.toMatch(/"auth":/);
+    expect(useDappApprovalStore.getState().job).toBeNull();
+  });
+
+  it("countersigns and returns the SEP-10 auth on connect when auto sign-in is on", async () => {
+    useRemoteConfigStore.setState({
+      webview_provider_enabled: true,
+      webview_auto_signin_enabled: true,
+    });
+    const h = setup();
+    h.result.current.start(TAB_ID, `${ORIGIN}/app`);
+    h.result.current.loaded(TAB_ID, `${ORIGIN}/app`);
+    const pending = h.connect("1");
+    await approvePendingSite();
+    await pending;
+    expect(prepareSep10Auth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: ORIGIN,
+        account: expect.objectContaining({
+          address: PUBLIC_KEY,
+          chainId: "stellar:testnet",
+        }),
+      }),
+    );
+    const delivered = h.injectJavaScript.mock.calls.at(-1)[0] as string;
+    expect(delivered).toMatch(/"auth":/);
+    expect(delivered).toContain(AUTH.signedXdr);
   });
 });

--- a/__tests__/hooks/useWebviewBridge.test.ts
+++ b/__tests__/hooks/useWebviewBridge.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { NETWORKS } from "config/constants";
+import { AUTH_STATUS } from "config/types";
+import { useAuthenticationStore } from "ducks/auth";
+import { useBrowserTabsStore } from "ducks/browserTabs";
+import { useDappApprovalStore } from "ducks/dappApproval";
+import { useRemoteConfigStore } from "ducks/remoteConfig";
+import { useWebviewBridge } from "hooks/useWebviewBridge";
+import type { WebView } from "react-native-webview";
+
+jest.mock("react-native-quick-crypto", () => ({
+  randomBytes: (size: number) => Buffer.alloc(size, 7),
+}));
+
+const ORIGIN = "https://example.org";
+const TAB_ID = "tab-1";
+const PUBLIC_KEY = "GAZAJVMMEWVIQRP6RXQYTVAITE7SC2CBHALQTVW2N4DYBYPWZUH5VJGG";
+const setup = () => {
+  const injectJavaScript = jest.fn();
+  const refs = {
+    current: { [TAB_ID]: { injectJavaScript } as unknown as WebView },
+  };
+  const hook = renderHook(() => useWebviewBridge(refs));
+  const activationToken = () => {
+    const activation = injectJavaScript.mock.calls
+      .map(([script]: [string]) =>
+        /__freighterActivate\("([0-9a-f]+)"\)/.exec(script),
+      )
+      .find(Boolean);
+    return activation?.[1] ?? "";
+  };
+  return { ...hook, injectJavaScript, activationToken };
+};
+
+describe("useWebviewBridge", () => {
+  beforeEach(() => {
+    useDappApprovalStore.setState({ job: null, walletConnectBusy: false });
+    useRemoteConfigStore.setState({ webview_provider_enabled: false });
+    useAuthenticationStore.setState({
+      authStatus: AUTH_STATUS.AUTHENTICATED,
+      isSoftLocked: false,
+      network: NETWORKS.TESTNET,
+      account: { publicKey: PUBLIC_KEY } as never,
+    });
+    useBrowserTabsStore.setState({
+      tabs: [
+        {
+          id: TAB_ID,
+          url: `${ORIGIN}/app`,
+          title: "",
+          canGoBack: false,
+          canGoForward: false,
+          lastAccessed: 0,
+        },
+      ],
+      activeTabId: TAB_ID,
+      showTabOverview: false,
+    });
+  });
+
+  it("injects nothing while webview_provider_enabled is off", () => {
+    const h = setup();
+    expect(h.result.current.enabled).toBe(false);
+    h.result.current.start(TAB_ID, `${ORIGIN}/app`);
+    h.result.current.loaded(TAB_ID, `${ORIGIN}/app`);
+    expect(h.injectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it("activates already-mounted tabs once the flag turns on", () => {
+    const h = setup();
+    h.result.current.start(TAB_ID, `${ORIGIN}/app`);
+    act(() => {
+      useRemoteConfigStore.setState({ webview_provider_enabled: true });
+    });
+    expect(h.result.current.enabled).toBe(true);
+    expect(h.activationToken()).toBe("07".repeat(24));
+    expect(h.injectJavaScript.mock.calls[0][0]).toContain(
+      `location.origin === ${JSON.stringify(ORIGIN)}`,
+    );
+  });
+});

--- a/__tests__/providers/WalletKitWebview.test.tsx
+++ b/__tests__/providers/WalletKitWebview.test.tsx
@@ -1,0 +1,295 @@
+/* eslint-disable @typescript-eslint/require-await -- Async act flushes provider effects and promise continuations. */
+import { act, cleanup, render } from "@testing-library/react-native";
+import {
+  DappApprovalKind,
+  DappErrorCode,
+  type DappRequest,
+  DappTransport,
+} from "config/dappRequest";
+import { useDappApprovalStore } from "ducks/dappApproval";
+import { StellarRpcMethods } from "ducks/walletKit";
+import { executeDappRequest, rejectDappRequest } from "helpers/walletKitUtil";
+import { useBlockaidSite } from "hooks/blockaid/useBlockaidSite";
+import { WalletKitProvider } from "providers/WalletKitProvider";
+import React from "react";
+
+type Sheet = {
+  content: { props: Record<string, any>; type: string };
+  present: jest.Mock;
+  dismiss: jest.Mock;
+  onDismiss?: () => void;
+};
+const mockSheets = new Map<string, Sheet>();
+
+// Keep the real provider/coordinator; replace only native modal presentation.
+jest.mock("components/BottomSheet", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    const key = props.customContent.type;
+    let sheet = mockSheets.get(key);
+    if (!sheet) {
+      sheet = {
+        content: props.customContent,
+        present: jest.fn(),
+        dismiss: jest.fn(),
+      };
+      mockSheets.set(key, sheet);
+    }
+    sheet.content = props.customContent;
+    sheet.onDismiss = props.bottomSheetModalProps?.onDismiss;
+    const { modalRef } = props;
+    modalRef.current = sheet;
+    return null;
+  },
+}));
+jest.mock(
+  "components/screens/WalletKit/DappConnectionBottomSheetContent",
+  () => "connection",
+);
+jest.mock(
+  "components/screens/WalletKit/DappRequestBottomSheetContent",
+  () => "request",
+);
+jest.mock("components/AddMemoExplanationBottomSheet", () => "memo");
+jest.mock("components/InformationBottomSheet", () => "information");
+jest.mock("components/blockaid", () => ({
+  SecurityDetailBottomSheet: "warning",
+}));
+jest.mock("components/sds/Icon", () => ({ InfoCircle: () => null }));
+jest.mock(
+  "components/screens/SignTransactionDetails/hooks/useSignTransactionDetails",
+  () => ({ useSignTransactionDetails: () => ({}) }),
+);
+jest.mock("ducks/auth", () => ({
+  useAuthenticationStore: () => ({
+    network: "TESTNET",
+    authStatus: "AUTHENTICATED",
+  }),
+}));
+jest.mock("ducks/debug", () => ({ useDebugStore: () => ({}) }));
+jest.mock("ducks/transactionSettings", () => ({
+  useTransactionSettingsStore: () => ({
+    transactionMemo: "",
+    saveMemo: jest.fn(),
+  }),
+}));
+jest.mock("hooks/useWalletKitInitialize", () => ({
+  useWalletKitInitialize: () => true,
+}));
+jest.mock("hooks/useWalletKitEventsManager", () => ({
+  useWalletKitEventsManager: jest.fn(),
+}));
+jest.mock("hooks/useGetActiveAccount", () => ({
+  __esModule: true,
+  default: () => ({
+    account: { publicKey: "GACCOUNT" },
+    signTransaction: jest.fn(),
+    signMessage: jest.fn(),
+    signAuthEntry: jest.fn(),
+  }),
+}));
+jest.mock("hooks/useValidateTransactionMemo", () => ({
+  useValidateTransactionMemo: () => ({
+    isMemoMissing: false,
+    isValidatingMemo: false,
+  }),
+}));
+jest.mock("hooks/useDappMetadata", () => ({
+  getDappMetadataFromEvent: jest.fn(),
+}));
+jest.mock("hooks/useColors", () => ({
+  __esModule: true,
+  default: () => ({ themeColors: { foreground: { primary: "black" } } }),
+}));
+jest.mock("hooks/useAppTranslation", () => ({
+  __esModule: true,
+  default: () => ({ t: (key: string) => key }),
+}));
+jest.mock("providers/ToastProvider", () => ({
+  useToast: () => ({ showToast: jest.fn() }),
+}));
+jest.mock("hooks/blockaid/useBlockaidSite", () => ({
+  useBlockaidSite: jest.fn(),
+}));
+jest.mock("hooks/blockaid/useBlockaidTransaction", () => ({
+  useBlockaidTransaction: () => ({
+    scanTransaction: jest.fn().mockResolvedValue({ status: "safe" }),
+  }),
+}));
+jest.mock("helpers/walletKitUtil", () => ({
+  executeDappRequest: jest.fn(),
+  rejectDappRequest: jest.fn(({ sessionRequest, message, code }) =>
+    sessionRequest.respond({
+      id: sessionRequest.id,
+      jsonrpc: "2.0",
+      error: { code, message },
+    }),
+  ),
+  resolveDappRejectionEvent: () => undefined,
+}));
+jest.mock("helpers/walletKitValidation", () => ({
+  validateSignMessageContent: (value: string) => ({ valid: true, value }),
+  validateSignMessageLength: () => ({ valid: true }),
+}));
+jest.mock("services/blockaid/helper", () => ({
+  assessSiteSecurity: (result: { status?: string } | undefined) => ({
+    isMalicious: result?.status === "malicious",
+    isSuspicious: false,
+    isUnableToScan: result?.status !== "safe" && result?.status !== "malicious",
+  }),
+  assessTransactionSecurity: () => ({
+    isMalicious: false,
+    isSuspicious: false,
+    isUnableToScan: false,
+  }),
+  extractSecurityWarnings: () => [],
+}));
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+const makeRequest = (id: string): DappRequest => ({
+  id,
+  transport: DappTransport.WEBVIEW,
+  origin: "https://example.com",
+  metadata: {
+    name: "example",
+    description: "",
+    url: "https://example.com",
+    icons: [],
+  },
+  params: {
+    chainId: "stellar:testnet",
+    request: {
+      method: StellarRpcMethods.SIGN_MESSAGE,
+      params: { message: "hello" },
+    },
+  },
+  isValid: () => true,
+  respond: jest.fn(async () => {
+    useDappApprovalStore.setState({ job: null });
+  }),
+});
+const enqueue = async (
+  request: DappRequest,
+  kind: DappApprovalKind = DappApprovalKind.SIGN,
+) => {
+  await act(async () => {
+    useDappApprovalStore.setState({
+      job: { request, kind },
+      walletConnectBusy: kind === DappApprovalKind.SIGN,
+    });
+  });
+};
+const sheet = (name: string) => mockSheets.get(name)!;
+
+describe("WalletKit WebView approval lifecycle", () => {
+  const scanSite = jest.fn();
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockSheets.clear();
+    useDappApprovalStore.setState({ job: null, walletConnectBusy: false });
+    scanSite.mockResolvedValue({ status: "safe" });
+    jest
+      .mocked(useBlockaidSite)
+      .mockReturnValue({ scanSite } as unknown as ReturnType<
+        typeof useBlockaidSite
+      >);
+    render(<WalletKitProvider>{null}</WalletKitProvider>);
+  });
+  afterEach(() => {
+    cleanup();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("executes only once when approve is delivered twice before a render", async () => {
+    const pending = deferred();
+    jest.mocked(executeDappRequest).mockReturnValue(pending.promise);
+    await enqueue(makeRequest("first"));
+    expect(sheet("request").present).toHaveBeenCalledTimes(1);
+    const confirm = sheet("request").content.props.onConfirm;
+    act(() => {
+      confirm();
+      confirm();
+    });
+    expect(executeDappRequest).toHaveBeenCalledTimes(1);
+    await act(async () => pending.resolve());
+  });
+
+  it("a canceled submission finishing later cannot dismiss the next approval", async () => {
+    const pending = deferred();
+    jest.mocked(executeDappRequest).mockReturnValue(pending.promise);
+    const first = makeRequest("first");
+    first.params.request = {
+      method: StellarRpcMethods.SIGN_AND_SUBMIT_XDR,
+      params: { xdr: "scanned-xdr" },
+    };
+    await enqueue(first);
+    act(() => sheet("request").content.props.onConfirm());
+    await act(async () => {
+      useDappApprovalStore.setState({ job: null });
+    });
+    act(() => jest.advanceTimersByTime(200));
+    const second = makeRequest("second");
+    await enqueue(second);
+    const dismissCount = sheet("request").dismiss.mock.calls.length;
+    await act(async () => pending.resolve());
+    act(() => jest.advanceTimersByTime(200));
+    expect(sheet("request").dismiss).toHaveBeenCalledTimes(dismissCount);
+    expect(sheet("request").content.props.requestEvent.id).toBe(second.id);
+    expect(useDappApprovalStore.getState().job?.request).toBe(second);
+    expect(second.respond).not.toHaveBeenCalled();
+  });
+
+  it("connects a safe site without presenting a connection approval", async () => {
+    const request = makeRequest("connect");
+    await enqueue(request, DappApprovalKind.SITE);
+    expect(scanSite).toHaveBeenCalledWith(request.origin);
+    expect(request.respond).toHaveBeenCalledWith({
+      id: request.id,
+      jsonrpc: "2.0",
+      result: true,
+    });
+    expect(sheet("connection").present).not.toHaveBeenCalled();
+    expect(sheet("warning").present).not.toHaveBeenCalled();
+  });
+
+  it("rejects a site warning dismissed by a gesture", async () => {
+    scanSite.mockResolvedValue({ status: "malicious" });
+    const request = makeRequest("connect");
+    await enqueue(request, DappApprovalKind.SITE);
+    expect(sheet("warning").present).toHaveBeenCalledTimes(1);
+    expect(request.respond).not.toHaveBeenCalled();
+    await act(async () => sheet("warning").onDismiss?.());
+    expect(rejectDappRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionRequest: request,
+        code: DappErrorCode.USER_REJECTED,
+      }),
+    );
+    expect(useDappApprovalStore.getState().job).toBeNull();
+    expect(sheet("connection").present).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit site acknowledgment successful when its sheet dismisses", async () => {
+    scanSite.mockResolvedValue({ status: "malicious" });
+    const request = makeRequest("acknowledge");
+    await enqueue(request, DappApprovalKind.SITE);
+    await act(async () => sheet("warning").content.props.onProceedAnyway());
+    await act(async () => sheet("warning").onDismiss?.());
+    expect(request.respond).toHaveBeenCalledTimes(1);
+    expect(request.respond).toHaveBeenCalledWith({
+      id: request.id,
+      jsonrpc: "2.0",
+      result: true,
+    });
+    expect(rejectDappRequest).not.toHaveBeenCalled();
+    expect(sheet("connection").present).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/webviewBridge.test.ts
+++ b/__tests__/services/webviewBridge.test.ts
@@ -1,0 +1,447 @@
+/* eslint-disable no-underscore-dangle, no-script-url */
+// Prettier sorts built-in test imports with absolute application imports.
+/* eslint-disable import/order */
+import {
+  DappApprovalKind,
+  DappErrorCode,
+  DappRequest,
+} from "config/dappRequest";
+import { WebviewBridge, walletOrigin } from "services/webview/bridge";
+import {
+  activateBridge,
+  bridgeBootstrap,
+  bridgeDelivery,
+} from "services/webview/injection";
+import { TextEncoder } from "util";
+import { createContext, runInContext } from "vm";
+
+const ORIGIN = "https://example.org";
+const ACCOUNT = {
+  address: "GACCOUNT",
+  chainId: "stellar:testnet",
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+const page = () => {
+  const window = { ReactNativeWebView: { postMessage: jest.fn() } } as any;
+  window.top = window;
+  const location = { origin: ORIGIN };
+  const context = createContext({
+    window,
+    location,
+    TextEncoder,
+    setTimeout,
+    clearTimeout,
+  });
+  const run = (script: string) => runInContext(script, context);
+  return { window, location, run };
+};
+const setup = () => {
+  const browser = page();
+  const state: { active: boolean; account: typeof ACCOUNT | null } = {
+    active: true,
+    account: ACCOUNT,
+  };
+  const approve = jest
+    .fn<Promise<unknown>, [DappApprovalKind, DappRequest]>()
+    .mockResolvedValue(true);
+  let generation = 0;
+  const bridge = new WebviewBridge({
+    version: "1",
+    development: false,
+    token: () => `token-${++generation}`,
+    context: () => state,
+    approve,
+    inject: browser.run,
+  });
+  bridge.loaded(ORIGIN);
+  const received: any[] = [];
+  const receive = browser.window.__freighterReceive;
+  browser.window.__freighterReceive = (value: unknown) => {
+    received.push(value);
+    receive(value);
+  };
+  const raw = (
+    id: string,
+    method = "freighter_connect",
+    params = {},
+    overrides = {},
+  ) =>
+    JSON.stringify({
+      protocol: "freighter-webview",
+      version: 1,
+      id,
+      documentToken: `token-${generation}`,
+      method,
+      params,
+      ...overrides,
+    });
+  const send = (
+    id: string,
+    method = "freighter_connect",
+    params = {},
+    overrides = {},
+  ) => bridge.receive(raw(id, method, params, overrides), ORIGIN);
+  return { bridge, state, approve, received, raw, send, ...browser };
+};
+
+describe("native WebView request boundary", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it.each([
+    "http://example.org",
+    "https://user:password@example.org",
+    "file:///tmp/a",
+    "data:text/html,hi",
+    "javascript:alert(1)",
+  ])("rejects unsafe origin %s", (url) => {
+    expect(walletOrigin(url, false)).toBeNull();
+  });
+  it("restricts development HTTP to explicit local hosts", () => {
+    expect(walletOrigin("http://localhost:3000/path", true)).toBe(
+      "http://localhost:3000",
+    );
+    expect(walletOrigin("http://localhost.evil.org", true)).toBeNull();
+    expect(walletOrigin("http://localhost:3000", false)).toBeNull();
+  });
+  it("ignores forged body origins, native origin mismatch, and old document tokens", async () => {
+    const h = setup();
+    await h.bridge.receive(
+      h.raw("1", "freighter_connect", {}, { origin: ORIGIN }),
+      "https://attacker.org",
+    );
+    await h.send("2", "freighter_connect", {}, { documentToken: "old" });
+    expect(h.approve).not.toHaveBeenCalled();
+    expect(h.received).toEqual([]);
+  });
+  it("holds account access behind site approval and caches only the current document", async () => {
+    const h = setup();
+    let allow!: () => void;
+    h.approve.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          allow = resolve;
+        }),
+    );
+    const pending = h.send("1");
+    expect(h.received).toEqual([]);
+    allow();
+    await pending;
+    expect(h.received[0].result).toEqual(ACCOUNT);
+    await h.send("2");
+    expect(h.approve).toHaveBeenCalledTimes(1);
+    h.bridge.navigationStarted();
+    h.bridge.loaded(ORIGIN);
+    await h.send("3");
+    expect(h.approve).toHaveBeenCalledTimes(2);
+  });
+  it("does not expose an account after a denied or failed site gate", async () => {
+    const h = setup();
+    h.approve.mockRejectedValue({
+      code: DappErrorCode.USER_REJECTED,
+      message: "Rejected",
+    });
+    await h.send("1");
+    await h.send("2", "freighter_getAccount");
+    expect(h.received.map((r) => r.error.code)).toEqual([
+      "USER_REJECTED",
+      "NOT_CONNECTED",
+    ]);
+    expect(h.received.every((r) => r.result === undefined)).toBe(true);
+  });
+  it.each(["navigation", "account", "inactive"])(
+    "cancels a pending site scan on %s",
+    async (change) => {
+      const h = setup();
+      let allow!: () => void;
+      h.approve.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            allow = resolve;
+          }),
+      );
+      const pending = h.send("1");
+      const request = h.approve.mock.calls[0][1];
+      if (change === "navigation") {
+        h.bridge.navigationStarted();
+        h.bridge.loaded("https://other.org");
+      } else {
+        if (change === "account")
+          h.state.account = { ...ACCOUNT, address: "GOTHER" };
+        else h.state.active = false;
+        h.bridge.contextChanged();
+      }
+      expect(request.isValid()).toBe(false);
+      allow();
+      await pending;
+      expect(h.received.some((r) => r.result?.address)).toBe(false);
+    },
+  );
+  it("executes a duplicate signing ID at most once and ignores responses after cancellation", async () => {
+    const h = setup();
+    await h.send("connect");
+    h.approve.mockImplementationOnce(() => Promise.resolve(undefined));
+    await h.send("sign", "stellar_signMessage", {
+      chainId: ACCOUNT.chainId,
+      message: "hello",
+    });
+    const request = h.approve.mock.calls[1][1];
+    await h.send("sign", "stellar_signMessage", {
+      chainId: ACCOUNT.chainId,
+      message: "different",
+    });
+    expect(h.approve).toHaveBeenCalledTimes(2);
+    h.bridge.navigationStarted();
+    h.bridge.loaded(ORIGIN);
+    await request.respond({
+      id: "sign",
+      jsonrpc: "2.0",
+      result: { signature: "secret" },
+    });
+    expect(h.received.some((r) => r.result?.signature)).toBe(false);
+  });
+  it("rejects inactive, locked, wrong-network and unsupported requests before approval", async () => {
+    const h = setup();
+    h.state.active = false;
+    await h.send("1");
+    h.state.active = true;
+    h.state.account = null;
+    await h.send("2");
+    h.state.account = ACCOUNT;
+    await h.send("3");
+    await h.send("4", "stellar_signMessage", {
+      chainId: "stellar:pubnet",
+      message: "hello",
+    });
+    await h.send("5", "unknown");
+    expect(h.approve).toHaveBeenCalledTimes(1);
+    expect(h.received.filter((r) => r.error).map((r) => r.error.code)).toEqual([
+      "CONTEXT_CHANGED",
+      "WALLET_LOCKED",
+      "WRONG_NETWORK",
+      "UNSUPPORTED_METHOD",
+    ]);
+  });
+  it("refreshes a connected hidden document when it becomes active", async () => {
+    const h = setup();
+    await h.send("connect");
+    h.state.active = false;
+    h.bridge.contextChanged();
+    h.state.account = { ...ACCOUNT, address: "GOTHER" };
+    h.bridge.contextChanged();
+    const before = h.received.length;
+    h.state.active = true;
+    h.bridge.contextChanged();
+    expect(
+      h.received.slice(before).map((r) => [r.event, r.data.address]),
+    ).toEqual([
+      ["accountsChanged", "GOTHER"],
+      ["chainChanged", "GOTHER"],
+    ]);
+    await h.send("account", "freighter_getAccount");
+    expect(h.received.at(-1).result.address).toBe("GOTHER");
+    expect(h.approve).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves disconnect before its event cancels pending page promises", async () => {
+    const h = setup();
+    await h.send("connect");
+    h.window.ReactNativeWebView.postMessage.mockImplementation((raw: string) =>
+      h.bridge.receive(raw, ORIGIN),
+    );
+    await expect(
+      h.window.stellar.request({ method: "freighter_disconnect" }),
+    ).resolves.toBe(true);
+    h.state.active = false;
+    h.bridge.contextChanged();
+    h.state.active = true;
+    h.bridge.contextChanged();
+    await h.send("account", "freighter_getAccount");
+    expect(h.received.at(-1).error.code).toBe("NOT_CONNECTED");
+  });
+
+  it.each([
+    ["stellar_signXDR", { xdr: "transaction" }, { signedXDR: "signed" }],
+    ["stellar_signAndSubmitXDR", { xdr: "transaction" }, { status: "success" }],
+    ["stellar_signMessage", { message: "hello" }, { signature: "signed" }],
+    [
+      "stellar_signAuthEntry",
+      { entryXdr: "auth" },
+      { signedAuthEntry: "signed", signerAddress: "GACCOUNT" },
+    ],
+  ])(
+    "routes %s through native approval with pinned context",
+    async (method, params, result) => {
+      const h = setup();
+      await h.send("connect");
+      h.approve.mockImplementationOnce(async (kind, request) => {
+        expect(kind).toBe(DappApprovalKind.SIGN);
+        expect(request.origin).toBe(ORIGIN);
+        expect(request.isValid()).toBe(true);
+        expect(request.params.request).toEqual({
+          method,
+          params: { ...params, chainId: ACCOUNT.chainId },
+        });
+        await request.respond({ id: request.id, jsonrpc: "2.0", result });
+      });
+      await h.send("sign", method, {
+        ...(params as object),
+        chainId: ACCOUNT.chainId,
+      });
+      expect(h.received.at(-1).result).toEqual(result);
+    },
+  );
+
+  it("enforces exact UTF-8 message and envelope byte limits", async () => {
+    const h = setup();
+    await h.send("connect");
+    h.approve.mockImplementation(() => Promise.resolve());
+    await h.send("at-limit", "stellar_signMessage", {
+      message: "🔥".repeat(256),
+      chainId: ACCOUNT.chainId,
+    });
+    expect(h.approve).toHaveBeenCalledTimes(2);
+    await h.send("over-limit", "stellar_signMessage", {
+      message: `${"🔥".repeat(256)}a`,
+      chainId: ACCOUNT.chainId,
+    });
+    expect(h.received.at(-1).error.code).toBe("INVALID_PARAMS");
+    expect(h.approve).toHaveBeenCalledTimes(2);
+    const base = h.raw("envelope", "freighter_getCapabilities", {
+      padding: "",
+    });
+    const exact = h.raw("envelope", "freighter_getCapabilities", {
+      padding: "a".repeat(1048576 - Buffer.byteLength(base)),
+    });
+    expect(Buffer.byteLength(exact)).toBe(1048576);
+    await h.bridge.receive(`${exact} `, ORIGIN);
+    expect(h.received.at(-1).id).toBe("over-limit");
+    await h.bridge.receive(exact, ORIGIN);
+    expect(h.received.at(-1).result).toEqual({ protocolVersion: 1 });
+  });
+
+  it("bounds envelope bytes and invalidates timed-out approval handles", async () => {
+    const h = setup();
+    await h.send("huge", "freighter_connect", { data: "🔥".repeat(270000) });
+    expect(h.approve).not.toHaveBeenCalled();
+    h.approve.mockImplementationOnce(() => Promise.resolve(undefined));
+    await h.send("connect");
+    h.approve.mockImplementationOnce(() => Promise.resolve(undefined));
+    await h.send("sign", "stellar_signXDR", {
+      chainId: ACCOUNT.chainId,
+      xdr: "xdr",
+    });
+    const request = h.approve.mock.calls[1][1];
+    jest.advanceTimersByTime(300000);
+    expect(request.isValid()).toBe(false);
+    expect(h.received.at(-1).error.code).toBe("TIMEOUT");
+    await request.respond({ id: "sign", jsonrpc: "2.0", result: "late" });
+    expect(h.received.at(-1).error.code).toBe("TIMEOUT");
+  });
+});
+
+describe("injected JavaScript delivery", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+  it("registers promises before synchronous native responses", async () => {
+    const h = page();
+    h.run(activateBridge("1", "token", ORIGIN));
+    h.window.ReactNativeWebView.postMessage.mockImplementation(
+      (raw: string) => {
+        const request = JSON.parse(raw);
+        h.run(bridgeDelivery("token", ORIGIN, { ...request, result: "ok" }));
+      },
+    );
+    await expect(
+      h.window.stellar.request({ method: "freighter_getCapabilities" }),
+    ).resolves.toBe("ok");
+  });
+  it("drops cross-origin and stale-token responses, then accepts the originating document", async () => {
+    const h = page();
+    h.run(activateBridge("1", "token", ORIGIN));
+    const promise = h.window.stellar.request({ method: "freighter_connect" });
+    const request = JSON.parse(
+      h.window.ReactNativeWebView.postMessage.mock.calls.at(-1)[0],
+    );
+    const delivery = { ...request, result: "account" };
+    h.run(
+      bridgeDelivery("old", ORIGIN, {
+        ...delivery,
+        result: "leaked-old-document",
+      }),
+    );
+    h.location.origin = "https://other.org";
+    h.run(
+      bridgeDelivery("token", ORIGIN, {
+        ...delivery,
+        result: "leaked-other-origin",
+      }),
+    );
+    h.location.origin = ORIGIN;
+    h.run(bridgeDelivery("token", ORIGIN, delivery));
+    await expect(promise).resolves.toBe("account");
+  });
+  it("keeps bootstrap idempotent and rejects pending work when document token changes", async () => {
+    const h = page();
+    h.run(activateBridge("1", "first", ORIGIN));
+    const provider = h.window.stellar;
+    h.run(bridgeBootstrap("1"));
+    expect(h.window.stellar).toBe(provider);
+    const promise = h.window.stellar.request({ method: "stellar_signXDR" });
+    h.run(activateBridge("1", "second", ORIGIN));
+    await expect(promise).rejects.toMatchObject({ code: "CONTEXT_CHANGED" });
+  });
+  const readyPage = () => {
+    const h = page();
+    h.run(bridgeBootstrap("1"));
+    const ready = h.window.ReactNativeWebView.postMessage.mock.calls[0][0];
+    const inject = jest.fn(h.run);
+    const bridge = new WebviewBridge({
+      version: "1",
+      development: false,
+      token: () => "token-1",
+      context: () => ({ active: true, account: ACCOUNT }),
+      approve: jest.fn(),
+      inject,
+    });
+    return { ...h, ready, inject, bridge };
+  };
+  it("announces readiness at document start so activation does not wait for load end", async () => {
+    const h = readyPage();
+    expect(JSON.parse(h.ready)).toEqual({
+      protocol: "freighter-webview",
+      version: 1,
+      ready: true,
+    });
+    h.bridge.navigationStarted(`${ORIGIN}/app`);
+    await h.bridge.receive(h.ready, ORIGIN);
+    expect(h.window.stellar.documentToken).toBe("token-1");
+    expect(h.window.stellar.protocolVersion).toBe(1);
+    // Same-origin repeats keep the token; anything past the second is ignored.
+    await h.bridge.receive(h.ready, ORIGIN);
+    await h.bridge.receive(h.ready, ORIGIN);
+    expect(h.window.stellar.documentToken).toBe("token-1");
+    expect(h.inject).toHaveBeenCalledTimes(2);
+  });
+  it("activates only the navigated main-frame URL, whatever frame reports readiness", async () => {
+    const h = readyPage();
+    // No navigation known yet: nothing to activate.
+    await h.bridge.receive(h.ready, ORIGIN);
+    expect(h.inject).not.toHaveBeenCalled();
+    // A third-party iframe cannot steer activation to its own origin...
+    h.bridge.navigationStarted(`${ORIGIN}/app`);
+    await h.bridge.receive(h.ready, "https://attacker.org/frame");
+    expect(h.inject).toHaveBeenCalledTimes(1);
+    expect(h.window.stellar.documentToken).toBe("token-1");
+    // ...and a navigation the wallet does not serve never activates.
+    h.bridge.navigationStarted("http://attacker.example");
+    await h.bridge.receive(h.ready, ORIGIN);
+    expect(h.inject).toHaveBeenCalledTimes(1);
+  });
+  it("does not install into an iframe", () => {
+    const h = page();
+    h.window.top = {};
+    h.run(bridgeBootstrap("1"));
+    expect(h.window.stellar).toBeUndefined();
+  });
+});

--- a/__tests__/services/webviewSep10.test.ts
+++ b/__tests__/services/webviewSep10.test.ts
@@ -1,0 +1,205 @@
+// Prettier sorts built-in test imports with absolute application imports.
+/* eslint-disable import/order */
+import {
+  Keypair,
+  StellarToml,
+  TransactionBuilder,
+  WebAuth,
+} from "@stellar/stellar-sdk";
+import { prepareSep10Auth } from "services/webview/sep10";
+
+const TESTNET = "Test SDF Network ; September 2015";
+const server = Keypair.random();
+const client = Keypair.random();
+const account = {
+  address: client.publicKey(),
+  chainId: "stellar:testnet",
+  networkPassphrase: TESTNET,
+};
+const endpoint = "https://testnet-api.xoxno.com/user/stellar/challenge";
+
+const challengeFor = (
+  homeDomain: string,
+  webAuthDomain = "testnet-api.xoxno.com",
+) =>
+  WebAuth.buildChallengeTx(
+    server,
+    client.publicKey(),
+    homeDomain,
+    300,
+    TESTNET,
+    webAuthDomain,
+  );
+
+const install = ({
+  toml = {
+    WEB_AUTH_ENDPOINT: endpoint,
+    SIGNING_KEY: server.publicKey(),
+    NETWORK_PASSPHRASE: TESTNET,
+  },
+  challenge = challengeFor("xoxno.com"),
+  passphraseField = "networkPassphrase",
+}: {
+  toml?: Record<string, unknown>;
+  challenge?: string;
+  passphraseField?: string;
+} = {}) => {
+  jest.spyOn(StellarToml.Resolver, "resolve").mockResolvedValue(toml as never);
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ transaction: challenge, [passphraseField]: TESTNET }),
+    }),
+  );
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+};
+
+const signTransaction = jest.fn(
+  (tx: { sign: (k: Keypair) => void; toXdr: () => string }) => {
+    tx.sign(client);
+    return tx.toXdr();
+  },
+);
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  signTransaction.mockClear();
+});
+
+describe("prepareSep10Auth", () => {
+  it("countersigns a genuine challenge for the site and account", async () => {
+    const fetchMock = install();
+    const auth = await prepareSep10Auth({
+      origin: "https://xoxno.com",
+      account,
+      development: false,
+      signTransaction,
+    });
+    expect(auth).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${endpoint}?account=${client.publicKey()}`,
+      expect.anything(),
+    );
+    const signed = TransactionBuilder.fromXDR(auth!.signedXdr, TESTNET);
+    expect("signatures" in signed && signed.signatures).toHaveLength(2);
+    expect(auth!.homeDomain).toBe("xoxno.com");
+    expect(auth!.networkPassphrase).toBe(TESTNET);
+  });
+
+  it("accepts the snake_case SEP-10 field name too", async () => {
+    install({ passphraseField: "network_passphrase" });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.not.toBeNull();
+  });
+
+  it("refuses a challenge signed by a key other than the TOML SIGNING_KEY", async () => {
+    install({
+      toml: {
+        WEB_AUTH_ENDPOINT: endpoint,
+        SIGNING_KEY: Keypair.random().publicKey(),
+        NETWORK_PASSPHRASE: TESTNET,
+      },
+    });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
+  it("refuses a challenge for another account, another domain, or another network", async () => {
+    const other = Keypair.random().publicKey();
+    install({
+      challenge: WebAuth.buildChallengeTx(
+        server,
+        other,
+        "xoxno.com",
+        300,
+        TESTNET,
+        "testnet-api.xoxno.com",
+      ),
+    });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    install({ challenge: challengeFor("evil.example") });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    // A subdomain must not be able to sign in as the user on its parent: a
+    // genuine xoxno.com challenge is refused when the page is *.xoxno.com.
+    install({ challenge: challengeFor("xoxno.com") });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://evil.xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    install();
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account: {
+          ...account,
+          networkPassphrase: "Public Global Stellar Network ; September 2015",
+        },
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-https endpoint outside development and a TOML without SEP-10 fields", async () => {
+    install({
+      toml: {
+        WEB_AUTH_ENDPOINT:
+          "http://testnet-api.xoxno.com/user/stellar/challenge",
+        SIGNING_KEY: server.publicKey(),
+        NETWORK_PASSPHRASE: TESTNET,
+      },
+    });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    install({ toml: { NETWORK_PASSPHRASE: TESTNET } });
+    await expect(
+      prepareSep10Auth({
+        origin: "https://xoxno.com",
+        account,
+        development: false,
+        signTransaction,
+      }),
+    ).resolves.toBeNull();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/docs/webview-provider.md
+++ b/docs/webview-provider.md
@@ -1,0 +1,55 @@
+# Freighter WebView provider
+
+Discovery exposes a wallet transport to top-level dApps through
+`window.stellar`. dApps talk to it through the standalone
+[`@xoxno/freighter-webview-provider`](https://github.com/XOXNO/freighter-webview-provider)
+SDK; WalletConnect and extension integrations are unchanged.
+
+Feature flags (remote config, on in dev, off in production):
+
+- `webview_provider_enabled` — inject and activate the bridge.
+
+## Native boundary
+
+- No native patch. The per-document token is the frame authenticator: the
+  bootstrap is injected main-frame only, and activation and every reply are
+  delivered with `injectJavaScript`, which runs in the main frame. The token
+  therefore exists only in the top-level document, which the same-origin policy
+  keeps from cross-origin iframes; a same-origin iframe already shares the
+  page's authority. Iframes can reach `ReactNativeWebView.postMessage` but
+  cannot present a valid token.
+- `services/webview/injection.ts` is the bootstrap injected before content
+  loads. It is idempotent, never installs into an iframe, and only becomes
+  usable once the controller activates the document with a fresh token.
+- `services/webview/bridge.ts` is the per-WebView controller. It activates a
+  document only from the main-frame URL the WebView reported on navigation
+  (never a URL taken from a message), requires HTTPS (dev: local HTTP hosts),
+  and accepts a request only when the document token matches, the reported frame
+  URL is the activated origin, the id is new (replay set), the version and
+  method are known, and params are an object. Message signing is capped at 1
+  KiB, envelopes at 1 MiB, approvals at five minutes. Navigation, tab change,
+  background, lock, leaving Discovery, or an account/network change cancels
+  pending work with `CONTEXT_CHANGED`.
+- `config/dappRequest.ts` holds the shared `DappRequest` shape and the
+  `DappTransport`, `DappApprovalKind`, `DappErrorCode`, `WebviewBridgeMethod`
+  and `WebviewBridgeEvent` enums; bridge limits live in `config/constants.ts`
+  and the WebView message cap in `helpers/walletKitValidation.ts`.
+- `hooks/useWebviewBridge.ts` owns controller lifetime and hands approvals to
+  `WalletKitProvider` through `ducks/dappApproval`, the single approval surface
+  shared with WalletConnect (`BUSY` while occupied).
+- `helpers/walletKitUtil.ts#executeDappRequest` signs and submits for both
+  transports and re-checks request validity right before signing.
+
+## Connect
+
+`connect()` scans the origin with Blockaid; safe sites connect silently, others
+need the existing warning acknowledgment. Connecting never signs anything: the
+dApp runs its own SEP-10 flow and every signature goes through the normal
+approval sheet.
+
+## Tests
+
+`__tests__/services/webviewBridge.test.ts` runs the injected JavaScript in a VM
+against the controller; `hooks/useWebviewBridge.test.ts` pins the flag gating;
+`providers/WalletKitWebview.test.tsx` and `helpers/dappExecutor.test.ts` cover
+the approval provider and executor.

--- a/docs/webview-provider.md
+++ b/docs/webview-provider.md
@@ -8,6 +8,7 @@ SDK; WalletConnect and extension integrations are unchanged.
 Feature flags (remote config, on in dev, off in production):
 
 - `webview_provider_enabled` — inject and activate the bridge.
+- `webview_auto_signin_enabled` — countersign a SEP-10 challenge on connect.
 
 ## Native boundary
 
@@ -40,16 +41,22 @@ Feature flags (remote config, on in dev, off in production):
 - `helpers/walletKitUtil.ts#executeDappRequest` signs and submits for both
   transports and re-checks request validity right before signing.
 
-## Connect
+## Connect and SEP-10
 
 `connect()` scans the origin with Blockaid; safe sites connect silently, others
-need the existing warning acknowledgment. Connecting never signs anything: the
-dApp runs its own SEP-10 flow and every signature goes through the normal
-approval sheet.
+need the existing warning acknowledgment. When auto sign-in is on,
+`services/webview/sep10.ts` reads the site's `/.well-known/stellar.toml`,
+fetches a challenge from its `WEB_AUTH_ENDPOINT`, verifies it with
+`WebAuth.readChallengeTx` against the TOML `SIGNING_KEY`, the page's exact host
+as home domain (never a parent domain, so a stray subdomain cannot obtain a
+session on its parent), `web_auth_domain` and the wallet's network, checks the
+client account, and countersigns without a prompt. Any failure returns no `auth`
+and the dApp asks for a signature normally. Challenges are never cached. A
+challenge (sequence 0, manage-data only) skips the Blockaid transaction scan.
 
 ## Tests
 
 `__tests__/services/webviewBridge.test.ts` runs the injected JavaScript in a VM
-against the controller; `hooks/useWebviewBridge.test.ts` pins the flag gating;
-`providers/WalletKitWebview.test.tsx` and `helpers/dappExecutor.test.ts` cover
-the approval provider and executor.
+against the controller; `webviewSep10.test.ts` covers SEP-10 acceptance and
+refusals; `providers/WalletKitWebview.test.tsx` and
+`helpers/dappExecutor.test.ts` cover the approval provider and executor.

--- a/src/components/blockaid/SecurityDetailBottomSheet.tsx
+++ b/src/components/blockaid/SecurityDetailBottomSheet.tsx
@@ -15,6 +15,7 @@ import { SecurityWarning } from "services/blockaid/helper";
 
 export interface SecurityDetailBottomSheetProps {
   warnings: SecurityWarning[];
+  origin?: string;
   onCancel?: () => void;
   onProceedAnyway?: () => void;
   onClose: () => void;
@@ -36,6 +37,7 @@ export const SecurityDetailBottomSheet: React.FC<
   SecurityDetailBottomSheetProps
 > = ({
   warnings,
+  origin,
   onCancel,
   onProceedAnyway,
   onClose,
@@ -212,6 +214,11 @@ export const SecurityDetailBottomSheet: React.FC<
           return t("securityWarning.suspiciousRequest");
         })()}
       </Text>
+      {origin && (
+        <Text md primary>
+          {origin}
+        </Text>
+      )}
       <Text md secondary regular>
         {getDescription()}
       </Text>

--- a/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
+++ b/src/components/screens/DiscoveryScreen/components/WebViewContainer.tsx
@@ -6,10 +6,16 @@ import { useBrowserTabsStore } from "ducks/browserTabs";
 import { isDangerousScheme, isHomepageUrl } from "helpers/browser";
 import { captureTabScreenshot } from "helpers/screenshots";
 import useColors from "hooks/useColors";
+import { useWebviewBridge } from "hooks/useWebviewBridge";
 import React, { useRef, useCallback, useEffect, useState } from "react";
 import { View, Animated } from "react-native";
 import ViewShot from "react-native-view-shot";
-import { WebView, WebViewNavigation } from "react-native-webview";
+import {
+  WebView,
+  WebViewNavigation,
+  WebViewMessageEvent,
+} from "react-native-webview";
+import { bridgeBootstrap } from "services/webview/injection";
 
 interface WebViewContainerProps {
   webViewRef: React.RefObject<WebView | null>;
@@ -45,6 +51,7 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
     // Refs to track ViewShot components for each tab
     const viewShotRefs = useRef<{ [tabId: string]: ViewShot | null }>({});
     const webViewRefs = useRef<{ [tabId: string]: WebView | null }>({});
+    const bridge = useWebviewBridge(webViewRefs);
     const quickCaptureTimeouts = useRef<{ [tabId: string]: NodeJS.Timeout }>(
       {},
     );
@@ -100,6 +107,7 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
      * @param tabId - The tab ID to unregister
      */
     const handleWebViewUnmount = (tabId: string) => {
+      bridge.dispose(tabId);
       unregisterWebView(tabId);
     };
 
@@ -107,49 +115,53 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
      * Properly disposes of WebView instances to prevent memory leaks
      * @param tabIds - Array of tab IDs to dispose
      */
-    const disposeWebViews = useCallback((tabIds: string[]) => {
-      tabIds.forEach((tabId) => {
-        const webViewInstance = webViewRefs.current[tabId];
+    const disposeWebViews = useCallback(
+      (tabIds: string[]) => {
+        tabIds.forEach((tabId) => {
+          bridge.dispose(tabId);
+          const webViewInstance = webViewRefs.current[tabId];
 
-        if (webViewInstance) {
-          try {
-            // Stop loading and clear cache
-            webViewInstance.stopLoading?.();
-            webViewInstance.clearCache?.(true); // true = clear everything including cookies
-            webViewInstance.clearHistory?.();
-          } catch (error) {
-            // Disposal race - same family as the screenshot capture
-            // failures (the WebView may have already been unmounted).
-            // Not actionable for downstream errors.
-            logger.info(
-              "WebViewContainer",
-              `Failed to dispose WebView for tab ${tabId}`,
-              error,
-            );
+          if (webViewInstance) {
+            try {
+              // Stop loading and clear cache
+              webViewInstance.stopLoading?.();
+              webViewInstance.clearCache?.(true); // true = clear everything including cookies
+              webViewInstance.clearHistory?.();
+            } catch (error) {
+              // Disposal race - same family as the screenshot capture
+              // failures (the WebView may have already been unmounted).
+              // Not actionable for downstream errors.
+              logger.info(
+                "WebViewContainer",
+                `Failed to dispose WebView for tab ${tabId}`,
+                error,
+              );
+            }
           }
-        }
 
-        // Clear ViewShot ref
-        viewShotRefs.current[tabId] = null;
-        webViewRefs.current[tabId] = null;
+          // Clear ViewShot ref
+          viewShotRefs.current[tabId] = null;
+          webViewRefs.current[tabId] = null;
 
-        // Clear any pending timeouts
-        if (quickCaptureTimeouts.current[tabId]) {
-          clearTimeout(quickCaptureTimeouts.current[tabId]);
-          delete quickCaptureTimeouts.current[tabId];
-        }
-        if (finalCaptureTimeouts.current[tabId]) {
-          clearTimeout(finalCaptureTimeouts.current[tabId]);
-          delete finalCaptureTimeouts.current[tabId];
-        }
-        if (scrollCaptureTimeouts.current[tabId]) {
-          clearTimeout(scrollCaptureTimeouts.current[tabId]);
-          delete scrollCaptureTimeouts.current[tabId];
-        }
+          // Clear any pending timeouts
+          if (quickCaptureTimeouts.current[tabId]) {
+            clearTimeout(quickCaptureTimeouts.current[tabId]);
+            delete quickCaptureTimeouts.current[tabId];
+          }
+          if (finalCaptureTimeouts.current[tabId]) {
+            clearTimeout(finalCaptureTimeouts.current[tabId]);
+            delete finalCaptureTimeouts.current[tabId];
+          }
+          if (scrollCaptureTimeouts.current[tabId]) {
+            clearTimeout(scrollCaptureTimeouts.current[tabId]);
+            delete scrollCaptureTimeouts.current[tabId];
+          }
 
-        logger.info("WebViewContainer", `Disposed WebView for tab ${tabId}`);
-      });
-    }, []);
+          logger.info("WebViewContainer", `Disposed WebView for tab ${tabId}`);
+        });
+      },
+      [bridge],
+    );
 
     /**
      * Checks for and disposes excess WebViews when limit is exceeded
@@ -336,13 +348,30 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
                         javaScriptEnabled={javaScriptEnabled}
                         domStorageEnabled={domStorageEnabled}
                         startInLoadingState
-                        injectedJavaScriptBeforeContentLoaded={`
-                          window.stellar = {
-                            provider: 'freighter',
-                            platform: 'mobile',
-                            version: '${APP_VERSION}'
-                          };
-                        `}
+                        injectedJavaScriptBeforeContentLoaded={
+                          bridge.enabled
+                            ? bridgeBootstrap(APP_VERSION)
+                            : `window.stellar = {provider:'freighter',platform:'mobile',version:${JSON.stringify(APP_VERSION)}}; true;`
+                        }
+                        onMessage={
+                          bridge.enabled
+                            ? (event: WebViewMessageEvent) => {
+                                bridge
+                                  .receive(
+                                    tab.id,
+                                    event.nativeEvent.data,
+                                    event.nativeEvent.url,
+                                  )
+                                  .catch((error) =>
+                                    logger.warn(
+                                      "WebViewBridge",
+                                      "Message failed",
+                                      error,
+                                    ),
+                                  );
+                              }
+                            : undefined
+                        }
                         ref={(ref) => {
                           webViewRefs.current[tab.id] = ref;
                           if (isActive) {
@@ -357,18 +386,25 @@ const WebViewContainer: React.FC<WebViewContainerProps> = React.memo(
                           }
                         }}
                         source={{ uri: tab.url }}
-                        onLoadEnd={() => handleLoadEnd(tab.id)}
+                        onLoadEnd={(event) => {
+                          bridge.loaded(tab.id, event.nativeEvent.url);
+                          handleLoadEnd(tab.id);
+                        }}
                         onScroll={() => handleScroll(tab.id)}
                         allowsBackForwardNavigationGestures={isActive}
-                        onNavigationStateChange={
-                          isActive ? onNavigationStateChange : undefined
-                        }
+                        onNavigationStateChange={(state) => {
+                          if (state.loading) bridge.start(tab.id, state.url);
+                          if (isActive) onNavigationStateChange(state);
+                        }}
                         onShouldStartLoadWithRequest={
                           isActive
                             ? onShouldStartLoadWithRequest
                             : (req) => !isDangerousScheme(req.url)
                         }
-                        onLoadStart={() => handleWebViewMount(tab.id)}
+                        onLoadStart={(event) => {
+                          bridge.start(tab.id, event.nativeEvent.url);
+                          handleWebViewMount(tab.id);
+                        }}
                         onError={() => handleWebViewUnmount(tab.id)}
                       />
                     </ViewShot>

--- a/src/components/screens/WalletKit/DappRequestBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappRequestBottomSheetContent.tsx
@@ -4,17 +4,13 @@ import { DappSignAuthEntryBottomSheetContent } from "components/screens/WalletKi
 import { DappSignMessageBottomSheetContent } from "components/screens/WalletKit/DappSignMessageBottomSheetContent";
 import { DappSignTransactionBottomSheetContent } from "components/screens/WalletKit/DappSignTransactionBottomSheetContent";
 import { NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import {
-  StellarRpcMethods,
-  StellarSignAuthEntryParams,
-  StellarSignMessageParams,
-  WalletKitSessionRequest,
-} from "ducks/walletKit";
+import { StellarRpcMethods } from "ducks/walletKit";
 import React from "react";
 
 interface DappRequestBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   onCancelRequest: () => void;
@@ -40,16 +36,16 @@ const DappRequestBottomSheetContent: React.FC<
   const requestParams = requestEvent?.params?.request?.params;
 
   if (requestMethod === StellarRpcMethods.SIGN_MESSAGE) {
-    const message = (requestParams as StellarSignMessageParams)?.message;
-    if (message) {
+    const message = requestParams?.message;
+    if (typeof message === "string" && message) {
       return <DappSignMessageBottomSheetContent {...props} message={message} />;
     }
     return null;
   }
 
   if (requestMethod === StellarRpcMethods.SIGN_AUTH_ENTRY) {
-    const entryXdr = (requestParams as StellarSignAuthEntryParams)?.entryXdr;
-    if (entryXdr) {
+    const entryXdr = requestParams?.entryXdr;
+    if (typeof entryXdr === "string" && entryXdr) {
       return (
         <DappSignAuthEntryBottomSheetContent {...props} entryXdr={entryXdr} />
       );

--- a/src/components/screens/WalletKit/DappSignAuthEntryBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignAuthEntryBottomSheetContent.tsx
@@ -9,8 +9,8 @@ import { Button } from "components/sds/Button";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import useAppTranslation from "hooks/useAppTranslation";
 import { useClipboard } from "hooks/useClipboard";
 import useColors from "hooks/useColors";
@@ -18,7 +18,7 @@ import React, { useMemo } from "react";
 import { Dimensions, ScrollView, View } from "react-native";
 
 interface DappSignAuthEntryBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   entryXdr: string;

--- a/src/components/screens/WalletKit/DappSignMessageBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignMessageBottomSheetContent.tsx
@@ -8,8 +8,8 @@ import Avatar from "components/sds/Avatar";
 import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import useAppTranslation from "hooks/useAppTranslation";
 import useColors from "hooks/useColors";
 import React, { useMemo } from "react";
@@ -25,7 +25,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 const SHEET_CHROME_HEIGHT = 80;
 
 interface DappSignMessageBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   message: string;

--- a/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx
@@ -12,8 +12,8 @@ import Icon from "components/sds/Icon";
 import { Text } from "components/sds/Typography";
 import { AnalyticsEvent } from "config/analyticsConfig";
 import { NATIVE_TOKEN_CODE, NetworkDetails } from "config/constants";
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import { formatTokenForDisplay } from "helpers/formatAmount";
 import { useTransactionBalanceListItems } from "hooks/blockaid/useTransactionBalanceListItems";
 import useAppTranslation from "hooks/useAppTranslation";
@@ -22,7 +22,7 @@ import React, { useMemo } from "react";
 import { View } from "react-native";
 
 interface DappSignTransactionBottomSheetContentProps {
-  requestEvent: WalletKitSessionRequest | null;
+  requestEvent: DappRequest | null;
   account: ActiveAccount | null;
   networkDetails: NetworkDetails;
   onCancelRequest: () => void;

--- a/src/components/screens/WalletKit/useDappHeader.ts
+++ b/src/components/screens/WalletKit/useDappHeader.ts
@@ -1,8 +1,7 @@
+import type { DappRequest } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
 import { useProtocolsStore } from "ducks/protocols";
-import { WalletKitSessionRequest } from "ducks/walletKit";
 import { findMatchedProtocol, getDisplayHost } from "helpers/protocols";
-import { useDappMetadata } from "hooks/useDappMetadata";
 import { useMemo } from "react";
 
 /**
@@ -10,12 +9,12 @@ import { useMemo } from "react";
  * Returns null if required data is not yet available — callers should render null in that case.
  */
 export const useDappHeader = (
-  requestEvent: WalletKitSessionRequest | null,
+  requestEvent: DappRequest | null,
   account: ActiveAccount | null,
 ) => {
   const { protocols } = useProtocolsStore();
-  const dappMetadata = useDappMetadata(requestEvent);
-  const requestOrigin = requestEvent?.verifyContext?.verified?.origin;
+  const dappMetadata = requestEvent?.metadata;
+  const requestOrigin = requestEvent?.origin;
 
   const matchedProtocol = useMemo(
     () =>

--- a/src/components/screens/WalletKit/useDappHeader.ts
+++ b/src/components/screens/WalletKit/useDappHeader.ts
@@ -1,4 +1,4 @@
-import type { DappRequest } from "config/dappRequest";
+import { type DappRequest, DappTransport } from "config/dappRequest";
 import { ActiveAccount } from "ducks/auth";
 import { useProtocolsStore } from "ducks/protocols";
 import { findMatchedProtocol, getDisplayHost } from "helpers/protocols";
@@ -28,7 +28,10 @@ export const useDappHeader = (
   if (!dappMetadata || !account) return null;
 
   return {
-    dAppDomain: getDisplayHost(requestOrigin || dappMetadata.url || ""),
+    dAppDomain:
+      requestEvent?.transport === DappTransport.WEBVIEW
+        ? requestOrigin
+        : getDisplayHost(requestOrigin || dappMetadata.url || ""),
     dAppName: matchedProtocol?.name ?? dappMetadata.name,
     dAppFavicon: matchedProtocol?.iconUrl ?? dappMetadata.icons[0],
   };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -116,6 +116,8 @@ export const WEBVIEW_BRIDGE_MAX_SEEN_REQUESTS = 10_000;
 export const WEBVIEW_BRIDGE_MAX_READY_PER_DOCUMENT = 2;
 /** How long a dApp request may wait for the user's decision before it times out. */
 export const DAPP_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
+/** Network timeout for stellar.toml and SEP-10 challenge fetches during silent sign-in. */
+export const SEP10_FETCH_TIMEOUT_MS = 6_000;
 
 const SECOND_IN_MS = 1000;
 const MINUTE_IN_MS = 60 * SECOND_IN_MS;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -104,6 +104,19 @@ export const ACCOUNTS_TO_VERIFY_ON_EXISTING_MNEMONIC_PHRASE = 6;
 export const HASH_KEY_EXPIRATION_MS = 72 * 60 * 60 * 1000; // 72 hours
 export const VISUAL_DELAY_MS = 500;
 
+// In-app WebView dApp bridge (Discovery). Limits are enforced natively; the
+// injected bootstrap mirrors the envelope and deadline values.
+/** Upper bound on one JSON envelope from a page, checked before parsing. */
+export const WEBVIEW_BRIDGE_MAX_ENVELOPE_BYTES = 1024 * 1024;
+/** Request ids are page-chosen; cap their length before they enter the replay set. */
+export const WEBVIEW_BRIDGE_MAX_REQUEST_ID_LENGTH = 128;
+/** Replay-protection set size per document; past it the page must reload. */
+export const WEBVIEW_BRIDGE_MAX_SEEN_REQUESTS = 10_000;
+/** Readiness announcements accepted per document (document start + DOMContentLoaded). */
+export const WEBVIEW_BRIDGE_MAX_READY_PER_DOCUMENT = 2;
+/** How long a dApp request may wait for the user's decision before it times out. */
+export const DAPP_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
+
 const SECOND_IN_MS = 1000;
 const MINUTE_IN_MS = 60 * SECOND_IN_MS;
 const HOUR_IN_MS = 60 * MINUTE_IN_MS;

--- a/src/config/dappRequest.ts
+++ b/src/config/dappRequest.ts
@@ -1,0 +1,37 @@
+/** Where a dApp request arrived from; decides how the response travels back. */
+export enum DappTransport {
+  WALLET_CONNECT = "walletconnect",
+}
+
+/**
+ * Error codes attached to dApp rejections. WalletConnect keeps its numeric
+ * JSON-RPC code on the wire; these name the reason for callers and tests.
+ */
+export enum DappErrorCode {
+  INVALID_PARAMS = "INVALID_PARAMS",
+  UNSUPPORTED_METHOD = "UNSUPPORTED_METHOD",
+  WRONG_NETWORK = "WRONG_NETWORK",
+  USER_REJECTED = "USER_REJECTED",
+  CONTEXT_CHANGED = "CONTEXT_CHANGED",
+}
+
+/** A native-verified dApp request, independent of its response transport. */
+export interface DappRequest {
+  id: number | string;
+  params: {
+    chainId: string;
+    request: { method: string; params?: Record<string, unknown> };
+  };
+  /** Origin the wallet verified natively; never taken from the request payload. */
+  origin: string;
+  metadata: { name: string; description: string; url: string; icons: string[] };
+  transport: DappTransport;
+  /** False once navigation, tab, lock or account/network changes made the request stale. */
+  isValid: () => boolean;
+  respond: (response: {
+    id: number | string;
+    jsonrpc: string;
+    result?: unknown;
+    error?: { code: DappErrorCode | number; message: string };
+  }) => Promise<void>;
+}

--- a/src/config/dappRequest.ts
+++ b/src/config/dappRequest.ts
@@ -1,18 +1,53 @@
 /** Where a dApp request arrived from; decides how the response travels back. */
 export enum DappTransport {
   WALLET_CONNECT = "walletconnect",
+  WEBVIEW = "webview",
+}
+
+/** What a native approval sheet is asking the user to approve. */
+export enum DappApprovalKind {
+  /** Blockaid site verdict before a document gets the account. */
+  SITE = "site",
+  /** A signing request (transaction, message or auth entry). */
+  SIGN = "sign",
 }
 
 /**
- * Error codes attached to dApp rejections. WalletConnect keeps its numeric
- * JSON-RPC code on the wire; these name the reason for callers and tests.
+ * Error codes returned to dApps. WalletConnect keeps its numeric JSON-RPC
+ * code; the WebView bridge delivers these strings verbatim and the dApp SDK
+ * exposes the same set.
  */
 export enum DappErrorCode {
+  UNAVAILABLE = "UNAVAILABLE",
   INVALID_PARAMS = "INVALID_PARAMS",
   UNSUPPORTED_METHOD = "UNSUPPORTED_METHOD",
+  UNSUPPORTED_VERSION = "UNSUPPORTED_VERSION",
+  WALLET_LOCKED = "WALLET_LOCKED",
   WRONG_NETWORK = "WRONG_NETWORK",
   USER_REJECTED = "USER_REJECTED",
+  BUSY = "BUSY",
   CONTEXT_CHANGED = "CONTEXT_CHANGED",
+  NOT_CONNECTED = "NOT_CONNECTED",
+  TIMEOUT = "TIMEOUT",
+}
+
+/** Methods the in-app WebView bridge accepts; the `stellar_*` ones map onto StellarRpcMethods. */
+export enum WebviewBridgeMethod {
+  GET_CAPABILITIES = "freighter_getCapabilities",
+  CONNECT = "freighter_connect",
+  GET_ACCOUNT = "freighter_getAccount",
+  DISCONNECT = "freighter_disconnect",
+  SIGN_XDR = "stellar_signXDR",
+  SIGN_AND_SUBMIT_XDR = "stellar_signAndSubmitXDR",
+  SIGN_MESSAGE = "stellar_signMessage",
+  SIGN_AUTH_ENTRY = "stellar_signAuthEntry",
+}
+
+/** Events the bridge pushes to a connected document. */
+export enum WebviewBridgeEvent {
+  ACCOUNTS_CHANGED = "accountsChanged",
+  CHAIN_CHANGED = "chainChanged",
+  DISCONNECT = "disconnect",
 }
 
 /** A native-verified dApp request, independent of its response transport. */

--- a/src/ducks/dappApproval.ts
+++ b/src/ducks/dappApproval.ts
@@ -1,0 +1,34 @@
+import type { DappApprovalKind, DappRequest } from "config/dappRequest";
+import { create } from "zustand";
+
+/** A WebView request waiting for the user's decision in WalletKitProvider. */
+export interface WebviewApproval {
+  kind: DappApprovalKind;
+  request: DappRequest;
+}
+
+interface DappApprovalState {
+  // State
+  /** The WebView request currently owning the approval sheets, if any. */
+  job: WebviewApproval | null;
+  /** True while WalletConnect owns the approval sheets; WebView requests get BUSY meanwhile. */
+  walletConnectBusy: boolean;
+
+  // Actions
+  setJob: (job: WebviewApproval | null) => void;
+  /** Clears the job only if it still belongs to `request`, so a late response cannot evict a newer job. */
+  clearJob: (request: DappRequest) => void;
+  setWalletConnectBusy: (busy: boolean) => void;
+}
+
+/** One native approval surface, shared by the WalletConnect and WebView transports. */
+export const useDappApprovalStore = create<DappApprovalState>((set, get) => ({
+  job: null,
+  walletConnectBusy: false,
+
+  setJob: (job) => set({ job }),
+  clearJob: (request) => {
+    if (get().job?.request === request) set({ job: null });
+  },
+  setWalletConnectBusy: (walletConnectBusy) => set({ walletConnectBusy }),
+}));

--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -17,6 +17,7 @@ const BOOLEAN_FLAGS = [
   "swap_enabled",
   "discover_enabled",
   "webview_provider_enabled",
+  "webview_auto_signin_enabled",
   "onramp_enabled",
   "use_token_prices_v2",
   "use_balances_v2",
@@ -72,6 +73,7 @@ const INITIAL_REMOTE_CONFIG_STATE =
         swap_enabled: true,
         discover_enabled: true,
         webview_provider_enabled: true,
+        webview_auto_signin_enabled: true,
         onramp_enabled: true,
         use_token_prices_v2: true,
         // Defaults to v1 until the wallet-backend indexer is deployed for
@@ -98,6 +100,7 @@ const INITIAL_REMOTE_CONFIG_STATE =
         swap_enabled: isAndroid,
         discover_enabled: isAndroid,
         webview_provider_enabled: false,
+        webview_auto_signin_enabled: false,
         onramp_enabled: isAndroid,
         use_token_prices_v2: true,
         // Defaults to v1 until the wallet-backend indexer is deployed for

--- a/src/ducks/remoteConfig.ts
+++ b/src/ducks/remoteConfig.ts
@@ -16,6 +16,7 @@ const ON_VARIANT_VALUES = ["on", "true", "enabled", "yes"];
 const BOOLEAN_FLAGS = [
   "swap_enabled",
   "discover_enabled",
+  "webview_provider_enabled",
   "onramp_enabled",
   "use_token_prices_v2",
   "use_balances_v2",
@@ -70,6 +71,7 @@ const INITIAL_REMOTE_CONFIG_STATE =
     ? {
         swap_enabled: true,
         discover_enabled: true,
+        webview_provider_enabled: true,
         onramp_enabled: true,
         use_token_prices_v2: true,
         // Defaults to v1 until the wallet-backend indexer is deployed for
@@ -95,6 +97,7 @@ const INITIAL_REMOTE_CONFIG_STATE =
     : {
         swap_enabled: isAndroid,
         discover_enabled: isAndroid,
+        webview_provider_enabled: false,
         onramp_enabled: isAndroid,
         use_token_prices_v2: true,
         // Defaults to v1 until the wallet-backend indexer is deployed for

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -475,7 +475,9 @@ export const executeDappRequest = async ({
 
       showToast({
         title: t("walletKit.signMessageSuccessfull"),
-        message: t("walletKit.returnToBrowser"),
+        ...(sessionRequest.transport === DappTransport.WALLET_CONNECT
+          ? { message: t("walletKit.returnToBrowser") }
+          : {}),
         variant: "success",
       });
     } catch (err) {
@@ -559,7 +561,9 @@ export const executeDappRequest = async ({
 
       showToast({
         title: t("walletKit.signAuthEntrySuccessfull"),
-        message: t("walletKit.returnToBrowser"),
+        ...(sessionRequest.transport === DappTransport.WALLET_CONNECT
+          ? { message: t("walletKit.returnToBrowser") }
+          : {}),
         variant: "success",
       });
     } catch (err) {
@@ -675,7 +679,9 @@ export const executeDappRequest = async ({
 
       showToast({
         title: t("walletKit.signAndSubmitSuccessfull"),
-        message: t("walletKit.returnToBrowser"),
+        ...(sessionRequest.transport === DappTransport.WALLET_CONNECT
+          ? { message: t("walletKit.returnToBrowser") }
+          : {}),
         variant: "success",
       });
     } catch (error) {
@@ -705,7 +711,9 @@ export const executeDappRequest = async ({
 
       showToast({
         title: t("walletKit.signSuccessfull"),
-        message: t("walletKit.returnToBrowser"),
+        ...(sessionRequest.transport === DappTransport.WALLET_CONNECT
+          ? { message: t("walletKit.returnToBrowser") }
+          : {}),
         variant: "success",
       });
     } catch (error) {

--- a/src/helpers/walletKitUtil.ts
+++ b/src/helpers/walletKitUtil.ts
@@ -11,8 +11,15 @@ import {
   getSdkError,
   SdkErrorKey,
 } from "@walletconnect/utils";
-import { NETWORK_NAMES, NETWORKS } from "config/constants";
+import {
+  NETWORK_NAMES,
+  NETWORKS,
+  mapNetworkToNetworkDetails,
+} from "config/constants";
+import { DappErrorCode, DappRequest, DappTransport } from "config/dappRequest";
 import { logger } from "config/logger";
+import { AUTH_STATUS } from "config/types";
+import { useAuthenticationStore } from "ducks/auth";
 import {
   ActiveSessions,
   StellarRpcChains,
@@ -53,10 +60,10 @@ const stellarNamespaceEvents = [StellarRpcEvents.ACCOUNTS_CHANGED];
  *
  * A rejection is emitted ONLY for a genuine user dismissal of a still-pending
  * request:
- * - `hasResponded` (approveSessionRequest already sent a WC response) => the
+ * - `hasResponded` (executeDappRequest already sent a response) => the
  *   request was approved/completed, never a rejection.
  * - `approvalInFlight` (the user hit Approve — success OR an unexpected throw in
- *   approveSessionRequest) => an approval attempt, not a dismissal; the throw
+ *   executeDappRequest) => an approval attempt, not a dismissal; the throw
  *   still triggers a WC-level fallback rejection but must not be counted as a
  *   user reject in analytics.
  * - no active `requestEvent` => nothing to reject.
@@ -256,9 +263,45 @@ export const rejectSessionRequest = async ({
 };
 
 /**
- * Approves and processes a session request from a dApp
+ * Rejects a dApp request on whichever transport it arrived on. Fire-and-forget:
+ * a delivery failure is logged, never thrown, so rejection paths cannot
+ * themselves fail.
  * @param {Object} params - The parameters object
- * @param {WalletKitSessionRequest} params.sessionRequest - The session request to approve
+ * @param {DappRequest} params.sessionRequest - The request to reject
+ * @param {string} params.message - Human-readable reason sent to the dApp
+ * @param {DappErrorCode} [params.code] - Error code; defaults to USER_REJECTED
+ */
+export const rejectDappRequest = ({
+  sessionRequest,
+  message,
+  code = DappErrorCode.USER_REJECTED,
+}: {
+  sessionRequest: DappRequest;
+  message: string;
+  code?: DappErrorCode;
+}): void => {
+  sessionRequest
+    .respond({
+      id: sessionRequest.id,
+      jsonrpc: "2.0",
+      error: { code, message },
+    })
+    .catch((error) => {
+      logger.warn(
+        "walletKitUtil.rejectDappRequest",
+        "Rejection could not be delivered",
+        error,
+      );
+    });
+};
+
+/**
+ * Validates, signs and (for sign-and-submit) submits a dApp request, then
+ * responds on the request's own transport. Shared by WalletConnect and the
+ * in-app WebView bridge; re-checks `sessionRequest.isValid()` right before
+ * signing so a stale request never reaches the signer.
+ * @param {Object} params - The parameters object
+ * @param {DappRequest} params.sessionRequest - The native-verified request to execute
  * @param {Function} params.signTransaction - Function to sign the transaction
  * @param {string} params.networkPassphrase - The network passphrase
  * @param {string} params.activeChain - The active chain identifier
@@ -266,7 +309,7 @@ export const rejectSessionRequest = async ({
  * @param {TFunction} params.t - Translation function
  * @returns {Promise<void>} A promise that resolves when the approval is complete
  */
-export const approveSessionRequest = async ({
+export const executeDappRequest = async ({
   sessionRequest,
   signTransaction,
   signMessage,
@@ -277,7 +320,7 @@ export const approveSessionRequest = async ({
   showToast,
   t,
 }: {
-  sessionRequest: WalletKitSessionRequest;
+  sessionRequest: DappRequest;
   signTransaction: (
     transaction: Transaction | FeeBumpTransaction,
   ) => string | null;
@@ -291,12 +334,31 @@ export const approveSessionRequest = async ({
   showToast: (options: ToastOptions) => void;
   t: TFunction<"translations", undefined>;
 }) => {
-  const { id, params, topic } = sessionRequest;
+  const { id, params } = sessionRequest;
   const { request, chainId } = params || {};
   const { params: requestParams, method: requestMethod } = request || {};
   const { xdr } = requestParams || {};
 
   const rpcMethod = requestMethod as StellarRpcMethods;
+
+  const ensureValid = () => {
+    if (sessionRequest.isValid()) return true;
+    rejectDappRequest({
+      sessionRequest,
+      message: "Wallet context changed",
+      code: DappErrorCode.CONTEXT_CHANGED,
+    });
+    return false;
+  };
+  if (!ensureValid()) return;
+  if (!stellarNamespaceMethods.includes(rpcMethod)) {
+    rejectDappRequest({
+      sessionRequest,
+      message: t("walletKit.errorUnsupportedMethod", { method: requestMethod }),
+      code: DappErrorCode.UNSUPPORTED_METHOD,
+    });
+    return;
+  }
 
   const supportedChains = [StellarRpcChains.PUBLIC, StellarRpcChains.TESTNET];
 
@@ -310,7 +372,11 @@ export const approveSessionRequest = async ({
       message,
       variant: "error",
     });
-    rejectSessionRequest({ sessionRequest, message });
+    rejectDappRequest({
+      sessionRequest,
+      message,
+      code: DappErrorCode.WRONG_NETWORK,
+    });
     return;
   }
 
@@ -329,7 +395,11 @@ export const approveSessionRequest = async ({
       message,
       variant: "error",
     });
-    rejectSessionRequest({ sessionRequest, message });
+    rejectDappRequest({
+      sessionRequest,
+      message,
+      code: DappErrorCode.WRONG_NETWORK,
+    });
     return;
   }
 
@@ -345,7 +415,11 @@ export const approveSessionRequest = async ({
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({
+        sessionRequest,
+        message: errorMessage,
+        code: DappErrorCode.INVALID_PARAMS,
+      });
       return;
     }
 
@@ -357,35 +431,33 @@ export const approveSessionRequest = async ({
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({
+        sessionRequest,
+        message: errorMessage,
+        code: DappErrorCode.INVALID_PARAMS,
+      });
       return;
     }
 
+    if (!sessionRequest.isValid()) {
+      ensureValid();
+      return;
+    }
     const signedMessage = signMessage(contentResult.value);
 
     if (!signedMessage) {
       const errorMessage = "Failed to sign message";
-      logger.error(
-        "approveSessionRequest",
-        errorMessage,
-        new Error(errorMessage),
-      );
+      logger.error("executeDappRequest", errorMessage, new Error(errorMessage));
       showToast({
         title: t("walletKit.errorSigningMessage"),
         message: t("walletKit.pleaseTryAgainLater"),
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({ sessionRequest, message: errorMessage });
       return;
     }
 
-    // Get dapp metadata for analytics
-    const { activeSessions } = useWalletKitStore.getState();
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
-    );
-    const dappDomain = dappMetadata?.url;
+    const dappDomain = sessionRequest.origin;
 
     analytics.trackSignedMessage({
       messageLength: contentResult.value.length,
@@ -399,7 +471,7 @@ export const approveSessionRequest = async ({
     };
 
     try {
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signMessageSuccessfull"),
@@ -418,7 +490,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message: errorMsg });
+      rejectDappRequest({ sessionRequest, message: errorMsg });
     }
 
     return;
@@ -443,36 +515,34 @@ export const approveSessionRequest = async ({
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({
+        sessionRequest,
+        message: errorMessage,
+        code: DappErrorCode.INVALID_PARAMS,
+      });
       return;
     }
 
     // signAuthEntry catches internally — null return signals failure
+    if (!sessionRequest.isValid()) {
+      ensureValid();
+      return;
+    }
     const result = signAuthEntry(entryXdr as string);
 
     if (!result) {
       const errorMessage = t("walletKit.failedToProcessAuthEntry");
-      logger.error(
-        "approveSessionRequest",
-        errorMessage,
-        new Error(errorMessage),
-      );
+      logger.error("executeDappRequest", errorMessage, new Error(errorMessage));
       showToast({
         title: t("walletKit.errorSigningAuthEntry"),
         message: errorMessage,
         variant: "error",
       });
-      rejectSessionRequest({ sessionRequest, message: errorMessage });
+      rejectDappRequest({ sessionRequest, message: errorMessage });
       return;
     }
 
-    // Get dapp metadata for analytics
-    const { activeSessions } = useWalletKitStore.getState();
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
-    );
-    const dappDomain = dappMetadata?.url;
+    const dappDomain = sessionRequest.origin;
 
     analytics.trackSignedAuthEntry({
       ...(dappDomain ? { dappDomain } : {}),
@@ -485,7 +555,7 @@ export const approveSessionRequest = async ({
     };
 
     try {
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signAuthEntrySuccessfull"),
@@ -504,7 +574,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t("walletKit.failedToProcessAuthEntry"),
       });
@@ -521,34 +591,28 @@ export const approveSessionRequest = async ({
     transaction = TransactionBuilder.fromXdr(xdr as string, networkPassphrase);
 
     // Always sign the transaction for both supported RPC methods
+    if (!sessionRequest.isValid()) {
+      ensureValid();
+      return;
+    }
     signedTransaction = signTransaction(transaction);
 
     if (!signedTransaction) {
       const errorMessage = "Failed to sign transaction";
-      logger.error(
-        "approveSessionRequest",
-        errorMessage,
-        new Error(errorMessage),
-      );
+      logger.error("executeDappRequest", errorMessage, new Error(errorMessage));
       showToast({
         title: t("walletKit.errorSigning"),
         message: t("walletKit.pleaseTryAgainLater"),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t("common.error", { errorMessage }),
       });
       return;
     }
 
-    // Get dapp metadata for analytics
-    const { activeSessions } = useWalletKitStore.getState();
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
-    );
-    dappDomain = dappMetadata?.url;
+    dappDomain = sessionRequest.origin;
 
     analytics.trackSignedTransaction({
       ...(dappDomain ? { dappDomain } : {}),
@@ -563,7 +627,7 @@ export const approveSessionRequest = async ({
       message,
       variant: "error",
     });
-    rejectSessionRequest({ sessionRequest, message });
+    rejectDappRequest({ sessionRequest, message });
     return;
   }
 
@@ -571,6 +635,10 @@ export const approveSessionRequest = async ({
   if (rpcMethod === StellarRpcMethods.SIGN_AND_SUBMIT_XDR) {
     // For stellar_signAndSubmitXDR: sign AND submit, then return success status
     try {
+      if (!sessionRequest.isValid()) {
+        ensureValid();
+        return;
+      }
       await submitTx({
         network: targetNetwork,
         tx: signedTransaction,
@@ -591,7 +659,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message });
+      rejectDappRequest({ sessionRequest, message });
 
       return;
     }
@@ -603,7 +671,7 @@ export const approveSessionRequest = async ({
         jsonrpc: "2.0",
       };
 
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signAndSubmitSuccessfull"),
@@ -622,7 +690,7 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message });
+      rejectDappRequest({ sessionRequest, message });
     }
   } else if (rpcMethod === StellarRpcMethods.SIGN_XDR) {
     // For stellar_signXDR: sign only, then return the signed transaction
@@ -633,7 +701,7 @@ export const approveSessionRequest = async ({
     };
 
     try {
-      await walletKit.respondSessionRequest({ topic, response });
+      await sessionRequest.respond(response);
 
       showToast({
         title: t("walletKit.signSuccessfull"),
@@ -652,21 +720,55 @@ export const approveSessionRequest = async ({
         variant: "error",
       });
 
-      rejectSessionRequest({ sessionRequest, message });
+      rejectDappRequest({ sessionRequest, message });
     }
-  } else {
-    // Unknown RPC method
-    const message = t("walletKit.errorUnsupportedMethod", {
-      method: rpcMethod || "unknown",
-    });
-    logger.error("approveSessionRequest", message, new Error(message));
-    showToast({
-      title: t("walletKit.errorUnsupportedMethodTitle"),
-      message,
-      variant: "error",
-    });
-    rejectSessionRequest({ sessionRequest, message });
   }
+};
+
+/** WalletConnect keeps its session transport and numeric rejection code. */
+export const toDappRequest = (
+  sessionRequest: WalletKitSessionRequest,
+  publicKey: string,
+  networkPassphrase: string,
+): DappRequest => {
+  const metadata = getDappMetadataFromEvent(
+    sessionRequest,
+    useWalletKitStore.getState().activeSessions,
+  ) || { name: "", description: "", url: "", icons: [] };
+  return {
+    id: sessionRequest.id,
+    params: sessionRequest.params,
+    origin: sessionRequest.verifyContext?.verified?.origin || metadata.url,
+    metadata,
+    transport: DappTransport.WALLET_CONNECT,
+    isValid: () => {
+      const state = useAuthenticationStore.getState();
+      return (
+        state.authStatus === AUTH_STATUS.AUTHENTICATED &&
+        !state.isSoftLocked &&
+        state.account?.publicKey === publicKey &&
+        (mapNetworkToNetworkDetails(state.network)
+          .networkPassphrase as string) === networkPassphrase
+      );
+    },
+    respond: async (response) => {
+      if (response.error) {
+        await rejectSessionRequest({
+          sessionRequest,
+          message: response.error.message,
+        });
+      } else {
+        await walletKit.respondSessionRequest({
+          topic: sessionRequest.topic,
+          response: {
+            id: sessionRequest.id,
+            jsonrpc: "2.0",
+            result: response.result,
+          },
+        });
+      }
+    },
+  };
 };
 
 /**

--- a/src/helpers/walletKitValidation.ts
+++ b/src/helpers/walletKitValidation.ts
@@ -25,6 +25,13 @@ export const ValidationErrorKeys = {
  */
 export const SIGN_MESSAGE_MAX_BYTES = 10240;
 
+/**
+ * Max UTF-8 byte length for sign_message content arriving over the in-app
+ * WebView bridge. Tighter than WalletConnect because the bridge is reachable
+ * by any page the user browses to.
+ */
+export const WEBVIEW_SIGN_MESSAGE_MAX_BYTES = 1024;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -62,6 +69,22 @@ export function validateSignMessageLength(
     return { valid: false, errorKey: ValidationErrorKeys.MESSAGE_TOO_LONG };
   }
   return { valid: true, value: message };
+}
+
+/**
+ * Validates a WebView sign_message payload: non-empty string within
+ * WEBVIEW_SIGN_MESSAGE_MAX_BYTES (UTF-8 bytes).
+ */
+export function validateWebviewSignMessage(
+  message: unknown,
+): ValidationResult<string> {
+  const content = validateSignMessageContent(message);
+  if (!content.valid) return content;
+  const messageByteLength = new TextEncoder().encode(content.value).length;
+  if (messageByteLength > WEBVIEW_SIGN_MESSAGE_MAX_BYTES) {
+    return { valid: false, errorKey: ValidationErrorKeys.MESSAGE_TOO_LONG };
+  }
+  return content;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/hooks/useWebviewBridge.ts
+++ b/src/hooks/useWebviewBridge.ts
@@ -16,12 +16,15 @@ import { useBrowserTabsStore } from "ducks/browserTabs";
 import { useDappApprovalStore } from "ducks/dappApproval";
 import { useRemoteConfigStore } from "ducks/remoteConfig";
 import { isDev } from "helpers/isEnv";
-import { isWalletUnlocked } from "hooks/useGetActiveAccount";
+import useGetActiveAccount, {
+  isWalletUnlocked,
+} from "hooks/useGetActiveAccount";
 import { useEffect, useRef, useCallback, useMemo } from "react";
 import { AppState } from "react-native";
 import { randomBytes } from "react-native-quick-crypto";
 import type { WebView } from "react-native-webview";
 import { WebviewBridge } from "services/webview/bridge";
+import { prepareSep10Auth } from "services/webview/sep10";
 
 /**
  * Hands a WebView request to WalletKitProvider through the shared approval
@@ -98,6 +101,9 @@ export const useWebviewBridge = (
   const enabled = useRemoteConfigStore(
     (state) => state.webview_provider_enabled,
   );
+  const { signTransaction } = useGetActiveAccount();
+  const signTransactionRef = useRef(signTransaction);
+  signTransactionRef.current = signTransaction;
   const focused = useIsFocused();
   const focusedRef = useRef(focused);
   focusedRef.current = focused;
@@ -116,6 +122,15 @@ export const useWebviewBridge = (
           inject: (script) => refs.current[tabId]?.injectJavaScript(script),
           approve,
           onInvalidated: cancelInvalidApproval,
+          prepareAuth: (origin, account) =>
+            useRemoteConfigStore.getState().webview_auto_signin_enabled
+              ? prepareSep10Auth({
+                  origin,
+                  account,
+                  development: isDev,
+                  signTransaction: (tx) => signTransactionRef.current(tx),
+                })
+              : Promise.resolve(null),
           context: () => {
             const browser = useBrowserTabsStore.getState();
             const auth = useAuthenticationStore.getState();

--- a/src/hooks/useWebviewBridge.ts
+++ b/src/hooks/useWebviewBridge.ts
@@ -1,0 +1,225 @@
+import { useIsFocused } from "@react-navigation/native";
+import {
+  APP_VERSION,
+  DAPP_APPROVAL_TIMEOUT_MS,
+  mapNetworkToNetworkDetails,
+  NETWORKS,
+} from "config/constants";
+import {
+  DappApprovalKind,
+  DappErrorCode,
+  type DappRequest,
+} from "config/dappRequest";
+import { logger } from "config/logger";
+import { useAuthenticationStore } from "ducks/auth";
+import { useBrowserTabsStore } from "ducks/browserTabs";
+import { useDappApprovalStore } from "ducks/dappApproval";
+import { useRemoteConfigStore } from "ducks/remoteConfig";
+import { isDev } from "helpers/isEnv";
+import { isWalletUnlocked } from "hooks/useGetActiveAccount";
+import { useEffect, useRef, useCallback, useMemo } from "react";
+import { AppState } from "react-native";
+import { randomBytes } from "react-native-quick-crypto";
+import type { WebView } from "react-native-webview";
+import { WebviewBridge } from "services/webview/bridge";
+
+/**
+ * Hands a WebView request to WalletKitProvider through the shared approval
+ * store and resolves with the user's decision. Rejects with BUSY while
+ * another approval (either transport) owns the sheets, and with TIMEOUT once
+ * DAPP_APPROVAL_TIMEOUT_MS elapses.
+ */
+const approve = (
+  kind: DappApprovalKind,
+  request: DappRequest,
+): Promise<unknown> =>
+  new Promise((resolve, reject) => {
+    const state = useDappApprovalStore.getState();
+    if (state.job || state.walletConnectBusy) {
+      reject(
+        Object.assign(new Error("Another wallet approval is in progress"), {
+          code: DappErrorCode.BUSY,
+        }),
+      );
+      return;
+    }
+    let timeout: ReturnType<typeof setTimeout>;
+    const jobRequest: DappRequest = {
+      ...request,
+      respond: async (response) => {
+        clearTimeout(timeout);
+        state.clearJob(jobRequest);
+        if (kind === DappApprovalKind.SIGN) await request.respond(response);
+        if (response.error) reject(response.error);
+        else resolve(response.result);
+      },
+    };
+    timeout = setTimeout(() => {
+      state.clearJob(jobRequest);
+      reject(
+        Object.assign(
+          new Error("Request timed out; submission outcome may be unknown"),
+          { code: DappErrorCode.TIMEOUT },
+        ),
+      );
+    }, DAPP_APPROVAL_TIMEOUT_MS);
+    state.setJob({ kind, request: jobRequest });
+    state.setWalletConnectBusy(kind === DappApprovalKind.SIGN);
+  });
+
+/** Rejects the queued approval when its request went stale before the user decided. */
+const cancelInvalidApproval = () => {
+  const { job } = useDappApprovalStore.getState();
+  if (job && !job.request.isValid()) {
+    job.request
+      .respond({
+        id: job.request.id,
+        jsonrpc: "2.0",
+        error: {
+          code: DappErrorCode.CONTEXT_CHANGED,
+          message: "Wallet context changed",
+        },
+      })
+      .catch((error) =>
+        logger.warn("WebViewBridge", "Approval cancellation failed", error),
+      );
+  }
+};
+
+/**
+ * One WebviewBridge per mounted Discovery tab. Browser lifecycle (navigation,
+ * focus, tab switches, disposal) owns transport lifetime; WalletKitProvider
+ * owns approval and signing. Everything is gated by the
+ * `webview_provider_enabled` remote-config flag.
+ */
+export const useWebviewBridge = (
+  refs: React.MutableRefObject<Record<string, WebView | null>>,
+) => {
+  const enabled = useRemoteConfigStore(
+    (state) => state.webview_provider_enabled,
+  );
+  const focused = useIsFocused();
+  const focusedRef = useRef(focused);
+  focusedRef.current = focused;
+  const bridges = useRef(new Map<string, WebviewBridge>());
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  const get = useCallback(
+    (tabId: string) => {
+      let bridge = bridges.current.get(tabId);
+      if (!bridge) {
+        bridge = new WebviewBridge({
+          version: APP_VERSION,
+          development: isDev,
+          token: () => randomBytes(24).toString("hex"),
+          inject: (script) => refs.current[tabId]?.injectJavaScript(script),
+          approve,
+          onInvalidated: cancelInvalidApproval,
+          context: () => {
+            const browser = useBrowserTabsStore.getState();
+            const auth = useAuthenticationStore.getState();
+            // "inactive" is transient on iOS (Face ID for the signing confirmation, the
+            // notification shade, an incoming call banner); only "background" means
+            // the user left. Treating inactive as lost context cancelled in-flight
+            // signatures right as the wallet approved them (CONTEXT_CHANGED).
+            const active =
+              enabledRef.current &&
+              focusedRef.current &&
+              AppState.currentState !== "background" &&
+              browser.activeTabId === tabId &&
+              !browser.showTabOverview;
+            const supported =
+              auth.network === NETWORKS.PUBLIC ||
+              auth.network === NETWORKS.TESTNET;
+            return {
+              active,
+              account:
+                isWalletUnlocked() && supported && auth.account
+                  ? {
+                      address: auth.account.publicKey,
+                      chainId:
+                        auth.network === NETWORKS.PUBLIC
+                          ? "stellar:pubnet"
+                          : "stellar:testnet",
+                      networkPassphrase: mapNetworkToNetworkDetails(
+                        auth.network,
+                      ).networkPassphrase,
+                    }
+                  : null,
+            };
+          },
+        });
+        bridges.current.set(tabId, bridge);
+      }
+      return bridge;
+    },
+    [refs],
+  );
+
+  useEffect(() => {
+    const update = () => {
+      const ids = new Set(
+        useBrowserTabsStore.getState().tabs.map((tab) => tab.id),
+      );
+      bridges.current.forEach((bridge, id) => {
+        if (!ids.has(id)) {
+          bridge.navigationStarted();
+          bridges.current.delete(id);
+        } else bridge.contextChanged();
+      });
+      cancelInvalidApproval();
+    };
+    const authUnsubscribe = useAuthenticationStore.subscribe(update);
+    const browserUnsubscribe = useBrowserTabsStore.subscribe(update);
+    const appSubscription = AppState.addEventListener("change", update);
+    update();
+    return () => {
+      authUnsubscribe();
+      browserUnsubscribe();
+      appSubscription.remove();
+    };
+  }, [focused, enabled]);
+
+  // Tabs restored at app start load before remote config resolves, so their
+  // documents only got the beacon injection. Once the flag turns on, activate
+  // the bridge on every mounted tab instead of waiting for its next navigation
+  // (activateBridge carries the idempotent bootstrap, so a late inject is safe).
+  useEffect(() => {
+    if (!enabled) return;
+    useBrowserTabsStore.getState().tabs.forEach((tab) => {
+      const bridge = bridges.current.get(tab.id);
+      if (bridge) bridge.loaded(tab.url);
+    });
+  }, [enabled]);
+
+  useEffect(
+    () => () => {
+      bridges.current.forEach((bridge) => bridge.navigationStarted());
+      bridges.current.clear();
+      cancelInvalidApproval();
+    },
+    [],
+  );
+
+  return useMemo(
+    () => ({
+      enabled,
+      start: (id: string, url: string) => {
+        get(id).navigationStarted(url);
+        cancelInvalidApproval();
+      },
+      loaded: (id: string, url: string) => {
+        if (enabled) get(id).loaded(url);
+      },
+      receive: (id: string, data: string, origin: string) =>
+        get(id).receive(data, origin),
+      dispose: (id: string) => {
+        bridges.current.get(id)?.navigationStarted();
+        bridges.current.delete(id);
+        cancelInvalidApproval();
+      },
+    }),
+    [enabled, get],
+  );
+};

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1,6 +1,6 @@
 import Blockaid from "@blockaid/client";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
-import { xdr as stellarXdr } from "@stellar/stellar-sdk";
+import { TransactionBuilder, xdr as stellarXdr } from "@stellar/stellar-sdk";
 import AddMemoExplanationBottomSheet from "components/AddMemoExplanationBottomSheet";
 import BottomSheet from "components/BottomSheet";
 import InformationBottomSheet from "components/InformationBottomSheet";
@@ -11,6 +11,7 @@ import DappRequestBottomSheetContent from "components/screens/WalletKit/DappRequ
 import Icon from "components/sds/Icon";
 import { AnalyticsEvent } from "config/analyticsConfig";
 import { mapNetworkToNetworkDetails, NETWORKS } from "config/constants";
+import { DappErrorCode, type DappRequest } from "config/dappRequest";
 import { logger } from "config/logger";
 import { AUTH_STATUS } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
@@ -23,13 +24,14 @@ import {
   WalletKitSessionRequest,
   StellarRpcChains,
   StellarRpcMethods,
-  StellarSignXDRParams,
 } from "ducks/walletKit";
 import { isE2ETest } from "helpers/isEnv";
 import { getHostname } from "helpers/protocols";
 import {
   approveSessionProposal,
-  approveSessionRequest,
+  executeDappRequest,
+  rejectDappRequest,
+  toDappRequest,
   rejectSessionRequest,
   rejectSessionProposal,
   resolveDappRejectionEvent,
@@ -125,8 +127,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const [isSigning, setIsSigning] = useState(false);
   const [proposalEvent, setProposalEvent] =
     useState<WalletKitSessionProposal | null>(null);
-  const [requestEvent, setRequestEvent] =
-    useState<WalletKitSessionRequest | null>(null);
+  const [requestEvent, setRequestEvent] = useState<DappRequest | null>(null);
   const [siteScanResult, setSiteScanResult] = useState<
     Blockaid.SiteScanResponse | undefined
   >(undefined);
@@ -136,13 +137,22 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
   // Request queue to prevent concurrent request handling race conditions
   const isProcessingRequestRef = useRef(false);
+  const activeProposalRef = useRef<number | null>(null);
+  const activeRequestRef = useRef<DappRequest | null>(null);
+  const isClearingRequestRef = useRef(false);
+  const securityWarningDecisionRef = useRef(false);
+  /** Releases the active request slot after a rejection so the next queued request can proceed. */
+  const resetActiveRequest = () => {
+    activeRequestRef.current = null;
+    isProcessingRequestRef.current = false;
+  };
   const pendingRequestsQueueRef = useRef<WalletKitSessionRequest[]>([]);
-  // Guard against double-reject: set to true once approveSessionRequest has sent
+  // Guard against double-reject: set to true once executeDappRequest has sent
   // its own response (success or handled error) so handleClearDappRequest doesn't
   // send a duplicate rejection when it fires via .finally().
   const hasRespondedRef = useRef(false);
   // True once the user has committed to approving (handleDappRequest called
-  // approveSessionRequest). Distinguishes an approval attempt — whether it
+  // executeDappRequest). Distinguishes an approval attempt — whether it
   // succeeds or throws — from a genuine user dismissal, so the exceptional
   // approve-threw path isn't miscounted as a signing.*_rejected. Reset with
   // hasRespondedRef in the teardown.
@@ -150,7 +160,9 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
   const xdr = useMemo(
     () =>
-      (requestEvent?.params.request.params as StellarSignXDRParams)?.xdr ?? "",
+      typeof requestEvent?.params.request.params?.xdr === "string"
+        ? requestEvent.params.request.params.xdr
+        : "",
     [requestEvent],
   );
 
@@ -189,6 +201,31 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const dappConnectionBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const dappRequestBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const siteSecurityWarningBottomSheetModalRef = useRef<BottomSheetModal>(null);
+  // The site and transaction warnings share one BottomSheetModal. Presenting it
+  // while its previous dismissal is still animating lets that dismissal's
+  // onDismiss fire against the new presentation and cancel it (the signing
+  // sheet then never appears and the dApp waits forever). Track presentation
+  // and in-flight dismissal so a present during a dismiss is deferred to
+  // onDismiss instead.
+  const securityWarningPresentedRef = useRef(false);
+  const securityWarningDismissingRef = useRef(false);
+  const securityWarningPendingPresentRef = useRef(false);
+  /** Presents the shared security warning sheet, deferring until an in-flight dismiss has settled. */
+  const presentSecurityWarning = () => {
+    if (securityWarningDismissingRef.current) {
+      securityWarningPendingPresentRef.current = true;
+      return;
+    }
+    securityWarningPresentedRef.current = true;
+    securityWarningDecisionRef.current = false;
+    siteSecurityWarningBottomSheetModalRef.current?.present();
+  };
+  /** Dismisses the shared security warning sheet if presented; onDismiss replays a deferred present. */
+  const dismissSecurityWarning = () => {
+    if (!securityWarningPresentedRef.current) return;
+    securityWarningDismissingRef.current = true;
+    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+  };
   const verifyDomainBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const [securityWarningContext, setSecurityWarningContext] =
     useState<SecurityContext>(SecurityContext.SITE);
@@ -419,8 +456,10 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleClearDappConnection = () => {
+    activeProposalRef.current = null;
     dappConnectionBottomSheetModalRef.current?.dismiss();
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
     verifyDomainBottomSheetModalRef.current?.dismiss();
     // Also ensure other sheets are closed to avoid any leftovers
     dappRequestBottomSheetModalRef.current?.dismiss();
@@ -430,6 +469,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     setSiteScanResult(undefined);
     setSecurityWarningContext(SecurityContext.SITE);
     clearEvent();
+    if (pendingRequestsQueueRef.current.length)
+      setEvent(pendingRequestsQueueRef.current.shift()!);
   };
 
   /**
@@ -439,16 +480,23 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleClearDappRequest = () => {
+    if (
+      isClearingRequestRef.current ||
+      activeRequestRef.current !== requestEvent
+    )
+      return;
+    isClearingRequestRef.current = true;
     dappRequestBottomSheetModalRef.current?.dismiss();
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
 
     // We need to explicitly reject the request here otherwise
     // the app will show the request again on next app launch.
-    // Skip if approveSessionRequest already sent a response. This WC-level
-    // fallback fires on BOTH a user dismissal AND the exceptional case where
-    // approveSessionRequest threw (so the dApp isn't left hanging).
+    // Skip if executeDappRequest already sent a response. This fallback
+    // fires on BOTH a user dismissal AND the exceptional case where
+    // executeDappRequest threw (so the dApp isn't left hanging).
     if (requestEvent && !hasRespondedRef.current) {
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest: requestEvent,
         message: t("walletKit.userRejected"),
       });
@@ -465,8 +513,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       approvalInFlight: approvalInFlightRef.current,
     });
     if (rejectionEvent && requestEvent) {
-      const dappDomain =
-        getDappMetadataFromEvent(requestEvent, activeSessions)?.url || "";
+      const dappDomain = requestEvent.metadata.url || "";
       const payload = dappDomain ? { dappDomain } : {};
       if (rejectionEvent === "message") {
         analytics.trackSignedMessageRejected(payload);
@@ -478,6 +525,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     }
 
     setTimeout(() => {
+      if (activeRequestRef.current !== requestEvent) return;
+      activeRequestRef.current = null;
       setIsSigning(false);
       setRequestEvent(null);
       setTransactionScanResult(undefined);
@@ -491,6 +540,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
       // Mark processing as complete and process pending request if any
       isProcessingRequestRef.current = false;
+      isClearingRequestRef.current = false;
       if (pendingRequestsQueueRef.current.length > 0) {
         logger.debug(
           "WalletKitProvider",
@@ -563,7 +613,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleDappRequest = () => {
-    if (!requestEvent) {
+    if (
+      !requestEvent ||
+      approvalInFlightRef.current ||
+      isClearingRequestRef.current ||
+      !requestEvent.isValid()
+    ) {
       return;
     }
 
@@ -572,7 +627,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     // exceptional approve-threw .catch path) is not miscounted as a user reject.
     approvalInFlightRef.current = true;
 
-    approveSessionRequest({
+    executeDappRequest({
       sessionRequest: requestEvent,
       signTransaction,
       signMessage,
@@ -584,7 +639,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       t,
     })
       .then(() => {
-        // approveSessionRequest handled the WC response internally (success or
+        if (activeRequestRef.current !== requestEvent) return;
+        // executeDappRequest handled the WC response internally (success or
         // its own rejection). Mark responded so handleClearDappRequest won't
         // send a duplicate rejection.
         hasRespondedRef.current = true;
@@ -599,6 +655,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         );
       })
       .finally(() => {
+        if (activeRequestRef.current !== requestEvent) return;
         handleClearDappRequest();
       });
   };
@@ -623,7 +680,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         dappConnectionBottomSheetModalRef.current?.dismiss();
       }
 
-      siteSecurityWarningBottomSheetModalRef.current?.present();
+      presentSecurityWarning();
     },
     [],
   );
@@ -632,7 +689,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Handles proceeding anyway from security warning (context-aware)
    */
   const handleProceedAnyway = (): void => {
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
 
     const isUnableToScan =
       securityWarningContext === SecurityContext.TRANSACTION
@@ -664,7 +722,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleCancelSecurityWarning = () => {
-    siteSecurityWarningBottomSheetModalRef.current?.dismiss();
+    securityWarningDecisionRef.current = true;
+    dismissSecurityWarning();
 
     if (
       securityWarningBlocksSheet &&
@@ -698,9 +757,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Validates the message param for sign_message requests.
    * @returns true if valid, false if invalid (rejection already handled)
    */
-  const prevalidateSignMessage = (
-    sessionRequest: WalletKitSessionRequest,
-  ): boolean => {
+  const prevalidateSignMessage = (sessionRequest: DappRequest): boolean => {
     const msgParam = (
       sessionRequest.params as
         | { request?: { params?: { message?: unknown } } }
@@ -715,12 +772,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(contentResult.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(contentResult.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -732,12 +789,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(lengthResult.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(lengthResult.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -749,7 +806,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns the entryXdr string if valid, or null if invalid (rejection handled)
    */
   const prevalidateSignAuthEntryContent = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
   ): string | null => {
     const entryParam = (
       sessionRequest.params as
@@ -764,12 +821,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return null;
     }
 
@@ -781,7 +838,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns the parsed preimage if valid, or null if invalid (rejection handled)
    */
   const prevalidateSignAuthEntryXdrFormat = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
     entryXdr: string,
   ): stellarXdr.HashIdPreimage | null => {
     const result = parseAuthEntryPreimage(entryXdr);
@@ -791,12 +848,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return null;
     }
 
@@ -809,7 +866,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns true if valid, false if invalid (rejection handled)
    */
   const prevalidateSignAuthEntryNetworkId = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
     preimage: stellarXdr.HashIdPreimage,
   ): boolean => {
     const result = validateAuthEntryNetwork(
@@ -822,12 +879,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -839,7 +896,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * wallet account. Rejects the request on mismatch.
    */
   const prevalidateSignAuthEntryAddress = (
-    sessionRequest: WalletKitSessionRequest,
+    sessionRequest: DappRequest,
     preimage: stellarXdr.HashIdPreimage,
   ): boolean => {
     const result = validateAuthEntryAddress(preimage, publicKey);
@@ -849,12 +906,12 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t(result.errorKey),
         variant: "error",
       });
-      rejectSessionRequest({
+      rejectDappRequest({
         sessionRequest,
         message: t(result.errorKey),
       });
       clearEvent();
-      isProcessingRequestRef.current = false;
+      resetActiveRequest();
       return false;
     }
 
@@ -865,9 +922,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Orchestrates all sign_auth_entry pre-validations.
    * @returns true if all validations pass, false if any fail (rejection handled)
    */
-  const prevalidateSignAuthEntry = (
-    sessionRequest: WalletKitSessionRequest,
-  ): boolean => {
+  const prevalidateSignAuthEntry = (sessionRequest: DappRequest): boolean => {
     // Step 1: Validate content (presence, type, non-empty)
     const entryXdr = prevalidateSignAuthEntryContent(sessionRequest);
     if (!entryXdr) {
@@ -900,6 +955,19 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Handles SESSION_PROPOSAL events — validates auth, scans site, shows connection sheet.
    */
   const handleSessionProposal = (sessionProposal: WalletKitSessionProposal) => {
+    if (activeProposalRef.current === sessionProposal.id) return;
+    if (
+      isProcessingRequestRef.current ||
+      isClearingRequestRef.current ||
+      activeProposalRef.current !== null
+    ) {
+      rejectSessionProposal({
+        sessionProposal,
+        message: t("walletKit.userRejected"),
+      });
+      clearEvent();
+      return;
+    }
     // Check if user is not authenticated
     if (authStatus === AUTH_STATUS.NOT_AUTHENTICATED) {
       showToast({
@@ -937,6 +1005,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       return;
     }
 
+    activeProposalRef.current = sessionProposal.id;
     setProposalEvent(sessionProposal);
 
     const dappMetadata = getDappMetadataFromEvent(
@@ -947,6 +1016,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
     scanSite(dappDomain)
       .then((scanResult) => {
+        if (activeProposalRef.current !== sessionProposal.id) return;
         setSiteScanResult(scanResult);
         const securityAssessment = assessSiteSecurity(
           scanResult,
@@ -954,12 +1024,13 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         );
         if (securityAssessment.isUnableToScan) {
           setSecurityWarningContext(SecurityContext.SITE);
-          siteSecurityWarningBottomSheetModalRef.current?.present();
+          presentSecurityWarning();
         } else {
           dappConnectionBottomSheetModalRef.current?.present();
         }
       })
       .catch(() => {
+        if (activeProposalRef.current !== sessionProposal.id) return;
         setSiteScanResult(undefined);
         const securityAssessment = assessSiteSecurity(
           undefined,
@@ -967,11 +1038,137 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         );
         if (securityAssessment.isUnableToScan) {
           setSecurityWarningContext(SecurityContext.SITE);
-          siteSecurityWarningBottomSheetModalRef.current?.present();
+          presentSecurityWarning();
         } else {
           dappConnectionBottomSheetModalRef.current?.present();
         }
       });
+  };
+
+  /**
+   * Entry point shared by both transports once a request is native-verified:
+   * pins it as the active request, validates method and params, runs the
+   * Blockaid transaction scan for XDR requests, and presents the signing
+   * sheet. Everything downstream (approve/reject) reads `activeRequestRef`.
+   */
+  const handleNormalizedRequest = (incoming: DappRequest) => {
+    const sessionRequest: DappRequest = {
+      ...incoming,
+      isValid: () =>
+        activeRequestRef.current === sessionRequest &&
+        !isClearingRequestRef.current &&
+        incoming.isValid(),
+    };
+    activeRequestRef.current = sessionRequest;
+    if (!sessionRequest.isValid()) {
+      rejectDappRequest({
+        sessionRequest,
+        message: t("walletKit.userNotAuthenticated"),
+        code: DappErrorCode.CONTEXT_CHANGED,
+      });
+      resetActiveRequest();
+      return;
+    }
+    const { method } = sessionRequest.params.request;
+    const { params } = sessionRequest.params.request;
+    const supported = Object.values(StellarRpcMethods).includes(
+      method as StellarRpcMethods,
+    );
+    const transactionMethod =
+      method === (StellarRpcMethods.SIGN_XDR as string) ||
+      method === (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
+    if (
+      !supported ||
+      (transactionMethod &&
+        (typeof params?.xdr !== "string" || !params.xdr.trim()))
+    ) {
+      rejectDappRequest({
+        sessionRequest,
+        message: t("walletKit.invalidRequestTitle"),
+        code: !supported
+          ? DappErrorCode.UNSUPPORTED_METHOD
+          : DappErrorCode.INVALID_PARAMS,
+      });
+      resetActiveRequest();
+      return;
+    }
+    // Get dApp metadata
+    const dappDomain = sessionRequest.origin;
+
+    const requestParams = sessionRequest.params as
+      | { request?: { method?: string; params?: { xdr?: string } } }
+      | undefined;
+    const currentRequestMethod = requestParams?.request?.method;
+    const requestXdr = requestParams?.request?.params?.xdr;
+
+    const isXdrRequest =
+      currentRequestMethod === (StellarRpcMethods.SIGN_XDR as string) ||
+      currentRequestMethod ===
+        (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
+
+    if (isXdrRequest && requestXdr) {
+      try {
+        TransactionBuilder.fromXdr(
+          requestXdr,
+          networkDetails.networkPassphrase,
+        );
+      } catch {
+        rejectDappRequest({
+          sessionRequest,
+          message: t("walletKit.invalidRequestTitle"),
+          code: DappErrorCode.INVALID_PARAMS,
+        });
+        resetActiveRequest();
+        return;
+      }
+      setRequestEvent(sessionRequest);
+      // XDR-based requests: scan transaction first
+      scanTransaction(requestXdr, dappDomain)
+        .then((scanResult) => {
+          if (!sessionRequest.isValid()) return;
+          setTransactionScanResult(scanResult);
+          const securityAssessment = assessTransactionSecurity(
+            scanResult,
+            overriddenBlockaidResponse,
+          );
+          if (securityAssessment.isUnableToScan) {
+            setSecurityWarningContext(SecurityContext.TRANSACTION);
+            setSecurityWarningBlocksSheet(true);
+            presentSecurityWarning();
+          } else {
+            dappRequestBottomSheetModalRef.current?.present();
+          }
+        })
+        .catch(() => {
+          if (!sessionRequest.isValid()) return;
+          setTransactionScanResult(undefined);
+          const securityAssessment = assessTransactionSecurity(
+            undefined,
+            overriddenBlockaidResponse,
+          );
+          if (securityAssessment.isUnableToScan) {
+            setSecurityWarningContext(SecurityContext.TRANSACTION);
+            setSecurityWarningBlocksSheet(true);
+            presentSecurityWarning();
+          } else {
+            dappRequestBottomSheetModalRef.current?.present();
+          }
+        });
+    } else {
+      // Non-XDR requests (sign_message, sign_auth_entry): validate params first
+      if (currentRequestMethod === (StellarRpcMethods.SIGN_MESSAGE as string)) {
+        if (!prevalidateSignMessage(sessionRequest)) return;
+      }
+
+      if (
+        currentRequestMethod === (StellarRpcMethods.SIGN_AUTH_ENTRY as string)
+      ) {
+        if (!prevalidateSignAuthEntry(sessionRequest)) return;
+      }
+
+      setRequestEvent(sessionRequest);
+      dappRequestBottomSheetModalRef.current?.present();
+    }
   };
 
   /**
@@ -980,7 +1177,11 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    */
   const handleSessionRequest = (sessionRequest: WalletKitSessionRequest) => {
     // Simple queue: if already processing a request, store this one as pending
-    if (isProcessingRequestRef.current) {
+    if (
+      isProcessingRequestRef.current ||
+      activeProposalRef.current !== null ||
+      isClearingRequestRef.current
+    ) {
       // Normal queue flow, not an error condition.
       logger.info(
         "WalletKitProvider",
@@ -1112,74 +1313,13 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       return;
     }
 
-    setRequestEvent(sessionRequest);
-
-    // Get dApp metadata
-    const dappMetadata = getDappMetadataFromEvent(
-      sessionRequest,
-      activeSessions,
+    handleNormalizedRequest(
+      toDappRequest(
+        sessionRequest,
+        publicKey,
+        networkDetails.networkPassphrase,
+      ),
     );
-    const dappDomain =
-      (dappMetadata?.url as string) ||
-      sessionRequest.verifyContext?.verified?.origin ||
-      "";
-
-    const requestParams = sessionRequest.params as
-      | { request?: { method?: string; params?: { xdr?: string } } }
-      | undefined;
-    const currentRequestMethod = requestParams?.request?.method;
-    const requestXdr = requestParams?.request?.params?.xdr;
-
-    const isXdrRequest =
-      currentRequestMethod === (StellarRpcMethods.SIGN_XDR as string) ||
-      currentRequestMethod ===
-        (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
-
-    if (isXdrRequest && requestXdr) {
-      // XDR-based requests: scan transaction first
-      scanTransaction(requestXdr, dappDomain)
-        .then((scanResult) => {
-          setTransactionScanResult(scanResult);
-          const securityAssessment = assessTransactionSecurity(
-            scanResult,
-            overriddenBlockaidResponse,
-          );
-          if (securityAssessment.isUnableToScan) {
-            setSecurityWarningContext(SecurityContext.TRANSACTION);
-            setSecurityWarningBlocksSheet(true);
-            siteSecurityWarningBottomSheetModalRef.current?.present();
-          } else {
-            dappRequestBottomSheetModalRef.current?.present();
-          }
-        })
-        .catch(() => {
-          setTransactionScanResult(undefined);
-          const securityAssessment = assessTransactionSecurity(
-            undefined,
-            overriddenBlockaidResponse,
-          );
-          if (securityAssessment.isUnableToScan) {
-            setSecurityWarningContext(SecurityContext.TRANSACTION);
-            setSecurityWarningBlocksSheet(true);
-            siteSecurityWarningBottomSheetModalRef.current?.present();
-          } else {
-            dappRequestBottomSheetModalRef.current?.present();
-          }
-        });
-    } else {
-      // Non-XDR requests (sign_message, sign_auth_entry): validate params first
-      if (currentRequestMethod === (StellarRpcMethods.SIGN_MESSAGE as string)) {
-        if (!prevalidateSignMessage(sessionRequest)) return;
-      }
-
-      if (
-        currentRequestMethod === (StellarRpcMethods.SIGN_AUTH_ENTRY as string)
-      ) {
-        if (!prevalidateSignAuthEntry(sessionRequest)) return;
-      }
-
-      dappRequestBottomSheetModalRef.current?.present();
-    }
   };
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -1302,6 +1442,20 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       <BottomSheet
         modalRef={siteSecurityWarningBottomSheetModalRef}
         handleCloseModal={handleCancelSecurityWarning}
+        bottomSheetModalProps={{
+          onDismiss: () => {
+            securityWarningPresentedRef.current = false;
+            securityWarningDismissingRef.current = false;
+            const decided = securityWarningDecisionRef.current;
+            securityWarningDecisionRef.current = false;
+            if (securityWarningPendingPresentRef.current) {
+              securityWarningPendingPresentRef.current = false;
+              presentSecurityWarning();
+              return;
+            }
+            if (!decided) handleCancelSecurityWarning();
+          },
+        }}
         customContent={
           <SecurityDetailBottomSheet
             warnings={getWarnings()}

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -11,10 +11,16 @@ import DappRequestBottomSheetContent from "components/screens/WalletKit/DappRequ
 import Icon from "components/sds/Icon";
 import { AnalyticsEvent } from "config/analyticsConfig";
 import { mapNetworkToNetworkDetails, NETWORKS } from "config/constants";
-import { DappErrorCode, type DappRequest } from "config/dappRequest";
+import {
+  DappApprovalKind,
+  DappErrorCode,
+  type DappRequest,
+  DappTransport,
+} from "config/dappRequest";
 import { logger } from "config/logger";
 import { AUTH_STATUS } from "config/types";
 import { useAuthenticationStore } from "ducks/auth";
+import { useDappApprovalStore } from "ducks/dappApproval";
 import { useDebugStore } from "ducks/debug";
 import { useTransactionSettingsStore } from "ducks/transactionSettings";
 import {
@@ -141,10 +147,16 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const activeRequestRef = useRef<DappRequest | null>(null);
   const isClearingRequestRef = useRef(false);
   const securityWarningDecisionRef = useRef(false);
+  const webviewJob = useDappApprovalStore((state) => state.job);
+  const setWalletConnectBusy = useDappApprovalStore(
+    (state) => state.setWalletConnectBusy,
+  );
+  const handledWebviewJobRef = useRef<DappRequest | null>(null);
   /** Releases the active request slot after a rejection so the next queued request can proceed. */
   const resetActiveRequest = () => {
     activeRequestRef.current = null;
     isProcessingRequestRef.current = false;
+    setWalletConnectBusy(false);
   };
   const pendingRequestsQueueRef = useRef<WalletKitSessionRequest[]>([]);
   // Guard against double-reject: set to true once executeDappRequest has sent
@@ -464,6 +476,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     // Also ensure other sheets are closed to avoid any leftovers
     dappRequestBottomSheetModalRef.current?.dismiss();
 
+    setWalletConnectBusy(false);
     setIsConnecting(false);
     setProposalEvent(null);
     setSiteScanResult(undefined);
@@ -540,6 +553,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
       // Mark processing as complete and process pending request if any
       isProcessingRequestRef.current = false;
+      setWalletConnectBusy(false);
       isClearingRequestRef.current = false;
       if (pendingRequestsQueueRef.current.length > 0) {
         logger.debug(
@@ -689,6 +703,28 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * Handles proceeding anyway from security warning (context-aware)
    */
   const handleProceedAnyway = (): void => {
+    const { job } = useDappApprovalStore.getState();
+    if (job?.kind === DappApprovalKind.SITE) {
+      if (job.request.isValid())
+        job.request
+          .respond({ id: job.request.id, jsonrpc: "2.0", result: true })
+          .catch((error) => {
+            logger.warn(
+              "WalletKitProvider",
+              "Site approval could not be delivered",
+              error,
+            );
+          });
+      else
+        rejectDappRequest({
+          sessionRequest: job.request,
+          message: t("walletKit.userRejected"),
+          code: DappErrorCode.CONTEXT_CHANGED,
+        });
+      securityWarningDecisionRef.current = true;
+      dismissSecurityWarning();
+      return;
+    }
     securityWarningDecisionRef.current = true;
     dismissSecurityWarning();
 
@@ -722,6 +758,14 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
    * @returns {void}
    */
   const handleCancelSecurityWarning = () => {
+    const { job } = useDappApprovalStore.getState();
+    if (job?.kind === DappApprovalKind.SITE) {
+      rejectDappRequest({
+        sessionRequest: job.request,
+        message: t("walletKit.userRejected"),
+        code: DappErrorCode.USER_REJECTED,
+      });
+    }
     securityWarningDecisionRef.current = true;
     dismissSecurityWarning();
 
@@ -957,6 +1001,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const handleSessionProposal = (sessionProposal: WalletKitSessionProposal) => {
     if (activeProposalRef.current === sessionProposal.id) return;
     if (
+      useDappApprovalStore.getState().job ||
       isProcessingRequestRef.current ||
       isClearingRequestRef.current ||
       activeProposalRef.current !== null
@@ -968,6 +1013,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       clearEvent();
       return;
     }
+    setWalletConnectBusy(true);
     // Check if user is not authenticated
     if (authStatus === AUTH_STATUS.NOT_AUTHENTICATED) {
       showToast({
@@ -989,6 +1035,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       );
 
       clearEvent();
+      setWalletConnectBusy(false);
       return;
     }
 
@@ -1002,6 +1049,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         message: t("walletKit.pleaseUnlockToConnect"),
         variant: "error",
       });
+      setWalletConnectBusy(false);
       return;
     }
 
@@ -1180,7 +1228,8 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     if (
       isProcessingRequestRef.current ||
       activeProposalRef.current !== null ||
-      isClearingRequestRef.current
+      isClearingRequestRef.current ||
+      useDappApprovalStore.getState().job
     ) {
       // Normal queue flow, not an error condition.
       logger.info(
@@ -1199,6 +1248,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
     // Mark as processing
     isProcessingRequestRef.current = true;
+    setWalletConnectBusy(true);
 
     // Check if user is not authenticated
     if (authStatus === AUTH_STATUS.NOT_AUTHENTICATED) {
@@ -1215,6 +1265,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
       clearEvent();
       isProcessingRequestRef.current = false;
+      setWalletConnectBusy(false);
       return;
     }
 
@@ -1229,12 +1280,14 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         variant: "error",
       });
       isProcessingRequestRef.current = false;
+      setWalletConnectBusy(false);
       return;
     }
 
     // Wait for active sessions to be fetched
     if (Object.keys(activeSessions).length === 0) {
       isProcessingRequestRef.current = false;
+      setWalletConnectBusy(false);
       return;
     }
 
@@ -1259,6 +1312,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
       clearEvent();
       isProcessingRequestRef.current = false;
+      setWalletConnectBusy(false);
       return;
     }
 
@@ -1310,6 +1364,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
 
       clearEvent();
       isProcessingRequestRef.current = false;
+      setWalletConnectBusy(false);
       return;
     }
 
@@ -1321,6 +1376,65 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
       ),
     );
   };
+
+  useEffect(() => {
+    if (!webviewJob) {
+      if (handledWebviewJobRef.current) {
+        handledWebviewJobRef.current = null;
+        securityWarningDecisionRef.current = true;
+        dismissSecurityWarning();
+        if (requestEvent?.transport === DappTransport.WEBVIEW) {
+          hasRespondedRef.current = true;
+          handleClearDappRequest();
+        } else if (pendingRequestsQueueRef.current.length) {
+          setEvent(pendingRequestsQueueRef.current.shift()!);
+        }
+      }
+      return;
+    }
+    if (handledWebviewJobRef.current === webviewJob.request) return;
+    handledWebviewJobRef.current = webviewJob.request;
+    const { request, kind } = webviewJob;
+    if (kind === DappApprovalKind.SIGN) {
+      handleNormalizedRequest(request);
+      return;
+    }
+    scanSite(request.origin)
+      .then((result) => {
+        if (!request.isValid()) return;
+        setSiteScanResult(result);
+        const assessment = assessSiteSecurity(
+          result,
+          overriddenBlockaidResponse,
+        );
+        if (
+          !assessment.isMalicious &&
+          !assessment.isSuspicious &&
+          !assessment.isUnableToScan
+        ) {
+          request
+            .respond({ id: request.id, jsonrpc: "2.0", result: true })
+            .catch((error) => {
+              logger.warn(
+                "WalletKitProvider",
+                "Site approval could not be delivered",
+                error,
+              );
+            });
+          return;
+        }
+        setSecurityWarningContext(SecurityContext.SITE);
+        presentSecurityWarning();
+      })
+      .catch(() => {
+        if (!request.isValid()) return;
+        setSiteScanResult(undefined);
+        setSecurityWarningContext(SecurityContext.SITE);
+        presentSecurityWarning();
+      });
+    // Job identity is immutable; account/navigation changes invalidate it upstream.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [webviewJob]);
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Main WalletKit event handler effect
@@ -1459,6 +1573,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         customContent={
           <SecurityDetailBottomSheet
             warnings={getWarnings()}
+            origin={webviewJob?.request.origin}
             onCancel={handleCancelSecurityWarning}
             onProceedAnyway={handleProceedAnyway}
             onClose={handleCancelSecurityWarning}

--- a/src/providers/WalletKitProvider.tsx
+++ b/src/providers/WalletKitProvider.tsx
@@ -1,6 +1,10 @@
 import Blockaid from "@blockaid/client";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
-import { TransactionBuilder, xdr as stellarXdr } from "@stellar/stellar-sdk";
+import {
+  Transaction,
+  TransactionBuilder,
+  xdr as stellarXdr,
+} from "@stellar/stellar-sdk";
 import AddMemoExplanationBottomSheet from "components/AddMemoExplanationBottomSheet";
 import BottomSheet from "components/BottomSheet";
 import InformationBottomSheet from "components/InformationBottomSheet";
@@ -1155,11 +1159,17 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         (StellarRpcMethods.SIGN_AND_SUBMIT_XDR as string);
 
     if (isXdrRequest && requestXdr) {
+      let isSep10Challenge = false;
       try {
-        TransactionBuilder.fromXdr(
+        const parsed = TransactionBuilder.fromXdr(
           requestXdr,
           networkDetails.networkPassphrase,
         );
+        isSep10Challenge =
+          parsed instanceof Transaction &&
+          parsed.sequence === "0" &&
+          parsed.operations.length > 0 &&
+          parsed.operations.every((op) => op.type === "manageData");
       } catch {
         rejectDappRequest({
           sessionRequest,
@@ -1170,6 +1180,13 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
         return;
       }
       setRequestEvent(sessionRequest);
+      if (isSep10Challenge) {
+        // A SEP-10 challenge cannot be submitted (sequence 0); scanning it only
+        // adds a network round trip and, when Blockaid is unreachable, a
+        // second warning gate before the login signature.
+        dappRequestBottomSheetModalRef.current?.present();
+        return;
+      }
       // XDR-based requests: scan transaction first
       scanTransaction(requestXdr, dappDomain)
         .then((scanResult) => {

--- a/src/services/webview/bridge.ts
+++ b/src/services/webview/bridge.ts
@@ -21,6 +21,7 @@ import {
   WEBVIEW_BRIDGE_PROTOCOL,
   WEBVIEW_BRIDGE_PROTOCOL_VERSION,
 } from "services/webview/injection";
+import type { Sep10Auth } from "services/webview/sep10";
 
 /** The account context a connected document sees; never more than this. */
 export interface BridgeAccount {
@@ -47,6 +48,11 @@ interface BridgeOptions {
   /** Fresh per-document token; must be unguessable. */
   token: () => string;
   onInvalidated?: () => void;
+  /** Silent SEP-10 for an approved document; null means the dApp asks for a signature itself. */
+  prepareAuth?: (
+    origin: string,
+    account: BridgeAccount,
+  ) => Promise<Sep10Auth | null>;
 }
 
 /** Development-only HTTP hosts (simulator, emulator, loopback). */
@@ -416,7 +422,13 @@ export class WebviewBridge {
         this.wantsConnection = true;
         this.connected = true;
         this.lastAccount = account;
-        finish({ result: account });
+        // Never cached: a challenge is single-use server-side, so every
+        // connect (including after a dApp-side logout) gets a fresh one.
+        const auth = this.options.prepareAuth
+          ? await this.options.prepareAuth(this.origin, account)
+          : null;
+        if (!request.isValid()) return;
+        finish({ result: auth ? { ...account, auth } : account });
       } else if (method === WebviewBridgeMethod.GET_ACCOUNT) {
         finish(
           this.connected

--- a/src/services/webview/bridge.ts
+++ b/src/services/webview/bridge.ts
@@ -1,0 +1,454 @@
+import {
+  DAPP_APPROVAL_TIMEOUT_MS,
+  WEBVIEW_BRIDGE_MAX_ENVELOPE_BYTES,
+  WEBVIEW_BRIDGE_MAX_READY_PER_DOCUMENT,
+  WEBVIEW_BRIDGE_MAX_REQUEST_ID_LENGTH,
+  WEBVIEW_BRIDGE_MAX_SEEN_REQUESTS,
+} from "config/constants";
+import {
+  DappApprovalKind,
+  DappErrorCode,
+  type DappRequest,
+  DappTransport,
+  WebviewBridgeEvent,
+  WebviewBridgeMethod,
+} from "config/dappRequest";
+import { logger } from "config/logger";
+import { validateWebviewSignMessage } from "helpers/walletKitValidation";
+import {
+  activateBridge,
+  bridgeDelivery,
+  WEBVIEW_BRIDGE_PROTOCOL,
+  WEBVIEW_BRIDGE_PROTOCOL_VERSION,
+} from "services/webview/injection";
+
+/** The account context a connected document sees; never more than this. */
+export interface BridgeAccount {
+  address: string;
+  chainId: string;
+  networkPassphrase: string;
+}
+
+interface BridgeContext {
+  /** False while the tab is hidden, the browser is backgrounded or Discovery is not focused. */
+  active: boolean;
+  /** Null when the wallet is locked or on an unsupported network. */
+  account: BridgeAccount | null;
+}
+
+interface BridgeOptions {
+  version: string;
+  development: boolean;
+  /** Runs a script in the WebView's main frame. */
+  inject: (script: string) => void;
+  context: () => BridgeContext;
+  /** Resolves once the user approved the site or signed; rejects with a DappErrorCode. */
+  approve: (kind: DappApprovalKind, request: DappRequest) => Promise<unknown>;
+  /** Fresh per-document token; must be unguessable. */
+  token: () => string;
+  onInvalidated?: () => void;
+}
+
+/** Development-only HTTP hosts (simulator, emulator, loopback). */
+const DEVELOPMENT_HTTP_HOSTS = ["localhost", "127.0.0.1", "10.0.2.2", "[::1]"];
+const METHODS = new Set<string>(Object.values(WebviewBridgeMethod));
+const error = (code: DappErrorCode, message: string) => ({ code, message });
+const sameAccount = (a: BridgeAccount | null, b: BridgeAccount | null) =>
+  a?.address === b?.address &&
+  a?.chainId === b?.chainId &&
+  a?.networkPassphrase === b?.networkPassphrase;
+
+/**
+ * Origin a document may hold wallet access under, or null. Production is
+ * HTTPS only; development builds also allow HTTP on local hosts. URLs with
+ * credentials are refused outright.
+ */
+export const walletOrigin = (
+  url: string,
+  development: boolean,
+): string | null => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.username || parsed.password) return null;
+    if (parsed.protocol === "https:") return parsed.origin;
+    if (
+      development &&
+      parsed.protocol === "http:" &&
+      DEVELOPMENT_HTTP_HOSTS.includes(parsed.hostname)
+    )
+      return parsed.origin;
+  } catch {
+    /* Invalid and opaque URLs have no wallet access. */
+  }
+  return null;
+};
+
+/**
+ * Native side of the in-app dApp bridge for one mounted WebView.
+ *
+ * Every message from the page is untrusted: a request is accepted only for
+ * the activated document (native origin and per-document token), once per
+ * id, for a known method with object params, and only while the browser is
+ * active and the wallet unlocked. Approval and signing stay in
+ * WalletKitProvider; this class only correlates requests with responses.
+ * A controller belongs to exactly one mounted WebView, never the active-tab
+ * ref.
+ */
+export class WebviewBridge {
+  private origin: string | null = null;
+
+  private documentToken = "";
+
+  /** Main-frame URL the WebView reported on its last navigation; the only URL activation trusts. */
+  private navigationUrl = "";
+
+  private connected = false;
+
+  private wantsConnection = false;
+
+  private approvedSite = false;
+
+  private revision = 0;
+
+  private seen = new Set<string>();
+
+  private readyCount = 0;
+
+  private pending = new Map<string, () => void>();
+
+  private lastAccount: BridgeAccount | null = null;
+
+  constructor(private options: BridgeOptions) {
+    this.lastAccount = options.context().account;
+  }
+
+  private send(data: Record<string, unknown>) {
+    if (!this.origin || !this.documentToken) {
+      logger.warn("WebViewBridge", "send dropped: no active document", {
+        origin: this.origin,
+        hasToken: Boolean(this.documentToken),
+        keys: Object.keys(data),
+      });
+      return;
+    }
+    this.options.inject(
+      bridgeDelivery(this.documentToken, this.origin, {
+        protocol: WEBVIEW_BRIDGE_PROTOCOL,
+        version: WEBVIEW_BRIDGE_PROTOCOL_VERSION,
+        documentToken: this.documentToken,
+        ...data,
+      }),
+    );
+  }
+
+  /**
+   * Cancels every pending request and tells a connected document its wallet
+   * context changed. Called on navigation, account/network change, lock,
+   * backgrounding and disconnect.
+   */
+  invalidate() {
+    this.revision += 1;
+    this.pending.forEach((cancel) => cancel());
+    this.pending.clear();
+    if (this.connected)
+      this.send({
+        event: WebviewBridgeEvent.DISCONNECT,
+        data: error(DappErrorCode.CONTEXT_CHANGED, "Wallet context changed"),
+      });
+    this.connected = false;
+    this.options.onInvalidated?.();
+  }
+
+  /**
+   * The WebView started loading a new main-frame document. `url` is the
+   * navigation URL the WebView reported; it is the only URL later activation
+   * trusts.
+   */
+  navigationStarted(url = "") {
+    this.navigationUrl = url;
+    this.invalidate();
+    this.origin = null;
+    this.documentToken = "";
+    this.readyCount = 0;
+    this.approvedSite = false;
+    this.wantsConnection = false;
+    this.seen.clear();
+  }
+
+  /**
+   * Activates the document at `url` (main-frame URL from the WebView) with a
+   * fresh token, or tears the bridge down when the origin is not one the
+   * wallet serves. Idempotent for the same origin.
+   */
+  loaded(url: string) {
+    const origin = walletOrigin(url, this.options.development);
+    if (!origin) {
+      this.navigationStarted();
+      return;
+    }
+    if (!this.documentToken || origin !== this.origin) {
+      if (this.documentToken) this.navigationStarted(url);
+      this.navigationUrl = url;
+      this.origin = origin;
+      this.documentToken = this.options.token();
+    }
+    this.options.inject(
+      activateBridge(this.options.version, this.documentToken, origin),
+    );
+  }
+
+  /**
+   * Wallet or browser context changed (account, network, lock, focus, tab).
+   * Invalidates pending work and, for a connected document that is active
+   * again, pushes the current account.
+   */
+  contextChanged() {
+    const { account, active } = this.options.context();
+    const changed = !sameAccount(account, this.lastAccount);
+    const wasConnected = this.connected;
+    if (!active || changed) this.invalidate();
+    if (active && account && this.approvedSite && this.wantsConnection) {
+      this.connected = true;
+      if (changed || !wasConnected) {
+        this.send({
+          event: WebviewBridgeEvent.ACCOUNTS_CHANGED,
+          data: account,
+        });
+        this.send({ event: WebviewBridgeEvent.CHAIN_CHANGED, data: account });
+      }
+    }
+    this.lastAccount = account;
+  }
+
+  /**
+   * Handles one `onMessage` payload from the WebView. `frameUrl` is the URL
+   * the WebView attached natively; the payload itself carries no authority.
+   */
+  async receive(raw: string, frameUrl: string): Promise<void> {
+    if (Buffer.byteLength(raw, "utf8") > WEBVIEW_BRIDGE_MAX_ENVELOPE_BYTES)
+      return;
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      // Untrusted page input: malformed JSON is dropped, not logged, so a page
+      // cannot flood breadcrumbs.
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const message = value as Record<string, unknown>;
+    if (message.protocol !== WEBVIEW_BRIDGE_PROTOCOL) return;
+    // The bootstrap announces itself at document start and DOMContentLoaded,
+    // so activation does not wait for onLoadEnd (every subresource). Neither
+    // the payload nor the reporting frame has authority: activation uses the
+    // main-frame URL the WebView reported on navigation, capped per document
+    // (load end re-activates anyway).
+    if (message.ready === true) {
+      if (
+        this.readyCount >= WEBVIEW_BRIDGE_MAX_READY_PER_DOCUMENT ||
+        !this.navigationUrl
+      )
+        return;
+      this.readyCount += 1;
+      this.loaded(this.navigationUrl);
+      return;
+    }
+    // The document token authenticates the sender: it is delivered only into
+    // the main-frame document, which the same-origin policy keeps from
+    // cross-origin iframes. The reported frame URL is a consistency check on
+    // top.
+    if (
+      !this.origin ||
+      walletOrigin(frameUrl, this.options.development) !== this.origin ||
+      message.documentToken !== this.documentToken
+    ) {
+      logger.warn("WebViewBridge", "request dropped: not the active document", {
+        frameUrl,
+        method: message.method,
+      });
+      return;
+    }
+    if (
+      typeof message.id !== "string" ||
+      !message.id ||
+      message.id.length > WEBVIEW_BRIDGE_MAX_REQUEST_ID_LENGTH
+    )
+      return;
+    const { id } = message;
+    const reply = (data: Record<string, unknown>) => this.send({ id, ...data });
+    // Never settle an existing request with a duplicate's response.
+    if (this.seen.has(id)) return;
+    if (this.seen.size >= WEBVIEW_BRIDGE_MAX_SEEN_REQUESTS) {
+      reply({
+        error: error(DappErrorCode.BUSY, "Reload this document to continue"),
+      });
+      return;
+    }
+    this.seen.add(id);
+    if (message.version !== WEBVIEW_BRIDGE_PROTOCOL_VERSION) {
+      reply({
+        error: error(
+          DappErrorCode.UNSUPPORTED_VERSION,
+          "Unsupported bridge version",
+        ),
+      });
+      return;
+    }
+    if (typeof message.method !== "string" || !METHODS.has(message.method)) {
+      reply({
+        error: error(DappErrorCode.UNSUPPORTED_METHOD, "Unsupported method"),
+      });
+      return;
+    }
+    const method = message.method as WebviewBridgeMethod;
+    if (
+      !message.params ||
+      typeof message.params !== "object" ||
+      Array.isArray(message.params)
+    ) {
+      reply({
+        error: error(DappErrorCode.INVALID_PARAMS, "Invalid parameters"),
+      });
+      return;
+    }
+    const params = message.params as Record<string, unknown>;
+    if (
+      method === WebviewBridgeMethod.SIGN_MESSAGE &&
+      !validateWebviewSignMessage(params.message).valid
+    ) {
+      reply({
+        error: error(
+          DappErrorCode.INVALID_PARAMS,
+          "Message must be a non-empty string of at most 1 KiB",
+        ),
+      });
+      return;
+    }
+    const { account, active } = this.options.context();
+    if (!active) {
+      reply({
+        error: error(DappErrorCode.CONTEXT_CHANGED, "Browser is inactive"),
+      });
+      return;
+    }
+    if (method === WebviewBridgeMethod.GET_CAPABILITIES) {
+      reply({ result: { protocolVersion: WEBVIEW_BRIDGE_PROTOCOL_VERSION } });
+      return;
+    }
+    if (!account) {
+      reply({
+        error: error(DappErrorCode.WALLET_LOCKED, "Wallet is locked"),
+      });
+      return;
+    }
+    if (method === WebviewBridgeMethod.DISCONNECT) {
+      reply({ result: true });
+      this.wantsConnection = false;
+      this.invalidate();
+      this.approvedSite = false;
+      return;
+    }
+    const { revision } = this;
+    const token = this.documentToken;
+    const isValid = () =>
+      revision === this.revision &&
+      token === this.documentToken &&
+      this.options.context().active &&
+      sameAccount(account, this.options.context().account);
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const finish = (data: Record<string, unknown>) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      this.pending.delete(id);
+      if (token === this.documentToken) reply(data);
+      this.options.onInvalidated?.();
+    };
+    timer = setTimeout(
+      () =>
+        finish({
+          error: error(
+            DappErrorCode.TIMEOUT,
+            "Request timed out; submission outcome may be unknown",
+          ),
+        }),
+      DAPP_APPROVAL_TIMEOUT_MS,
+    );
+    this.pending.set(id, () =>
+      finish({
+        error: error(
+          DappErrorCode.CONTEXT_CHANGED,
+          "Wallet context changed; submission outcome may be unknown",
+        ),
+      }),
+    );
+    const request: DappRequest = {
+      id,
+      transport: DappTransport.WEBVIEW,
+      origin: this.origin,
+      metadata: {
+        name: this.origin,
+        description: "",
+        url: this.origin,
+        icons: [`${this.origin}/favicon.ico`],
+      },
+      params: {
+        chainId: typeof params.chainId === "string" ? params.chainId : "",
+        request: { method, params },
+      },
+      isValid: () => !settled && isValid(),
+      respond: (response) => {
+        finish(
+          response.error
+            ? { error: response.error }
+            : { result: response.result },
+        );
+        return Promise.resolve();
+      },
+    };
+    try {
+      if (method === WebviewBridgeMethod.CONNECT) {
+        if (!this.approvedSite)
+          await this.options.approve(DappApprovalKind.SITE, request);
+        if (!request.isValid()) return;
+        this.approvedSite = true;
+        this.wantsConnection = true;
+        this.connected = true;
+        this.lastAccount = account;
+        finish({ result: account });
+      } else if (method === WebviewBridgeMethod.GET_ACCOUNT) {
+        finish(
+          this.connected
+            ? { result: account }
+            : {
+                error: error(DappErrorCode.NOT_CONNECTED, "Call connect first"),
+              },
+        );
+      } else if (!this.connected) {
+        finish({
+          error: error(DappErrorCode.NOT_CONNECTED, "Call connect first"),
+        });
+      } else if (params.chainId !== account.chainId) {
+        finish({
+          error: error(
+            DappErrorCode.WRONG_NETWORK,
+            "Request network does not match wallet",
+          ),
+        });
+      } else {
+        await this.options.approve(DappApprovalKind.SIGN, request);
+      }
+    } catch (cause) {
+      logger.warn("WebViewBridge", "approval threw", { id, cause });
+      const failure =
+        cause &&
+        typeof cause === "object" &&
+        "code" in cause &&
+        "message" in cause
+          ? { code: String(cause.code), message: String(cause.message) }
+          : error(DappErrorCode.USER_REJECTED, "Request failed");
+      finish({ error: failure });
+    }
+  }
+}

--- a/src/services/webview/injection.ts
+++ b/src/services/webview/injection.ts
@@ -1,0 +1,88 @@
+import {
+  DAPP_APPROVAL_TIMEOUT_MS,
+  WEBVIEW_BRIDGE_MAX_ENVELOPE_BYTES,
+} from "config/constants";
+
+/** Wire protocol name shared by the bootstrap and the native controller. */
+export const WEBVIEW_BRIDGE_PROTOCOL = "freighter-webview";
+/** Bump when the envelope shape changes; the controller rejects other versions with UNSUPPORTED_VERSION. */
+export const WEBVIEW_BRIDGE_PROTOCOL_VERSION = 1;
+
+/**
+ * Script injected before content loads into every Discovery document. It
+ * installs `window.stellar` with promise-based `request/on/off`, correlates
+ * requests by id, and announces readiness. It never installs into an iframe
+ * and stays inert until the native controller activates the document with a
+ * token; authorization always happens natively.
+ */
+export const bridgeBootstrap = (appVersion: string): string => `
+(function () {
+  if (window.top !== window || window.__freighterActivate) return;
+  var pending = new Map(), listeners = new Map(), nextId = 0, token = '';
+  var protocol = ${JSON.stringify(WEBVIEW_BRIDGE_PROTOCOL)};
+  var bridge = { provider: 'freighter', platform: 'mobile', version: ${JSON.stringify(appVersion)},
+    request: function (input) {
+      return new Promise(function (resolve, reject) {
+        if (!token) return reject({code:'UNAVAILABLE',message:'Wallet bridge unavailable'});
+        var id = String(++nextId);
+        var envelope = {protocol:protocol,version:1,id:id,documentToken:token,method:input.method,params:input.params || {}};
+        var json = JSON.stringify(envelope);
+        if (new TextEncoder().encode(json).length > ${WEBVIEW_BRIDGE_MAX_ENVELOPE_BYTES}) return reject({code:'INVALID_PARAMS',message:'Request too large'});
+        var timeout = setTimeout(function () {
+          pending.delete(id);
+          reject({code:'TIMEOUT',message:'Request timed out; submission outcome may be unknown'});
+        }, ${DAPP_APPROVAL_TIMEOUT_MS});
+        pending.set(id, {resolve:resolve,reject:reject,timeout:timeout});
+        try { window.ReactNativeWebView.postMessage(json); }
+        catch (e) { clearTimeout(timeout); pending.delete(id); reject({code:'UNAVAILABLE',message:'Wallet bridge unavailable'}); }
+      });
+    },
+    on: function (event, listener) { if (!listeners.has(event)) listeners.set(event,new Set()); listeners.get(event).add(listener); },
+    off: function (event, listener) { if (listeners.has(event)) listeners.get(event).delete(listener); }
+  };
+  window.stellar = bridge;
+  var ready = function () {
+    try { window.ReactNativeWebView.postMessage(JSON.stringify({protocol:protocol,version:1,ready:true})); } catch (e) {}
+  };
+  ready();
+  if (typeof document !== 'undefined' && document.readyState === 'loading') document.addEventListener('DOMContentLoaded', ready);
+  window.__freighterReceive = function (message) {
+    if (message.protocol !== protocol || message.version !== 1 || message.documentToken !== token) return;
+    if (message.event) {
+      if (message.event === 'disconnect') {
+        pending.forEach(function(p) {clearTimeout(p.timeout);p.reject(message.data);});pending.clear();
+      }
+      if (listeners.has(message.event)) listeners.get(message.event).forEach(function(fn){try{fn(message.data);}catch(e){}});
+      return;
+    }
+    var p = pending.get(message.id); if (!p) return;
+    clearTimeout(p.timeout); pending.delete(message.id);
+    if (message.error) p.reject(message.error); else p.resolve(message.result);
+  };
+  window.__freighterActivate = function (newToken) {
+    if (token && token !== newToken) {
+      pending.forEach(function(p){clearTimeout(p.timeout);p.reject({code:'CONTEXT_CHANGED',message:'Document changed'});});pending.clear();
+    }
+    token = newToken; bridge.documentToken = token; bridge.protocolVersion = 1;
+  };
+})(); true;
+`;
+
+/**
+ * Script that (re)installs the bootstrap and activates the document at
+ * `origin` with `token`. The origin guard keeps a late injection from
+ * activating a document that navigated meanwhile.
+ */
+export const activateBridge = (
+  version: string,
+  token: string,
+  origin: string,
+) =>
+  `${bridgeBootstrap(version)}\nif (location.origin === ${JSON.stringify(origin)}) window.__freighterActivate(${JSON.stringify(token)}); true;`;
+
+/**
+ * Script that delivers one response or event to the page, guarded so a
+ * replacement document (new origin or token) never receives it.
+ */
+export const bridgeDelivery = (token: string, origin: string, data: unknown) =>
+  `if (location.origin === ${JSON.stringify(origin)} && window.stellar && window.stellar.documentToken === ${JSON.stringify(token)}) window.__freighterReceive(${JSON.stringify(data)}); true;`;

--- a/src/services/webview/sep10.ts
+++ b/src/services/webview/sep10.ts
@@ -1,0 +1,120 @@
+import { StellarToml, type Transaction, WebAuth } from "@stellar/stellar-sdk";
+import { SEP10_FETCH_TIMEOUT_MS } from "config/constants";
+import { logger } from "config/logger";
+
+/**
+ * A SEP-10 challenge the wallet fetched from the site's own WEB_AUTH_ENDPOINT,
+ * verified and countersigned.
+ */
+export interface Sep10Auth {
+  challengeXdr: string;
+  signedXdr: string;
+  networkPassphrase: string;
+  homeDomain: string;
+  webAuthEndpoint: string;
+}
+
+const fetchJson = async (url: string): Promise<Record<string, unknown>> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SEP10_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return (await response.json()) as Record<string, unknown>;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Silent SEP-10 for a document the wallet already approved: read the site's
+ * stellar.toml, fetch a challenge from its WEB_AUTH_ENDPOINT, verify it is a
+ * genuine challenge for this origin and this account (server signature,
+ * sequence 0, home and web-auth domains, timebounds), then countersign.
+ * Anything short of that returns null and the dApp falls back to asking.
+ * Only the TOML is trusted for the endpoint and signing key; nothing from the
+ * page is.
+ */
+export const prepareSep10Auth = async ({
+  origin,
+  account,
+  development,
+  signTransaction,
+}: {
+  origin: string;
+  account: { address: string; networkPassphrase: string };
+  development: boolean;
+  signTransaction: (tx: Transaction) => string | null;
+}): Promise<Sep10Auth | null> => {
+  try {
+    const url = new URL(origin);
+    const homeDomain = url.host;
+    const allowHttp = development && url.protocol === "http:";
+    const toml = (await StellarToml.Resolver.resolve(homeDomain, {
+      allowHttp,
+      timeout: SEP10_FETCH_TIMEOUT_MS,
+    })) as Record<string, unknown>;
+    const {
+      WEB_AUTH_ENDPOINT: endpoint,
+      SIGNING_KEY: signingKey,
+      NETWORK_PASSPHRASE: passphrase,
+    } = toml;
+    if (
+      typeof endpoint !== "string" ||
+      typeof signingKey !== "string" ||
+      typeof passphrase !== "string"
+    )
+      throw new Error("toml lacks SEP-10 fields");
+    if (passphrase !== account.networkPassphrase)
+      throw new Error("toml network differs from wallet");
+    const endpointUrl = new URL(endpoint);
+    if (endpointUrl.protocol !== "https:" && !allowHttp)
+      throw new Error("non-https WEB_AUTH_ENDPOINT");
+    endpointUrl.searchParams.set("account", account.address);
+    const body = await fetchJson(endpointUrl.toString());
+    const challengeXdr = body.transaction;
+    if (
+      typeof challengeXdr !== "string" ||
+      (body.network_passphrase ?? body.networkPassphrase) !== passphrase
+    )
+      throw new Error("challenge response malformed");
+    // Throws on a bad server signature, non-zero sequence, wrong domains or
+    // expired timebounds. The home domain must be exactly the page's host: a
+    // subdomain the site does not control could otherwise publish a TOML
+    // naming the parent's real SIGNING_KEY and endpoint, obtain a genuine
+    // parent-domain challenge for the user, and replay the wallet's silent
+    // signature to hijack the user's session on the parent site.
+    const parsed = WebAuth.readChallengeTx(
+      challengeXdr,
+      signingKey,
+      passphrase,
+      homeDomain,
+      endpointUrl.host,
+    );
+    if (parsed.clientAccountID !== account.address)
+      throw new Error("challenge is for another account");
+    // readChallengeTx only validates web_auth_domain when present; require it
+    // so the challenge is bound to the endpoint host.
+    if (
+      !parsed.tx.operations.some(
+        (op) => op.type === "manageData" && op.name === "web_auth_domain",
+      )
+    )
+      throw new Error("challenge lacks web_auth_domain");
+    const signedXdr = signTransaction(parsed.tx);
+    if (!signedXdr) return null;
+    return {
+      challengeXdr,
+      signedXdr,
+      networkPassphrase: passphrase,
+      homeDomain,
+      webAuthEndpoint: endpoint,
+    };
+  } catch (error) {
+    logger.warn("WebViewSep10", "auto sign-in unavailable", { origin, error });
+    return null;
+  }
+};


### PR DESCRIPTION
> Stacked on #1001 (which is stacked on #1000). Review only the last commit (`feat(webview): silent SEP-10 sign-in for approved documents`). I will rebase as the lower PRs merge.

### What

When `webview_auto_signin_enabled` is on, `connect()` also hands the dApp a signed SEP-10 challenge, so a site the wallet already approved can log the user in with no sheet at all.

The flow, all on the wallet side in `services/webview/sep10.ts`:

1. Read the page's own `/.well-known/stellar.toml`. Only the TOML is trusted for `WEB_AUTH_ENDPOINT` and `SIGNING_KEY`; nothing from the page is.
2. Fetch a challenge from that endpoint for the connected account. HTTPS only outside dev.
3. Verify it with `WebAuth.readChallengeTx` against the TOML signing key, the page's exact host as home domain, `web_auth_domain` equal to the endpoint host, and the wallet's network. Check the client account is ours and that `web_auth_domain` is present.
4. Countersign and return it with the account. The dApp verifies it again and posts it to its own session endpoint.

Anything short of that returns no `auth` and the dApp asks for a signature the normal way. Challenges are never cached because they are single-use on the server.

### Why

Connecting proves nothing to a website by itself; every dApp still runs SEP-10, which today means one more signing sheet right after the site was approved. For a site that publishes a proper `stellar.toml`, the wallet can do that step safely and silently. Off in production behind its own flag, so it can be rolled out per site readiness.

### Security notes for reviewers

- A SEP-10 challenge has sequence 0 and only `manageData` operations, and `readChallengeTx` refuses anything else (fee bumps, payments, a different source account, missing or expired time bounds, missing server signature). It cannot be submitted and cannot move funds. The signature only proves key ownership to the domain named in the challenge.
- Home domain must be the page's exact host, never a parent domain. Otherwise a subdomain the site does not control could publish a TOML pointing at the parent's real signing key and endpoint, get a genuine parent challenge for the user, and replay our signature to take over the user's session on the parent site. There is a regression test for this case.
- A challenge skips the Blockaid transaction scan. It is unsubmittable, and the site scan already ran at connect. Happy to keep the scan if you prefer; it only costs a round trip and a second "unable to scan" gate when Blockaid is unreachable.
- This is the one place the wallet signs without a prompt, so it needs an explicit product decision, not just a code review.

### Known limitations

- Tested on iOS against xoxno.com. Not tested on Android or small screens.
- Only works for sites whose API mints challenges for the exact host the page is served from.

### Checklist

#### PR structure

- [x] This PR does not mix refactoring changes with feature changes (break it down into smaller PRs if not).
- [x] This PR has reasonably narrow scope (break it down into smaller PRs if not).
- [ ] This PR includes relevant before and after screenshots/videos highlighting these changes. (No new UI; the change is that a sheet does not appear.)
- [x] I took the time to review my own PR.

#### Testing

- [ ] These changes have been tested and confirmed to work as intended on Android.
- [x] These changes have been tested and confirmed to work as intended on iOS.
- [ ] These changes have been tested and confirmed to work as intended on small iOS screens.
- [ ] These changes have been tested and confirmed to work as intended on small Android screens.
- [x] I have tried to break these changes while extensively testing them.
- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This PR updates existing JSDocs when applicable.
- [x] This PR adds JSDocs to new functionalities.
- [ ] I've checked with the product team if we should add metrics to these changes.
- [ ] I've shared relevant before and after screenshots/videos highlighting these changes with the design team and they've approved the changes.
