### PR TITLE
fix(blockaid): attribute signing balance changes to the signing account

### DIFF
--- a/__tests__/services/blockaid.helper.test.ts
+++ b/__tests__/services/blockaid.helper.test.ts
@@ -11,14 +11,23 @@ const CONTRACT_ADDRESS =
   "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND";
 const USDC_ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 
+const SIGNER = "GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY";
+const OTHER_ACCOUNT =
+  "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF";
+
+/** A successful simulation whose `assets_diffs` attributes `diffs` to SIGNER. */
 const makeScanResult = (diffs: unknown[]) =>
   ({
     simulation: {
-      account_summary: {
-        account_assets_diffs: diffs,
+      assets_diffs: {
+        [SIGNER]: diffs,
       },
     },
   }) as any;
+
+/** Every case below resolves diffs for SIGNER unless it says otherwise. */
+const balanceChangesFor = (scanResult: any) =>
+  getTransactionBalanceChanges(scanResult, SIGNER);
 
 describe("getTransactionBalanceChanges", () => {
   it.each([
@@ -29,18 +38,108 @@ describe("getTransactionBalanceChanges", () => {
       { simulation: { error: "simulation failed" } } as any,
     ],
   ])("returns null when %s", (_description, input) => {
-    expect(getTransactionBalanceChanges(input)).toBeNull();
+    expect(balanceChangesFor(input)).toBeNull();
   });
 
   it.each([
-    ["account_assets_diffs is absent", { simulation: {} } as any],
-    ["account_assets_diffs is empty", makeScanResult([])],
+    ["publicKey is undefined", undefined],
+    ["publicKey is empty", ""],
+  ])(
+    "returns null when %s, rather than claiming no balance changes",
+    (_description, publicKey) => {
+      expect(
+        getTransactionBalanceChanges(
+          makeScanResult([
+            {
+              asset: { type: "NATIVE", code: "XLM" },
+              in: { raw_value: 10290000 },
+              out: null,
+            },
+          ]),
+          publicKey,
+        ),
+      ).toBeNull();
+    },
+  );
+
+  it.each([
+    ["assets_diffs is absent", { simulation: {} } as any],
+    ["assets_diffs is empty", { simulation: { assets_diffs: {} } } as any],
+    ["assets_diffs has no entry for the signer", makeScanResult([])],
   ])("returns [] when %s", (_description, input) => {
-    expect(getTransactionBalanceChanges(input)).toEqual([]);
+    expect(balanceChangesFor(input)).toEqual([]);
+  });
+
+  it("attributes diffs to the signing account, not the scanned source account", () => {
+    // assets_diffs carries both sides of a transfer. The signer is debited;
+    // account_summary (which mirrors whichever account the scan was requested
+    // for) shows the counterparty's credit and must not be read.
+    const scanResult = {
+      simulation: {
+        assets_diffs: {
+          [SIGNER]: [
+            {
+              asset: { type: "NATIVE", code: "XLM" },
+              in: null,
+              out: { raw_value: 2000000 },
+            },
+          ],
+          [OTHER_ACCOUNT]: [
+            {
+              asset: { type: "NATIVE", code: "XLM" },
+              in: { raw_value: 2000000 },
+              out: null,
+            },
+          ],
+        },
+        account_summary: {
+          account_assets_diffs: [
+            {
+              asset: { type: "NATIVE", code: "XLM" },
+              in: { raw_value: 2000000 },
+              out: null,
+            },
+          ],
+        },
+      },
+    } as any;
+
+    const result = balanceChangesFor(scanResult);
+
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({ assetCode: "XLM", isCredit: false });
+    expect(result![0].amount).toEqual(new BigNumber("0.2"));
+  });
+
+  it("returns [] when only another account's balances change", () => {
+    const scanResult = {
+      simulation: {
+        assets_diffs: {
+          [OTHER_ACCOUNT]: [
+            {
+              asset: { type: "NATIVE", code: "XLM" },
+              in: { raw_value: 2000000 },
+              out: null,
+            },
+          ],
+        },
+        account_summary: {
+          account_assets_diffs: [
+            {
+              asset: { type: "NATIVE", code: "XLM" },
+              in: { raw_value: 2000000 },
+              out: null,
+            },
+          ],
+        },
+      },
+    } as any;
+
+    expect(balanceChangesFor(scanResult)).toEqual([]);
   });
 
   it("correctly maps all valid asset types", () => {
-    const result = getTransactionBalanceChanges(
+    const result = balanceChangesFor(
       makeScanResult([
         // NATIVE credit — no decimals field → DEFAULT_DECIMALS (7); 10290000 / 1e7 = 1.029
         {
@@ -124,7 +223,7 @@ describe("getTransactionBalanceChanges", () => {
   });
 
   it("skips invalid entries and returns only valid ones", () => {
-    const result = getTransactionBalanceChanges(
+    const result = balanceChangesFor(
       makeScanResult([
         // no in/out
         { asset: { type: "NATIVE", code: "XLM" }, in: null, out: null },
@@ -234,7 +333,7 @@ describe("getTransactionBalanceChanges", () => {
   });
 
   it("falls back to XLM for NATIVE asset with no code or symbol", () => {
-    const result = getTransactionBalanceChanges(
+    const result = balanceChangesFor(
       makeScanResult([
         {
           asset: { type: "NATIVE" },
@@ -255,7 +354,7 @@ describe("getTransactionBalanceChanges", () => {
   });
 
   it("accepts decimals at the upper boundary (19) and rejects above it (20)", () => {
-    const result = getTransactionBalanceChanges(
+    const result = balanceChangesFor(
       makeScanResult([
         // decimals: 19 — at the boundary, must be included
         {

--- a/__tests__/services/blockaid.helper.test.ts
+++ b/__tests__/services/blockaid.helper.test.ts
@@ -65,7 +65,7 @@ describe("getTransactionBalanceChanges", () => {
   it.each([
     ["assets_diffs is absent", { simulation: {} } as any],
     ["assets_diffs is empty", { simulation: { assets_diffs: {} } } as any],
-    ["assets_diffs has no entry for the signer", makeScanResult([])],
+    ["the signer's assets_diffs entry is an empty array", makeScanResult([])],
   ])("returns [] when %s", (_description, input) => {
     expect(balanceChangesFor(input)).toEqual([]);
   });

--- a/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx
+++ b/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx
@@ -71,6 +71,7 @@ export const DappSignTransactionBottomSheetContent: React.FC<
   const transactionBalanceListItems = useTransactionBalanceListItems(
     transactionScanResult,
     signTransactionDetails,
+    account?.publicKey,
   );
 
   const accountList = useMemo(

--- a/src/hooks/blockaid/useTransactionBalanceListItems.tsx
+++ b/src/hooks/blockaid/useTransactionBalanceListItems.tsx
@@ -24,6 +24,9 @@ import { getTransactionBalanceChanges } from "services/blockaid/helper";
  * Adapter hook that maps Blockaid transaction simulation results and change trust operations
  * into `ListItemProps[]` for display.
  *
+ * Balance changes are the ones Blockaid attributes to `publicKey` — the
+ * account being asked to sign. See `getTransactionBalanceChanges`.
+ *
  * Scenarios handled:
  * - No scan result → single row "Unable to simulate transaction"
  * - No balance changes AND no change trust → single row "No balance changes detected"
@@ -34,6 +37,7 @@ import { getTransactionBalanceChanges } from "services/blockaid/helper";
 export const useTransactionBalanceListItems = (
   scanResult?: Blockaid.StellarTransactionScanResponse,
   signTransactionDetails?: SignTransactionDetailsInterface | null,
+  publicKey?: string,
 ): ListItemProps[] => {
   const { themeColors } = useColors();
   const { t } = useAppTranslation();
@@ -47,10 +51,12 @@ export const useTransactionBalanceListItems = (
   // re-render) and never shows another network's prices.
   const prices = usePricesForNetwork(network);
 
-  // Balance changes for this transaction: null = unable to simulate.
+  // Balance changes attributed to the signing account: null = unable to
+  // simulate.
   const balanceUpdates = useMemo(
-    () => (scanResult ? getTransactionBalanceChanges(scanResult) : null),
-    [scanResult],
+    () =>
+      scanResult ? getTransactionBalanceChanges(scanResult, publicKey) : null,
+    [scanResult, publicKey],
   );
 
   // Token ids affected by the transaction. Memoized so its identity is stable

--- a/src/services/blockaid/helper.ts
+++ b/src/services/blockaid/helper.ts
@@ -571,12 +571,23 @@ type AccountAssetDiff = {
 
 /**
  * Extracts per-asset balance changes from a Blockaid transaction simulation.
- * - Returns null when simulation is unavailable or failed ("unable to simulate")
- * - Returns [] when there are no balance changes
+ *
+ * Reads `assets_diffs[publicKey]` — the diffs Blockaid attributes to the
+ * signing account — rather than `account_summary`, which summarizes whichever
+ * account was passed to the scan as `account_address`. The backend derives
+ * that from the transaction's source account, so for a transaction whose
+ * source is not the signing account (an operation-level `source`, for
+ * example) `account_summary` describes a different account than the one being
+ * asked to sign. Matches the extension, which keys off the signing account.
+ *
+ * - Returns null when simulation is unavailable or failed ("unable to
+ *   simulate"), or when there is no account to attribute diffs to
+ * - Returns [] when there are no balance changes for this account
  * - Otherwise returns a list of signed deltas per asset
  */
 export const getTransactionBalanceChanges = (
   scanResult?: Blockaid.StellarTransactionScanResponse,
+  publicKey?: string,
 ): TransactionBalanceChange[] | null => {
   // Missing result or simulation error -> treat as "unable to simulate"
   if (
@@ -587,13 +598,19 @@ export const getTransactionBalanceChanges = (
     return null;
   }
 
-  // account_assets_diffs holds per-asset in/out raw deltas
+  // Without an account there is nothing to attribute the diffs to. Report
+  // "unable to simulate" rather than the stronger "no balance changes".
+  if (!publicKey) {
+    return null;
+  }
+
+  // assets_diffs maps an account address to that account's in/out raw deltas
   type SimulationSummary = {
-    account_summary?: { account_assets_diffs?: AccountAssetDiff[] };
+    assets_diffs?: Record<string, AccountAssetDiff[] | undefined>;
   };
 
   const sim = scanResult.simulation as unknown as SimulationSummary;
-  const diffs = sim.account_summary?.account_assets_diffs;
+  const diffs = sim.assets_diffs?.[publicKey];
 
   if (!Array.isArray(diffs) || diffs.length === 0) {
     return [];


### PR DESCRIPTION
## TL;DR

The balance-change rows at the top of the dApp signing sheet were taken from Blockaid's `account_summary`, which describes whichever account the scan was requested for. That account is derived from the transaction's source, so when the transaction's source isn't the account being asked to sign, the amounts shown belonged to a different account than the signer.

This switches the rows to the per-account diffs Blockaid keys by address, looked up under the signing account's public key, so the sheet shows what the transaction does to *your* balances. The browser extension already resolves them this way.

Only the WalletConnect/dApp signing path is affected. Send, swap, and collectible flows build their own XDR with the user's account as the source, so their attribution was already correct and their behaviour is unchanged.

<details>
<summary>Implementation details (for agents)</summary>

**What changed:**

`getTransactionBalanceChanges` now takes the signing account and resolves diffs under it, instead of reading the summary block:

https://github.com/stellar/freighter-mobile/blob/3eff114f897efc4206badbcde4002d1d5335db09/src/services/blockaid/helper.ts#L572-L616

The mechanism: `freighter-backend`'s `scanTx` sets Blockaid's `account_address` from `tx.source` (or `innerTransaction.source` for fee bumps), and `simulation.account_summary` is Blockaid's projection of `assets_diffs[account_address]`. Since a Stellar operation can carry its own `source`, a transaction can be sourced by account A while an operation debits account B — and B is the account signing. `simulation.assets_diffs` is keyed by account address and carries an entry per account whose balances move, so looking up the signer's key gives the diffs that actually apply to them.

Two behavioural notes:

- `null` (rendered as "Unable to simulate transaction") is now also returned when no `publicKey` is supplied. Returning `[]` there would render "No balance changes detected", which is a stronger claim than the data supports.
- `[]` (rendered as "No balance changes detected") now means "`assets_diffs` has no entry for this account", which is the correct reading for a transaction that genuinely doesn't move the signer's balances — a config-only transaction, for instance.

The hook threads the account through and adds it to the memo deps:

https://github.com/stellar/freighter-mobile/blob/3eff114f897efc4206badbcde4002d1d5335db09/src/hooks/blockaid/useTransactionBalanceListItems.tsx#L37-L60

There is one call site, which already had the active account in scope:

https://github.com/stellar/freighter-mobile/blob/3eff114f897efc4206badbcde4002d1d5335db09/src/components/screens/WalletKit/DappSignTransactionBottomSheetContent.tsx#L71-L75

For reference, the equivalent resolution in the extension is `extension/src/popup/views/SignTransaction/index.tsx` (`assets_diffs?.[publicKey]`) and `useGetSignTxData.tsx` (`diffs[publicKey] || []`).

**Tests:** the existing fixture built `account_summary`; it now builds `assets_diffs` keyed by a signer constant, and the suite resolves through a `balanceChangesFor` wrapper. Five cases added:

- `null` when `publicKey` is undefined, and when it is empty
- `[]` when `assets_diffs` is absent, when it is `{}`, and when it has no entry for the signer
- diffs are attributed to the signer, not the scanned source account — the fixture carries both sides of a transfer plus a contradicting `account_summary`, and asserts the signer's debit wins
- `[]` when only another account's balances change, with a populated `account_summary` present to confirm it is not consulted

**Verification:**

- `yarn jest __tests__/services/blockaid.helper.test.ts` — 38 passed
- `yarn jest` (full suite) — 234 suites passed, 1 skipped; 3183 tests passed, 6 skipped
- `yarn lint:ts` — clean
- `eslint` on the four changed files — clean

**Follow-ups / out of scope:**

- **Simulation union discrimination.** Mobile tests `"error" in simulation` while the extension tests `status === "Success"`. These select the same case under today's schema, since the success arm types `status` as the literal `'Success'` with no sibling members. But if Blockaid adds a third simulation state carrying neither an `error` key nor `status: "Success"`, mobile falls through into the parsing path while the extension bails. It spans three call sites in `helper.ts` (lines 326, 447, 583), two of which drive the malicious/suspicious banner, so tightening it here would have pulled banner logic into this diff. Left for a separate change.
- **`assets_diffs` absent on a successful simulation.** Treated as `[]` here, preserving today's rendering. Whether Blockaid omits the map entirely or returns `{}` for a transaction with no balance movement isn't documented — the field is optional in the schema, and every fixture across the three repos is hand-written. Worth confirming against a real scan of a config-only transaction and a SEP-10 challenge, then pinning with a test.
- **Transaction source account is never displayed.** `buildSummary` collects operation count, fee, sequence, and memo, but not the source. Surfacing it when it differs from the signing account would make this class of mismatch legible directly, rather than only via the per-operation `source` in the collapsed details pane. Note that a source differing from the signer is legitimate and common — a SEP-10 challenge is built exactly that way — so this wants design thought rather than a warning banner.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
