### PR TITLE
chore(ci): allow Xcode up to 26.6

### DIFF
--- a/scripts/setup-xcode-latest-stable
+++ b/scripts/setup-xcode-latest-stable
@@ -6,7 +6,7 @@ set -e
 
 # Maximum allowed Xcode major.minor version.
 # Bump this once all Pods (especially `fmt`) compile cleanly on the next Xcode.
-MAX_XCODE_VERSION="26.4"
+MAX_XCODE_VERSION="26.6"
 
 # Find all beta/RC Xcode versions to identify base versions to exclude
 BETA_XCODE_PATHS=$(ls -1d /Applications/Xcode*.app 2>/dev/null | grep -E "(Release_Candidate|RC|beta|Beta)" || true)


### PR DESCRIPTION
## TL;DR

Raises the CI Xcode ceiling from 26.4 to 26.6 so iOS jobs pick the newest stable
Xcode already present on the macOS 26 runner image instead of falling back to
26.4.1. Xcode 26.6 builds the app fine locally, so this PR is mainly here to
confirm the Pods (notably `fmt`) still compile cleanly on CI.

<details>
<summary>Implementation details (for agents)</summary>

**What changed:** single constant in the Xcode selection script used by every
iOS job (`ios.yml`, `ios-e2e.yml`, `prPreviewIos.yml`):

https://github.com/stellar/freighter-mobile/blob/cb0959dc2c6d4b5e22bf7576d89d5c257a42528f/scripts/setup-xcode-latest-stable#L7-L9

The script still skips beta/RC installs and picks the highest stable version at
or below the ceiling; only the ceiling moved.

**Verification:** the `macos-26-xlarge` image already ships 26.5 and 26.6 — the
2026-09-10 nightly iOS build logged `Excluding /Applications/Xcode_26.6.0.app
(Version: 26.6 exceeds max allowed 26.4)` and selected `Xcode 26.4.1
(17E202)`. With the new ceiling, selection should land on 26.6. The real
verification is this PR's own iOS CI (`iOS E2E` + `PR Preview iOS`) building
under 26.6.

**Follow-ups / out of scope:** nothing else pinned to 26.4; the nightly
TestFlight workflow (`ios.yml`) only runs on schedule/dispatch, so its first
26.6 build happens after merge.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
